### PR TITLE
Hangar ship fixes

### DIFF
--- a/Ship_Game/AI/EmpireAI/ShipBuilder.cs
+++ b/Ship_Game/AI/EmpireAI/ShipBuilder.cs
@@ -112,7 +112,10 @@ namespace Ship_Game.AI
                 else
                     return null;
             }
-            IShipDesign pickedShip = RandomMath.RandItem(bestShips);
+
+            // We choose the first item for the player to overcome edge case where several ships have the same str
+            // because for the player - min str and max str is set to be the same to get the best ship)
+            IShipDesign pickedShip = empire.isPlayer ? bestShips[0] : RandomMath.RandItem(bestShips);
 
             if (false && empire.Universe?.Debug == true)
             {

--- a/Ship_Game/Ships/ShipDesign_Stats.cs
+++ b/Ship_Game/Ships/ShipDesign_Stats.cs
@@ -207,7 +207,7 @@ namespace Ship_Game.Ships
 
         public static string GetRole(RoleName role)
         {
-            int roleNum = (int)role - 1;
+            int roleNum = (int)role;
             return RoleArray[roleNum];
         }
 


### PR DESCRIPTION
- fix error in GetRole - getting the wrong role.
- fix edge case of hangarships were several ships have the same str for the player and the hangar ship builder would alternate between them due to random selection