### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/AI/Research/ChooseTech.cs
+++ b/Ship_Game/AI/Research/ChooseTech.cs
@@ -419,7 +419,7 @@ namespace Ship_Game.AI.Research
                                 foreach (var shipTech in LineFocus.BestCombatShip.TechsNeeded)
                                 {
                                     bool foundTech = tech.Tech.UID == shipTech;
-                                    if (foundTech && tech.Tech.ActualCost > 0)
+                                    if (foundTech && tech.Tech.ActualCost(tech.Universe) > 0)
                                     {
                                         return true;
                                     }

--- a/Ship_Game/AI/Research/ShipPicker.cs
+++ b/Ship_Game/AI/Research/ShipPicker.cs
@@ -50,7 +50,7 @@ namespace Ship_Game.AI.Research
             foreach (var techName in techs)
             {
                 var tech       = empire.GetTechEntry(techName);
-                float techCost = tech.Tech.ActualCost;
+                float techCost = tech.Tech.ActualCost(empire.Universe);
                 if (tech.Locked && !tech.IsRoot)
                     minTechCost = Math.Min(techCost, minTechCost);
             }
@@ -72,7 +72,7 @@ namespace Ship_Game.AI.Research
                 var tech = empire.GetTechEntry(techName);
                 if (tech.Locked && !tech.IsRoot)
                 {
-                    var cost = tech.Tech.ActualCost;
+                    var cost = tech.Tech.ActualCost(empire.Universe);
 
                     if (tech.IsTechnologyType(TechnologyType.GroundCombat)) cost *= Options.CostMultiplier(GroundCombat);
                     if (tech.IsTechnologyType(TechnologyType.ShipHull)) cost *= Options.CostMultiplier(AllHulls);

--- a/Ship_Game/AI/Research/ShipTechProgresion.cs
+++ b/Ship_Game/AI/Research/ShipTechProgresion.cs
@@ -65,7 +65,7 @@ namespace Ship_Game.AI.Research
         {
             int turnsThreshold  = (int)OwnerEmpire.TotalPopBillion.Clamped(1, 200);
             float netResearch   = OwnerEmpire.Research.MaxResearchPotential.LowerBound(1);
-            float researchTurns = tech.Tech.ActualCost / netResearch;
+            float researchTurns = tech.Tech.ActualCost(OwnerEmpire.Universe) / netResearch;
             return researchTurns <= turnsThreshold;
         }
 
@@ -86,7 +86,7 @@ namespace Ship_Game.AI.Research
                                    * OwnerEmpire.DifficultyModifiers.HullTechMultiplier;
                     }
 
-                    totalCost += tech.Tech.ActualCost * multiplier;
+                    totalCost += tech.Tech.ActualCost(OwnerEmpire.Universe) * multiplier;
                 }
             }
 

--- a/Ship_Game/Beam.cs
+++ b/Ship_Game/Beam.cs
@@ -419,12 +419,12 @@ namespace Ship_Game
             Source = AI.Drone.Position;
             SetActualHitDestination(AI.DroneTarget?.Position ?? Source);
             // Apply drone repair effect, 5 times more if not in combat
-            if (DamageAmount < 0f && Source.InRadius(Destination, Range + 10f) && Target is Ship targetShip)
+            if (DamageAmount < 0f && Source.InRadius(Destination, Range + 10f))
             {
-                ShipModule moduleToRepair = TargetModule;
+                 ShipModule moduleToRepair = TargetModule;
                 if (moduleToRepair != null)
                 {
-                    float repairMultiplier = targetShip.OnLowAlert ? 5 : 1;
+                    float repairMultiplier = moduleToRepair.GetParent().OnLowAlert ? 5 : 1;
                     float repairAmount = -DamageAmount * repairMultiplier * timeStep.FixedTime;
 
                     moduleToRepair.Repair(repairAmount);
@@ -434,7 +434,7 @@ namespace Ship_Game
                 else
                 {
                     int repairLevel = Owner?.Level ?? 0;
-                    TargetModule = targetShip.GetModuleToRepair(repairLevel);
+                    TargetModule = TargetShip.GetModuleToRepair(repairLevel);
                 }
             }
 

--- a/Ship_Game/Data/GameContentManager.cs
+++ b/Ship_Game/Data/GameContentManager.cs
@@ -57,7 +57,24 @@ namespace Ship_Game.Data
             RawContent = new RawContentLoader(this);
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            LoadedAssets     = null;
+            DisposableAssets = null;
+            RawContent       = null;
+            LoadedEffects    = null;
+        }
+
         object GetField(string field) => typeof(ContentManager).GetField(field, BindingFlags.Instance|BindingFlags.NonPublic)?.GetValue(this);
+        
+        static T GetField<T>(object obj, string name)
+        {
+            return (T)obj.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(obj);
+        }
+
+        public GraphicsDeviceManager Manager => (GraphicsDeviceManager)ServiceProvider.GetService(typeof(IGraphicsDeviceManager));
+        public GraphicsDevice Device => Manager.GraphicsDevice;
 
         bool TryGetAsset(string assetNameNoExt, out object asset)
         {
@@ -120,23 +137,6 @@ namespace Ship_Game.Data
                 LoadedEffects.Add(assetName, effect);
             RecordDisposableObject(effect);
         }
-
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-            LoadedAssets     = null;
-            DisposableAssets = null;
-            RawContent       = null;
-            LoadedEffects    = null;
-        }
-
-        static T GetField<T>(object obj, string name)
-        {
-            return (T)obj.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(obj);
-        }
-
-        public GraphicsDeviceManager Manager => (GraphicsDeviceManager)ServiceProvider.GetService(typeof(IGraphicsDeviceManager));
-        public GraphicsDevice Device => Manager.GraphicsDevice;
 
         public static int TextureSize(Texture2D tex)
         {

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -1008,7 +1008,7 @@ namespace Ship_Game
 
             foreach (Technology tech in ResourceManager.TechsList)
             {
-                var entry = new TechEntry(tech.UID);
+                var entry = new TechEntry(tech.UID, Universe);
                 if (entry.IsHidden(this))
                 {
                     entry.SetDiscovered(false);
@@ -2095,7 +2095,7 @@ namespace Ship_Game
                 if (maxPopBillion >= 0.5)
                 {
                     if (ResourceManager.TryGetTech(Research.Topic, out Technology tech))
-                        researchPotential = (tech.ActualCost - Research.NetResearch) / tech.ActualCost
+                        researchPotential = (tech.ActualCost(Universe) - Research.NetResearch) / tech.ActualCost(Universe)
                                             * (fertility * 2 + p.MineralRichness + (maxPopBillion / 0.5f));
                 }
             }

--- a/Ship_Game/Empires/Components/EmpireFirstContact.cs
+++ b/Ship_Game/Empires/Components/EmpireFirstContact.cs
@@ -54,10 +54,16 @@ namespace Ship_Game.Empires.Components
                 DoFirstContact(them, them:owner);
 
             if (owner.Universe.Debug)
+            {
+                Log.Write(ConsoleColor.Blue, "DEBUG: Skipping first contact in DEBUG");
                 return;
+            }
 
             if (GlobalStats.RestrictAIPlayerInteraction && owner.isPlayer)
+            {
+                Log.Write(ConsoleColor.Blue, "DEBUG: Skipping first contact RestrictAIPlayerInteraction");
                 return;
+            }
 
             if (owner.isPlayer)
             {

--- a/Ship_Game/ExtensionMethods/HelperFunctions.cs
+++ b/Ship_Game/ExtensionMethods/HelperFunctions.cs
@@ -181,14 +181,6 @@ namespace Ship_Game
             }
         }
 
-        public static void ResetWithParseText(this ScrollList<TextListItem> list, 
-            Font font, string text, float maxLineWidth)
-        {
-            string[] lines = font.ParseTextToLines(text, maxLineWidth);
-            TextListItem[] textItems = lines.Select(line => new TextListItem(line, font));
-            list.SetItems(textItems);
-        }
-
         public static int RoundTo(float amount1, int roundTo)
         {
             int rounded = (int)((amount1 + 0.5 * roundTo) / roundTo) * roundTo;

--- a/Ship_Game/GameScreens/DiplomacyScreen/DialogOptionListItem.cs
+++ b/Ship_Game/GameScreens/DiplomacyScreen/DialogOptionListItem.cs
@@ -1,28 +1,41 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 using SDGraphics;
+using SDUtils;
 
 namespace Ship_Game.GameScreens.DiplomacyScreen
 {
     public class DialogOptionListItem : ScrollListItem<DialogOptionListItem>
     {
         readonly Graphics.Font Font = Fonts.Consolas18;
-        public override int ItemHeight => 24;
+        int TextHeightWithPadding;
+        public override int ItemHeight => TextHeightWithPadding;
+
         public DialogOption Option { get; }
         readonly UILabel Text;
 
-        public DialogOptionListItem(DialogOption option)
+        public DialogOptionListItem(DialogOption option, float maxWidth)
         {
             Option = option;
-            Text = Add(new UILabel($"{Option.Number}. {Option.Words}", Font));
-            Text.DropShadow = true;
-            Text.Color = Color.White;
-            Text.Highlight = Color.LightYellow;
-            Text.TextAlign = TextAlign.VerticalCenter;
+            Text = Add(new UILabel(Font)
+            {
+                DropShadow = true,
+                Color = Color.White,
+                Highlight = Color.LightYellow,
+            });
+        }
+
+        void UpdateMultilineText(float maxWidth)
+        {
+            string text = $"{Option.Number}. {Option.Words}";
+            string[] lines = Font.ParseTextToLines(text, maxWidth);
+            TextHeightWithPadding = lines.Length * 18;
+            Text.MultilineText = new(lines);
         }
 
         public override void PerformLayout()
         {
             Text.Rect = Rect;
+            UpdateMultilineText(Rect.Width);
             base.PerformLayout();
         }
 

--- a/Ship_Game/GameScreens/DiplomacyScreen/DiplomacyOffersComponent.cs
+++ b/Ship_Game/GameScreens/DiplomacyScreen/DiplomacyOffersComponent.cs
@@ -17,6 +17,9 @@ namespace Ship_Game.GameScreens.DiplomacyScreen
         Offer OurOffer;
         Offer TheirOffer;
 
+        // EVT: offer has changed (probably)
+        public Action OnOfferChanged;
+
         public DiplomacyOffersComponent(Empire empire, Empire other,
                                         Rectangle rect, SubTexture background) : base(rect)
         {
@@ -67,29 +70,31 @@ namespace Ship_Game.GameScreens.DiplomacyScreen
                 case "NAPact":
                     OurOffer.NAPact = TheirOffer.NAPact = selected;
                     SelectTheirItem(ourItem.Response, selected);
-                    return;
+                    break;
                 case "We Declare War":
                     OurOffer.NAPact = TheirOffer.NAPact = selected;
                     SelectTheirItem("NAPact", selected);
-                    return;
+                    break;
                 case "Peace Treaty":
                     OurOffer.PeaceTreaty = TheirOffer.PeaceTreaty = selected;
                     SelectTheirItem(ourItem.Response, selected);
-                    return;
+                    break;
                 case "OfferAlliance":
                     OurOffer.Alliance = TheirOffer.Alliance = selected;
                     SelectTheirItem(ourItem.Response, selected);
-                    return;
-                case "OpenBorders": OurOffer.OpenBorders = selected; return;
-                case "Declare War": ourItem.ChangeSpecialInquiry(OurOffer.EmpiresToWarOn);      return;
-                case "Tech":        ourItem.ChangeSpecialInquiry(OurOffer.TechnologiesOffered); return;
-                case "Artifacts":   ourItem.ChangeSpecialInquiry(OurOffer.ArtifactsOffered);    return;
-                case "Colony":      ourItem.ChangeSpecialInquiry(OurOffer.ColoniesOffered);     return;
+                    break;
+                case "OpenBorders": OurOffer.OpenBorders = selected; break;
+                case "Declare War": ourItem.ChangeSpecialInquiry(OurOffer.EmpiresToWarOn);      break;
+                case "Tech":        ourItem.ChangeSpecialInquiry(OurOffer.TechnologiesOffered); break;
+                case "Artifacts":   ourItem.ChangeSpecialInquiry(OurOffer.ArtifactsOffered);    break;
+                case "Colony":      ourItem.ChangeSpecialInquiry(OurOffer.ColoniesOffered);     break;
                 case "TradeTreaty":
                     OurOffer.TradeTreaty = TheirOffer.TradeTreaty = selected;
                     SelectTheirItem("TradeTreaty", selected);
-                    return;
+                    break;
             }
+
+            OnOfferChanged?.Invoke();
         }
 
         void Reset()

--- a/Ship_Game/GameScreens/DiplomacyScreen/DiplomacyOffersComponent.cs
+++ b/Ship_Game/GameScreens/DiplomacyScreen/DiplomacyOffersComponent.cs
@@ -111,7 +111,7 @@ namespace Ship_Game.GameScreens.DiplomacyScreen
                 if (!Them.isPlayer && !Them.WeCanUseThisTech(entry, theirDesigns))
                     continue;
                 
-                var text = LocalizedText.Parse($"{{{tech.NameIndex}}}: {(int)tech.ActualCost}");
+                var text = LocalizedText.Parse($"{{{tech.NameIndex}}}: {(int)tech.ActualCost(Them.Universe)}");
                 techs.AddSubItem(new ItemToOffer(text, "Tech") { SpecialInquiry = entry.UID });
             }
 

--- a/Ship_Game/GameScreens/MainMenu/MainMenuScreen.cs
+++ b/Ship_Game/GameScreens/MainMenu/MainMenuScreen.cs
@@ -124,7 +124,7 @@ namespace Ship_Game.GameScreens.MainMenu
             }
             else if (Type == MainMenuType.Defeat)
             {
-                ScreenManager.Music = GameAudio.PlayMusic("TitleTheme");
+                ScreenManager.Music = GameAudio.PlayMusic("Female_02_loop");
             }
             else if (GlobalStats.Defaults.CustomMenuMusic.NotEmpty())
             {

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
@@ -32,7 +32,7 @@ namespace Ship_Game
         UIButton ModeBtn;
         Rectangle FlagRect;
         ScrollList<RaceArchetypeListItem> ChooseRaceList;
-        ScrollList<TextListItem> DescriptionTextList;
+        UITextBox DescriptionTextList;
 
         UILabel NumSystemsLabel;
         UILabel ExtraPlanetsLabel;
@@ -193,9 +193,10 @@ namespace Ship_Game
                 tip:"This sets the intensity of Ancient Remnants presence. If you feel overwhelmed by their advanced technology, reduce this to Rare.");
 
             RectF description = new(traitsList.Right + 5, traitsList.Y, chooseRace.W, traitsList.H);
-            DescriptionTextList = Add(new ScrollList<TextListItem>(description, DescriptionTextFont.LineSpacing));
-            DescriptionTextList.SetBackground(new Menu1(description));
-            DescriptionTextList.EnableItemEvents = false;
+            DescriptionTextList = Add(new UITextBox(description, useBorder:false, DescriptionTextFont));
+            DescriptionTextList.ItemsList.SetBackground(new Menu1(description));
+            DescriptionTextList.ItemsList.ItemPadding = new Vector2(10, 0);
+
             Add(new SelectedTraitsSummary(this));
 
             Picker = Add(new UIColorPicker(new Rectangle(ScreenWidth / 2 - 310, ScreenHeight / 2 - 280, 620, 560)));
@@ -203,8 +204,6 @@ namespace Ship_Game
 
             ButtonMedium(ScreenWidth - 140, ScreenHeight - 40, text:GameText.Engage, click: OnEngageClicked);
             ButtonMedium(10, ScreenHeight - 40, text:GameText.Abort, click: OnAbortClicked);
-
-            DescriptionTextList.ItemPadding = new Vector2(10, 0);
 
             const int containerMarginBottom = 10;
             const int containerPaddingLeft = 10;
@@ -605,8 +604,8 @@ namespace Ship_Game
 
             public override void Draw(SpriteBatch batch, DrawTimes elapsed)
             {
-                float start = Screen.DescriptionTextList.NumEntries > 0
-                            ? Screen.DescriptionTextList.ItemAtBottom.Bottom
+                float start = Screen.DescriptionTextList.ItemsList.NumEntries > 0
+                            ? Screen.DescriptionTextList.ItemsList.ItemAtBottom.Bottom
                             : Screen.DescriptionTextList.Y;
 
                 var r = new Vector2(Screen.DescriptionTextList.X + 20, start + 20);

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
@@ -160,7 +160,7 @@ namespace Ship_Game
             {
                 b.Plural(GameText.AreNaturalSailorsAndShipwrights); // | HUMANS | are natural sailors and shipwrights
             }
-            DescriptionTextList.ResetWithParseText(DescriptionTextFont, b.ToString(), DescriptionTextList.Width-50);
+            DescriptionTextList.SetLines(b.ToString(), DescriptionTextFont, Color.White);
         }
 
     

--- a/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
+++ b/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
@@ -227,6 +227,8 @@ namespace Ship_Game.GameScreens.NewGame
                 UState.CreateEmpire(readOnlyData, isPlayer: false, difficulty: Difficulty);
                 step.Advance();
             }
+
+            UState.CalcInitialSettings();
         }
 
         void CreateSystemPlaceHolders(ProgressCounter step)

--- a/Ship_Game/GameScreens/ScreenManager.cs
+++ b/Ship_Game/GameScreens/ScreenManager.cs
@@ -585,12 +585,14 @@ namespace Ship_Game
             bool coveredByOtherScreen = false;
             bool inputCaptured = false;
 
-            // @note GameScreen could be removed during screen.Update, so [i] must always be bounds checked
-            for (int i = GameScreens.Count - 1; i >= 0 && i < GameScreens.Count; --i)
+            // since GameScreens are allowed to be removed randomly during their HandleInput,
+            // we always create a copy of current screens, and double check if the screen still exists
+            GameScreen[] activeScreens = GameScreens.ToArr();
+            for (int i = activeScreens.Length - 1; i >= 0; --i)
             {
-                GameScreen screen = GameScreens[i];
-                if (screen == null) // FIX: threading or other removal issue,
-                    continue;       // GameScreens was modified from another thread
+                GameScreen screen = activeScreens[i];
+                if (!GameScreens.ContainsRef(screen))
+                    continue; // this screen was removed while we were processing HandleInput events
 
                 // 1. Handle Input
                 if (!otherScreenHasFocus && !screen.IsExiting && !inputCaptured)

--- a/Ship_Game/GameScreens/ScreenManager.cs
+++ b/Ship_Game/GameScreens/ScreenManager.cs
@@ -313,9 +313,10 @@ namespace Ship_Game
             if (batch == null)
                 return; // ScreenManager was disposed
 
-            for (int i = 0; i < GameScreens.Count; ++i)
+            GameScreen[] screens = GameScreens.ToArray();
+            for (int i = 0; i < screens.Length; ++i)
             {
-                GameScreen screen = GameScreens[i];
+                GameScreen screen = screens[i];
                 if (screen.Visible && !screen.IsDisposed)
                 {
                     try

--- a/Ship_Game/GameScreens/ScreenManager.cs
+++ b/Ship_Game/GameScreens/ScreenManager.cs
@@ -322,6 +322,12 @@ namespace Ship_Game
                     {
                         screen.Draw(batch, DrawLoopTime);
                     }
+                    catch (ObjectDisposedException)
+                    {
+                        // When user device goes to sleep, graphics resources are lost
+                        // So all screens need to be reloaded
+                        ReloadAllScreens();
+                    }
                     catch (Exception e)
                     {
                         Log.Error(e, $"Draw Screen failed: {screen.GetType().GetTypeName()}");
@@ -432,6 +438,18 @@ namespace Ship_Game
 
             GameScreens.Remove(screen);
             screen.OnScreenRemoved();
+        }
+
+        public void ReloadAllScreens()
+        {
+            for (int i = 0; i < GameScreens.Count; ++i)
+            {
+                GameScreen screen = GameScreens[i];
+                if (!screen.IsDisposed)
+                {
+                    screen.ReloadContent();
+                }
+            }
         }
 
         float HotloadTimer;

--- a/Ship_Game/GameScreens/ShipDesign/ModuleSelection.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ModuleSelection.cs
@@ -154,7 +154,7 @@ namespace Ship_Game
             foreach (TechEntry tech in Player.TechEntries)
             {
                 if (tech.GetUnlockableModules(Player).Any(m => m.ModuleUID == module.UID))
-                    return tech.Tech.ActualCost;
+                    return tech.Tech.ActualCost(Player.Universe);
             }
 
             return 0;

--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignScreen.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignScreen.cs
@@ -554,7 +554,11 @@ namespace Ship_Game
                 () => CurrentDesign?.IsCarrierOnly == true,
                 (b) => { if (CurrentDesign != null) CurrentDesign.IsCarrierOnly = b; }, "Carrier Only", GameText.WhenMarkedThisShipCan);
 
-            ArcsButton = new GenericButton(new Vector2(HullSelectList.X - 32, 97f), "Arcs", Fonts.Pirulen20, Fonts.Pirulen16);
+            ArcsButton = new GenericButton(new Vector2(HullSelectList.X - 32, 97f), "Arcs", Fonts.Pirulen20, Fonts.Pirulen16)
+            {
+                ToggleOnColor = Color.DarkOrange,
+                ButtonStyle = GenericButton.Style.Shadow,
+            };
 
             var infoRect = RectF.FromPoints((HullSelectList.X + 20), (ScreenWidth - 20),
                                             HullSelectList.Bottom + 10, BlackBar.Y);

--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignScreenDraw.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignScreenDraw.cs
@@ -54,7 +54,7 @@ namespace Ship_Game
             }
 
             DrawUi(batch, elapsed);
-            ArcsButton.DrawWithShadowCaps(batch);
+            ArcsButton.Draw(batch, elapsed);
 
             base.Draw(batch, elapsed);
             batch.End();

--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignScreenInput.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignScreenInput.cs
@@ -168,7 +168,7 @@ namespace Ship_Game
 
             HandleInputZoom(input);
 
-            if (ArcsButton.R.HitTest(input.CursorPosition))
+            if (ArcsButton.HitTest(input.CursorPosition))
                 ToolTip.CreateTooltip(GameText.TogglesTheWeaponFireArc, "Tab");
 
             if (ArcsButton.HandleInput(input))

--- a/Ship_Game/Gameplay/Relationship.cs
+++ b/Ship_Game/Gameplay/Relationship.cs
@@ -1268,11 +1268,11 @@ namespace Ship_Game.Gameplay
 
             foreach (TechEntry tech in theirTechs.Sorted(t => t.Tech.Cost))
             {
-                if (tech.Tech.ActualCost + totalCost > theirMaxCost)
+                if (tech.Tech.ActualCost(Them.Universe) + totalCost > theirMaxCost)
                     break;
 
                 theirFinalTech.Add(tech.UID);
-                totalCost += tech.Tech.ActualCost;
+                totalCost += tech.Tech.ActualCost(Them.Universe);
             }
 
             return theirFinalTech.Count > 0;

--- a/Ship_Game/GlobalStats.cs
+++ b/Ship_Game/GlobalStats.cs
@@ -335,7 +335,7 @@ namespace Ship_Game
 
             if (modPath.NotEmpty())
             {
-                var modInfo = new FileInfo($"{modPath}/Globals.yaml");
+                var modInfo = new FileInfo($"Mods/{modPath}/Globals.yaml");
                 if (modInfo.Exists)
                 {
                     GamePlayGlobals settings = GamePlayGlobals.Deserialize(modInfo);

--- a/Ship_Game/ReplayElement.cs
+++ b/Ship_Game/ReplayElement.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using SDGraphics;
 using SDUtils;
 using Ship_Game.Universe;
 using Vector2 = SDGraphics.Vector2;
@@ -59,12 +57,21 @@ namespace Ship_Game
 
             ElementRect = r;
             TextRect = new Rectangle(r.X, r.Y + r.Height, r.Width, 128);
-            ShipCount = new GenericButton(new Vector2(ElementRect.X - 10, ElementRect.Y + 40), "Ship Count", Fonts.Pirulen16, Fonts.Pirulen12);
-            Buttons.Add(ShipCount);
-            MilStrength = new GenericButton(new Vector2(ElementRect.X - 10, ShipCount.R.Y + Fonts.Pirulen16.LineSpacing + 4), "Military Strength", Fonts.Pirulen16, Fonts.Pirulen12);
-            Buttons.Add(MilStrength);
-            Population = new GenericButton(new Vector2(ElementRect.X - 10, MilStrength.R.Y + Fonts.Pirulen16.LineSpacing + 4), "Population", Fonts.Pirulen16, Fonts.Pirulen12);
-            Buttons.Add(Population);
+
+            GenericButton AddButton(float x, float y, string title)
+            {
+                GenericButton button = new(new(x, y), title, Fonts.Pirulen16, Fonts.Pirulen12)
+                {
+                    ToggleOnColor = Color.DarkOrange,
+                    ButtonStyle = GenericButton.Style.Shadow
+                };
+                Buttons.Add(button);
+                return button;
+            }
+            
+            ShipCount = AddButton(ElementRect.X - 10, ElementRect.Y + 40, "Ship Count");
+            MilStrength = AddButton(ElementRect.X - 10, ShipCount.Y + Fonts.Pirulen16.LineSpacing + 4, "Military Strength");
+            Population = AddButton(ElementRect.X - 10, MilStrength.Y + Fonts.Pirulen16.LineSpacing + 4, "Population");
 
             TurnsRepresented = UState.Stats.NumRecordedTurns;
             foreach (Map<int, Snapshot> snapshots in UState.Stats.Snapshots)
@@ -87,10 +94,8 @@ namespace Ship_Game
             }
         }
 
-        public void Draw(ScreenManager ScreenManager)
+        public void Draw(SpriteBatch batch, DrawTimes elapsed)
         {
-            SpriteBatch batch = ScreenManager.SpriteBatch;
-
             MapRect = new Rectangle(ElementRect.X + 30, ElementRect.Y + 30, ElementRect.Width - 60, ElementRect.Height - 60);
             batch.Draw(ResourceManager.Texture("EndGameScreen/ReplayHousing"), ElementRect, Color.White);
             float scale = (ElementRect.Width - 60) / (Universe.UState.Size * 2);        //Correction for negative map values -Gretman
@@ -191,7 +196,7 @@ namespace Ship_Game
             batch.DrawString(Fonts.Tahoma11, "Left/Right Arrows", PlusMinus, Color.White);
             foreach (GenericButton button in Buttons)
             {
-                button.DrawWithShadowCaps(batch);
+                button.Draw(batch, elapsed);
             }
         }
 

--- a/Ship_Game/Ships/IShipDesign.cs
+++ b/Ship_Game/Ships/IShipDesign.cs
@@ -136,7 +136,7 @@ namespace Ship_Game.Ships
         // Which is not always able to clean up everything due to dangling references
         void Dispose();
 
-        void LoadModel(out SceneObject shipSO, GameContentManager content);
+        bool LoadModel(out SceneObject shipSO, GameContentManager content);
 
         float GetCost(Empire e);
 

--- a/Ship_Game/Ships/ShipDesign.cs
+++ b/Ship_Game/Ships/ShipDesign.cs
@@ -236,7 +236,7 @@ namespace Ship_Game.Ships
             }
             catch (Exception e)
             {
-                Log.Error(e, $"Failed to parse ShipData '{info.FullName}'", 0);
+                Log.Warning($"Failed to parse ShipData '{info.FullName}': {e.Message}");
             }
             return null;
         }

--- a/Ship_Game/Ships/ShipDesign.cs
+++ b/Ship_Game/Ships/ShipDesign.cs
@@ -254,9 +254,9 @@ namespace Ship_Game.Ships
             return true;
         }
 
-        public void LoadModel(out SceneObject shipSO, GameContentManager content)
+        public bool LoadModel(out SceneObject shipSO, GameContentManager content)
         {
-            BaseHull.LoadModel(out shipSO, content);
+            return BaseHull.LoadModel(out shipSO, content);
         }
 
         public static RoleType ShipRoleToRoleType(RoleName role)

--- a/Ship_Game/Ships/ShipHull.cs
+++ b/Ship_Game/Ships/ShipHull.cs
@@ -99,11 +99,13 @@ namespace Ship_Game.Ships
             return null;
         }
 
-        public void LoadModel(out SceneObject shipSO, GameContentManager content)
+        public bool LoadModel(out SceneObject shipSO, GameContentManager content)
         {
             lock (this)
             {
                 shipSO = StaticMesh.GetSceneMesh(content, ModelPath, Animated);
+                if (shipSO == null)
+                    return false;
 
                 if (Volume.X.AlmostEqual(0f))
                 {
@@ -111,12 +113,14 @@ namespace Ship_Game.Ships
                     {
                         Volume = new Vector3(shipSO.GetMeshBoundingBox().Max);
                         ModelZ = Volume.Z;
+                        return true;
                     }
                     catch (Exception e)
                     {
                         Log.Error(e, $"GetMeshBoundingBox failed: {ModelPath}");
                     }
                 }
+                return false;
             }
         }
 

--- a/Ship_Game/Ships/ShipHull.cs
+++ b/Ship_Game/Ships/ShipHull.cs
@@ -111,16 +111,19 @@ namespace Ship_Game.Ships
                 {
                     try
                     {
+                        // @note GetMeshBoundingBox is a slow operation, and can fail
                         Volume = new Vector3(shipSO.GetMeshBoundingBox().Max);
                         ModelZ = Volume.Z;
-                        return true;
                     }
-                    catch (Exception e)
+                    catch (Exception)
                     {
-                        Log.Error(e, $"GetMeshBoundingBox failed: {ModelPath}");
+                        Volume = new Vector3(shipSO.ObjectBoundingSphere.Radius);
+                        ModelZ = Volume.Z;
                     }
                 }
-                return false;
+                
+                // always succeed, even if we failed to get the Volume and ModelZ
+                return true;
             }
         }
 

--- a/Ship_Game/Ships/Ship_Update.cs
+++ b/Ship_Game/Ships/Ship_Update.cs
@@ -46,7 +46,9 @@ namespace Ship_Game.Ships
                 return; // allow creating invisible ships in Unit Tests
 
             //Log.Info($"CreateSO {Id} {Name}");
-            ShipData.LoadModel(out ShipSO, Universe.Screen.ContentManager);
+            if (!ShipData.LoadModel(out ShipSO, Universe.Screen.ContentManager))
+                return; // loading Ship SO failed
+
             ShipSO.World = Matrix.CreateTranslation(new Vector3(Position + ShipData.BaseHull.MeshOffset, 0f));
 
             NotVisibleToPlayerTimer = 0;

--- a/Ship_Game/StoryAndEvents/InGameWiki.cs
+++ b/Ship_Game/StoryAndEvents/InGameWiki.cs
@@ -16,7 +16,7 @@ namespace Ship_Game
         ScrollList<WikiHelpCategoryListItem> HelpCategories;
         RectF TextRect;
         Vector2 TitlePosition;
-        ScrollList<TextListItem> HelpEntries;
+        UITextBox HelpEntries;
 
         ScreenMediaPlayer Player;
         RectF SmallViewer;
@@ -56,7 +56,7 @@ namespace Ship_Game
             HelpCategories = Add(new ScrollList<WikiHelpCategoryListItem>(CategoriesRect));
 
             RectF textSlRect = new(CategoriesRect.X + CategoriesRect.W + 5, CategoriesRect.Y + 10, 375, 420);
-            HelpEntries = Add(new ScrollList<TextListItem>(textSlRect, Fonts.Arial12Bold.LineSpacing + 2));
+            HelpEntries = Add(new UITextBox(textSlRect, useBorder:false));
             TextRect = new(HelpCategories.X + HelpCategories.Width + 5, HelpCategories.Y + 10, 375, 420);
             
             ResetActiveTopic();
@@ -85,7 +85,7 @@ namespace Ship_Game
         
         void ResetActiveTopic()
         {
-            HelpEntries.ResetWithParseText(Fonts.Arial12Bold, ActiveTopic.Text, TextRect.W - 40);
+            HelpEntries.SetLines(ActiveTopic.Text, Fonts.Arial12Bold, Color.White);
             float titleW = Fonts.Arial20Bold.TextWidth(ActiveTopic.Title);
             TitlePosition = new(TextRect.CenterX - titleW / 2f - 15f, TextRect.Y + 10);
         }
@@ -99,7 +99,7 @@ namespace Ship_Game
                 return;
             }
 
-            HelpEntries.Reset();
+            HelpEntries.Clear();
             ActiveTopic = item.Topic;
 
             if (ActiveTopic.Text != null)
@@ -126,7 +126,7 @@ namespace Ship_Game
             }
             else
             {
-                HelpEntries.Reset();
+                HelpEntries.Clear();
                 Player.PlayVideo(ActiveTopic.VideoPath, looping: false, startPaused: true);
                 Player.Visible = true;
             }

--- a/Ship_Game/StoryAndEvents/YouLoseScreen.cs
+++ b/Ship_Game/StoryAndEvents/YouLoseScreen.cs
@@ -51,7 +51,7 @@ namespace Ship_Game
             batch.Draw(Reason, ReasonRect, Color.White);
             if (!IsExiting && ShowingReplay)
             {
-                replay.Draw(ScreenManager);
+                replay.Draw(batch, elapsed);
             }
             batch.End();
         }

--- a/Ship_Game/StoryAndEvents/YouWinScreen.cs
+++ b/Ship_Game/StoryAndEvents/YouWinScreen.cs
@@ -72,7 +72,7 @@ namespace Ship_Game
                 batch.Draw(Reason, ReasonRect, Color.White);
                 if (!IsExiting && ShowingReplay)
                 {
-                    replay.Draw(ScreenManager);
+                    replay.Draw(batch, elapsed);
                 }
             }
             batch.End();

--- a/Ship_Game/TechEntry.cs
+++ b/Ship_Game/TechEntry.cs
@@ -92,6 +92,7 @@ namespace Ship_Game
             Tech = clone.Tech;
             ConqueredSource = new(clone.ConqueredSource);
             TechTypeCostLookAhead = new(clone.TechTypeCostLookAhead);
+            Universe = clone.Universe;
         }
 
         [StarDataDeserialized]

--- a/Ship_Game/Technology.cs
+++ b/Ship_Game/Technology.cs
@@ -15,7 +15,6 @@ namespace Ship_Game
 
         /// This is purely used for logging/debugging to mark where the Technology was loaded from
         [XmlIgnore] public string DebugSourceFile = "<unknown>.xml";
-        [XmlIgnore] public float ActualCost => ResearchMultiplier() * UniverseState.DummyPacePlaceholder;
 
         [XmlIgnore] public Technology[] Children;
 
@@ -88,6 +87,8 @@ namespace Ship_Game
             }
         }
 
+        public float ActualCost(UniverseState us) => ResearchMultiplier(us) * us.ProductionPace;
+
         public bool AnyChildrenDiscovered(Empire empire)
             => Children.Any(tech => empire.GetTechEntry(tech.UID).Discovered);
 
@@ -140,13 +141,13 @@ namespace Ship_Game
             public string Type;
         }
 
-        float ResearchMultiplier()
+        float ResearchMultiplier(UniverseState uState)
         {
             if (!GlobalStats.Defaults.ChangeResearchCostBasedOnSize)
                 return Cost;
 
-            float settingResearchMultiplier = UniverseState.DummySettingsResearchModifier;
-            if (UniverseState.DummySettingsResearchModifier < 1f)
+            float settingResearchMultiplier = uState.SettingsResearchModifier;
+            if (settingResearchMultiplier < 1f)
                 return (Cost * settingResearchMultiplier.LowerBound(0.5f)).RoundTo10();
 
             float costRatio        = GetCostRatio();

--- a/Ship_Game/Troops/Troop.cs
+++ b/Ship_Game/Troops/Troop.cs
@@ -340,7 +340,7 @@ namespace Ship_Game
                 }
             }
 
-            Log.Write(ConsoleColor.Blue, $"Frame={WhichFrame} first={first_frame} idle={num_idle_frames} attack={num_attack_frames}");
+            //Log.Write(ConsoleColor.Blue, $"Frame={WhichFrame} first={first_frame} idle={num_idle_frames} attack={num_attack_frames}");
         }
 
         // Added by McShooterz, FB: changed it to level up every kill with decreasing chances

--- a/Ship_Game/UI/ScrollListBase.cs
+++ b/Ship_Game/UI/ScrollListBase.cs
@@ -417,6 +417,7 @@ namespace Ship_Game
             if (ScrollBarPosChanged)
             {
                 ScrollBarPosChanged = false;
+
                 // when scrollbar was moved being dragged by input, use it to update the visible index
                 float relScrollPos = GetRelativeScrollPosFromScrollBar();
                 float scrolledIndexF = Math.Max(0, FlatEntries.Count - maxVisibleItemsF) * relScrollPos;
@@ -464,8 +465,9 @@ namespace Ship_Game
 
         void UpdateScrollBarToCurrentIndex(float maxVisibleItemsF)
         {
-            int startOffset = (int)(ScrollHousing.H * (VisibleItemsBegin / (float)FlatEntries.Count));
-            int barHeight   = (int)(ScrollHousing.H * (maxVisibleItemsF / (float)FlatEntries.Count));
+            int count = FlatEntries.Count;
+            int startOffset = count == 0 ? 0 : (int)(ScrollHousing.H * (VisibleItemsBegin / (float)count));
+            int barHeight = count == 0 ? (int)ScrollHousing.H : (int)(ScrollHousing.H * (maxVisibleItemsF / count));
 
             ScrollBar = new(ScrollHousing.X, ScrollHousing.Y + startOffset,
                             GetStyle().ScrollBarMid.Normal.Width, barHeight);

--- a/Ship_Game/UI/UITextBox.cs
+++ b/Ship_Game/UI/UITextBox.cs
@@ -8,11 +8,18 @@ namespace Ship_Game
 {
     public class UITextBox : UIPanel
     {
-        readonly ScrollList<TextBoxItem> ItemsList;
+        readonly Graphics.Font DefaultFont;
+        public readonly ScrollList<TextBoxItem> ItemsList;
         
-        public UITextBox(in RectF rect) : base(rect, Color.TransparentBlack)
+        public UITextBox(in RectF rect, bool useBorder = true, Graphics.Font defaultFont = null) : base(rect, Color.TransparentBlack)
         {
-            ItemsList = base.Add(new SubmenuScrollList<TextBoxItem>(rect)).List;
+            DefaultFont = defaultFont ?? Fonts.Arial12Bold;
+
+            if (useBorder)
+                ItemsList = base.Add(new SubmenuScrollList<TextBoxItem>(rect)).List;
+            else
+                ItemsList = base.Add(new ScrollList<TextBoxItem>(rect));
+            
             ItemsList.EnableItemEvents = false;
         }
 
@@ -35,17 +42,18 @@ namespace Ship_Game
 
         public void AddLine(string line)
         {
-            AddLine(line, Fonts.Arial12Bold, Color.White);
+            AddLine(line, DefaultFont, Color.White);
         }
 
         public void AddLine(string line, Graphics.Font font, Color color)
         {
-            ItemsList.AddItem(new TextBoxItem(line, font, color));
+            ItemsList.AddItem(new(line, font ?? DefaultFont, color));
         }
 
         // Parses and WRAPS textblock into separate lines
         public void AddLines(string textBlock, Graphics.Font font, Color color)
         {
+            font ??= DefaultFont;
             string[] lines = font.ParseTextToLines(textBlock, ItemsList.ItemsHousing.W);
             foreach (string line in lines)
                 AddLine(line, font, color);
@@ -57,7 +65,21 @@ namespace Ship_Game
                 ItemsList.AddItem(new TextBoxItem(element));
         }
 
-        class TextBoxItem : ScrollListItem<TextBoxItem>
+        // Clears the textbox and sets new textblock lines, using DefaultFont and Color.White
+        public void SetLines(string textBlock)
+        {
+            Clear();
+            AddLines(textBlock, DefaultFont, Color.White);
+        }
+
+        // Clears the textbox and sets new textblock lines
+        public void SetLines(string textBlock, Graphics.Font font, Color color)
+        {
+            Clear();
+            AddLines(textBlock, font, color);
+        }
+
+        public sealed class TextBoxItem : ScrollListItem<TextBoxItem>
         {
             readonly UIElementV2 Elem;
             public override int ItemHeight => (int)Math.Round(Elem.Height);

--- a/Ship_Game/Universe/SolarBodies/SBProduction.cs
+++ b/Ship_Game/Universe/SolarBodies/SBProduction.cs
@@ -160,12 +160,12 @@ namespace Ship_Game.Universe.SolarBodies
             // we can't place it... there's some sort of bug
             if (q.Building.Unique && P.BuildingBuilt(q.Building.BID))
             {
-                Log.Error($"Unique building {q.Building} already exists on planet {P}");
+                Log.Warning($"Unique building {q.Building} already exists on planet {P}");
                 return false;
             }
             if (q.pgs.CanBuildHere(q.Building))
             {
-                Log.Error($"We can no longer build {q.Building} at tile {q.pgs}");
+                Log.Warning($"We can no longer build {q.Building} at tile {q.pgs}");
                 return false;
             }
 

--- a/Ship_Game/Universe/SolarSystem.cs
+++ b/Ship_Game/Universe/SolarSystem.cs
@@ -169,7 +169,7 @@ namespace Ship_Game
             }
         }
 
-        // Need in order for threat matrix to update starting remanants for Astronomers trait
+        // Need in order for threat matrix to update starting remnants for Astronomers trait
         public void NewGameAddRemnantShipToList(Ship s)
         {
             ShipList.Add(s);

--- a/Ship_Game/Universe/UniverseState.cs
+++ b/Ship_Game/Universe/UniverseState.cs
@@ -46,8 +46,6 @@ namespace Ship_Game.Universe
         public bool IsShipViewOrCloser   => ViewState <= UnivScreenState.ShipView;
 
         // TODO: This was too hard to fix, so added this placeholder until code is fixed
-        public static float DummyPacePlaceholder = 1f;
-        public static float DummySettingsResearchModifier = 1f;
         public static float DummyProductionPacePlaceholder = 1f;
 
         [StarData] public float SettingsResearchModifier = 1f;

--- a/Ship_Game/Universe/UniverseState.cs
+++ b/Ship_Game/Universe/UniverseState.cs
@@ -276,8 +276,7 @@ namespace Ship_Game.Universe
             Save = null;
             save.UpdateAllDesignsFromSave(this);
 
-            SettingsResearchModifier = GetResearchMultiplier();
-            RemnantPaceModifier = CalcRemnantPace();
+            CalcInitialSettings();
             
             // NOTE: This will automatically call AddShipInfluence() to update InfluenceTree
             Objects.AddRange(save.Ships);
@@ -473,6 +472,12 @@ namespace Ship_Game.Universe
         {
             owner.RemoveBorderNode(planet);
             Influence.Remove(owner, planet);
+        }
+
+        public void CalcInitialSettings()
+        {
+            SettingsResearchModifier = GetResearchMultiplier();
+            RemnantPaceModifier = CalcRemnantPace();
         }
 
         float CalcRemnantPace()

--- a/Ship_Game/Utils/Log.cs
+++ b/Ship_Game/Utils/Log.cs
@@ -679,8 +679,8 @@ namespace Ship_Game
                     evt["Mod"] = "Vanilla";
                 }
 
-                // find root UniverseScreen from ScreenManager
-                var universe = ScreenManager.Instance.FindScreen<UniverseScreen>();
+                // find root UniverseScreen from ScreenManager, unless the crash is before ScreenManager is created
+                var universe = ScreenManager.Instance?.FindScreen<UniverseScreen>();
                 evt["StarDate"]  = universe?.StarDateString ?? "NULL";
                 evt["Ships"]     = universe?.UState.Ships.Count.ToString() ?? "NULL";
                 evt["Planets"]   = universe?.UState.Planets?.Count.ToString() ?? "NULL";


### PR DESCRIPTION
remove verbose logging in Troop
refactor: use event based input in DiplomacyScreen, now it's suddenly… 
graphics: attempt to reload GameScreen when device is lost
fix: incorrect music playing in MainMenu after defeat
debug: log when diplomacy is skipped due to debug mode
fix: dialog textbox not scrolling properly in DiplomacyScreen, use UI… 
fix: GameScreens updating twice if another screen asked them to exit
fix: change incorrect error messages to be warning instead, if a buil… 
fix: ignore failed ship design errors, these are legacy files
fix: game crashes if a ship mesh fails to load, now just continue as-is
draw: always grab a copy of GameScreens during Draw()
fixed drone beams not repairing, not sure how this was suddenly broken.
fix remnant pace calc not working on new game. 
Fix: tech and remmant pace not calculated. still need to fix building… 
fix for rebels and defeated empire uninverse null when cloning tech
fix: logger crash when game has completely failed to initialize
fix: ignore Volume calculation failure when loading meshes