### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/AI/EmpireAI/EmpireAI.RunEconomicPlanner.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.RunEconomicPlanner.cs
@@ -194,8 +194,8 @@ namespace Ship_Game.AI
             var pBudgets = new Array<PlanetBudget>();
             foreach (var planet in OwnerEmpire.GetPlanets())
             {
-                var planetBudget = new PlanetBudget(planet);
-                pBudgets.Add(planetBudget);
+                if (planet.Budget != null)
+                    pBudgets.Add(planet.Budget);
             }
 
             PlanetBudgets = pBudgets;
@@ -307,7 +307,5 @@ namespace Ship_Game.AI
 
             return maxRisk.Clamped(0.25f, riskLimit);
         }
-
-        public PlanetBudget PlanetBudget(Planet planet) => new(planet);
     }
 }

--- a/Ship_Game/AI/ExpansionAI/PlanetRanker.cs
+++ b/Ship_Game/AI/ExpansionAI/PlanetRanker.cs
@@ -44,7 +44,7 @@ namespace Ship_Game.AI.ExpansionAI
             if (!Planet.ParentSystem.HasPlanetsOwnedBy(empire))
             {
                 DistanceMod = (planet.Position.Distance(empireCenter) / longestDistance * 10).Clamped(1, 10);
-                EnemyStrMod = (empire.KnownEnemyStrengthIn(planet.ParentSystem) / empire.OffensiveStrength * 10).Clamped(1, 10);
+                EnemyStrMod = ((empire.KnownEnemyStrengthIn(planet.ParentSystem) / (empire.OffensiveStrength+10)) * 10).Clamped(1, 10);
                 CanColonize = !moralityBlock && (rawValue > 30 || empire.IsCybernetic && planet.MineralRichness > 1.5f);
                 Value = rawValue / DistanceMod / EnemyStrMod;
             }

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -1425,7 +1425,7 @@ namespace Ship_Game
             {
                 Planet planet = OwnedPlanets[i];
                 TotalColonyValues          += planet.ColonyValue;
-                TotalColonyPotentialValues += planet.ColonyPotentialValue(this);
+                TotalColonyPotentialValues += planet.ColonyPotentialValue(this, useBaseMaxFertility: false);
                 if (planet.ColonyValue > MaxColonyValue)
                     MaxColonyValue = planet.ColonyValue;
             }
@@ -1650,12 +1650,7 @@ namespace Ship_Game
                     TotalMaintenanceInScrap += maintenance;
                     continue;
                 }
-                if (AI.DefenseBudget > 0 && ((ship.ShipData.HullRole == RoleName.platform && ship.IsTethered)
-                                            || (ship.ShipData.HullRole == RoleName.station &&
-                                               (ship.ShipData.IsOrbitalDefense || !ship.ShipData.IsShipyard))))
-                {
-                    AI.DefenseBudget -= maintenance;
-                }
+
                 switch (ship.DesignRoleType)
                 {
                     case RoleType.WarSupport:

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -1835,13 +1835,20 @@ namespace Ship_Game
 
                 foreach (string shipTech in design.TechsNeeded)
                 {
-                    if (ShipTechs.Contains(shipTech))
-                        continue;
-                    TechEntry onlyShipTech = GetTechEntry(shipTech);
-                    if (onlyShipTech.Locked)
+                    if (!ShipTechs.Contains(shipTech))
                     {
-                        if (debug) Log.Write($"WeCanBuildThis:false Reason:LockedTech={shipTech} Design:{design.Name}");
-                        return false;
+                        // some ShipDesigns are loaded from savegame only, and the tech might no longer exist
+                        // in this case the ship is no longer buildable
+                        if (!TryGetTechEntry(shipTech, out TechEntry onlyShipTech))
+                        {
+                            if (debug) Log.Write($"WeCanBuildThis:false Reason:MissingTech={shipTech} Design:{design.Name}");
+                            return false;
+                        }
+                        else if (onlyShipTech.Locked)
+                        {
+                            if (debug) Log.Write($"WeCanBuildThis:false Reason:LockedTech={shipTech} Design:{design.Name}");
+                            return false;
+                        }
                     }
                 }
             }

--- a/Ship_Game/GameScreens/ColonyScreen/GovernorDetailsComponent.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/GovernorDetailsComponent.cs
@@ -278,20 +278,17 @@ namespace Ship_Game
 
             OverrideCiv.OnChange = cb =>
             {
-                var budget = new PlanetBudget(Planet);
-                Planet.SetManualCivBudget(cb.Checked ? budget.CivilianAlloc : 0);
+                Planet.SetManualCivBudget(cb.Checked ? Planet.Budget.CivilianAlloc : 0);
             };
 
             OverrideGrd.OnChange = cb =>
             {
-                var budget = new PlanetBudget(Planet);
-                Planet.SetManualGroundDefBudget(cb.Checked ? budget.GrdDefAlloc : 0);
+                Planet.SetManualGroundDefBudget(cb.Checked ? Planet.Budget.GrdDefAlloc : 0);
             };
 
             OverrideSpc.OnChange = cb =>
             {
-                var budget = new PlanetBudget(Planet);
-                Planet.SetManualSpaceDefBudget(cb.Checked ? budget.SpcDefAlloc : 0);
+                Planet.SetManualSpaceDefBudget(cb.Checked ? Planet.Budget.SpcDefAlloc : 0);
             };
 
             UpdateButtons();
@@ -655,7 +652,7 @@ namespace Ship_Game
 
         void UpdateBudgets()
         {
-            var budget = new PlanetBudget(Planet);
+            var budget = Planet.Budget;
 
             UpdateCivBudget(budget);
             UpdateGrdBudget(budget);

--- a/Ship_Game/Ships/CarrierBays.cs
+++ b/Ship_Game/Ships/CarrierBays.cs
@@ -626,9 +626,9 @@ namespace Ship_Game.Ships
                 roles += role;
             }
 
-            Log.Warning($"No startingShip defined and no roles=[{roles}] designs available for {Owner}");
+            Log.Warning($"No startingShip defined and no roles=[{roles}] designs available for {Owner} ({Owner.Loyalty.Name})");
             return false; ;
-        }
+        } 
 
         private static HangarOptions GetCategoryFromHangarType(DynamicHangarOptions hangarType)
         {

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -14,6 +14,7 @@ using Ship_Game.Spatial;
 using Ship_Game.Gameplay;
 using Ship_Game.Utils;
 using Vector2 = SDGraphics.Vector2;
+using Ship_Game.AI.Budget;
 
 namespace Ship_Game
 {
@@ -38,6 +39,7 @@ namespace Ship_Game
         public SpaceStation Station;
         
         [StarData] public TroopManager Troops;
+        [StarData] public PlanetBudget Budget;
         
         // TODO: this is only for save compatibility, remove later
         [StarData] Array<Troop> TroopsHere
@@ -369,6 +371,11 @@ namespace Ship_Game
                 OrbitalRadius += Radius;
 
             UpdatePositionOnly();
+        }
+
+        public void CreatePlanetBudget(Empire owner)
+        {
+            Budget = new(this, owner);
         }
 
         // This will launch troops without having issues with modifying it's own TroopsHere

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
@@ -419,7 +419,7 @@ namespace Ship_Game
             if (MilitaryBuildingInTheWorks)
                 return;
 
-            if (budget < 0)
+            if (budget < -0.0499f)
                 TryScrapMilitaryBuilding();
             else
                 TryBuildMilitaryBuilding(budget);

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Colonize.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Colonize.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using SDUtils;
 using Ship_Game.Fleets;
 using Ship_Game.Ships;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
@@ -48,7 +48,7 @@ namespace Ship_Game
         void BuildAndScrapCivilianBuildings(float budget)
         {
             UpdateGovernorPriorities();
-            if (budget < 0f)
+            if (budget < -0.0499f)
             {
                 TryScrapBuilding(); // We must scrap something to bring us above of our debt tolerance
             }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
@@ -168,7 +168,7 @@ namespace Ship_Game
                 return ManualFoodImportSlots;
 
             float averageFreighterCargoCap = Owner.AverageFreighterCargoCap;
-            int maxSlots = (int)(Storage.Max / averageFreighterCargoCap);
+            int maxSlots = ((int)(Storage.Max / averageFreighterCargoCap)).LowerBound(1);
             float foodMissing = Storage.Max - FoodHere - IncomingFood;
 
             foodMissing += (-Food.NetIncome * AverageFoodImportTurns).LowerBound(0);
@@ -186,7 +186,7 @@ namespace Ship_Game
                 return ManualProdImportSlots;
 
             float averageFreighterCargoCap = Owner.AverageFreighterCargoCap;
-            int maxSlots = (int)(Storage.Max / averageFreighterCargoCap);
+            int maxSlots = ((int)(Storage.Max / averageFreighterCargoCap)).LowerBound(1);
             if (NonCybernetic)
             {
                 switch (ConstructionQueue.Count)

--- a/Ship_Game/Universe/UniverseState.cs
+++ b/Ship_Game/Universe/UniverseState.cs
@@ -467,6 +467,7 @@ namespace Ship_Game.Universe
         
         public void OnPlanetOwnerAdded(Empire owner, Planet planet)
         {
+            planet.CreatePlanetBudget(owner);
             owner.AddBorderNode(planet);
             Influence.Insert(owner, planet);
         }


### PR DESCRIPTION
Note - this is going to make governors flakey for several turns when loading an game saved by previous patches.
Fixed Nan in PlanetRanker.cs
Fix: Missing techs from savegames causing errors in 'WeCanBuildThis'
Fix: Move Planet Budget into a class and use EMA to smooth budget changes
Fix: Defense Budget being deducted of maint while it is already calculated in planet budget per plant.
Fix: Import Food/Prod slots being 0 in edge cases.
Fix: Allow governors to build more non profitable biospheres (up to 5)
Fix: Remove money buildings always suitable for build if profitable.
@gkapulis @RedFox20 