### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/Building.cs
+++ b/Ship_Game/Building.cs
@@ -43,7 +43,6 @@ namespace Ship_Game
         public bool IsDestroyed => Strength <= 0;
         [StarData(DefaultValue=true)] public bool Scrappable = true;
         [StarData(DefaultValue=true)] public bool Unique = true;
-        [StarData] public bool isWeapon;
         [StarData] public string Weapon = "";
         [StarData] public float WeaponTimer;
         [StarData] public float AttackTimer;
@@ -70,7 +69,7 @@ namespace Ship_Game
         [StarData] public float SensorRange;
         [StarData] public bool IsProjector;
         [StarData] public float ProjectorRange;
-        [StarData] public float ShipRepair; // ship repair multiplier, intended to be 1.0 or 2.0 etc
+        [StarData] public float ShipRepair; // Note that thee is a multiplier in globals.yamls for this
         [StarData] public BuildingCategory Category;
         [StarData] public bool IsPlayerAdded;
         [StarData] public int InvadeInjurePoints;
@@ -108,6 +107,7 @@ namespace Ship_Game
         public static int CapitalId, OutpostId, BiospheresId, SpacePortId, TerraformerId;
         public static int VolcanoId, ActiveVolcanoId, EruptingVolcanoId, Lava1Id, Lava2Id, Lava3Id;
         public static int Crater1Id, Crater2Id, Crater3Id, Crater4Id;
+        [XmlIgnore] public bool IsWeapon => Weapon.NotEmpty();
         [XmlIgnore] public bool IsCapital          => BID == CapitalId;
         [XmlIgnore] public bool IsOutpost          => BID == OutpostId;
         [XmlIgnore] public bool IsCapitalOrOutpost => BID == CapitalId || BID == OutpostId;
@@ -155,12 +155,12 @@ namespace Ship_Game
 
         public void CreateWeapon(Planet p)
         {
-            if (!isWeapon || TheWeapon != null)
-                return;
-
-            TheWeapon = ResourceManager.CreateWeapon(Weapon);
-            SpaceRange = TheWeapon.BaseRange;
-            UpdateOffense(p);
+            if (IsWeapon)
+            {
+                TheWeapon = ResourceManager.CreateWeapon(Weapon);
+                SpaceRange = TheWeapon.BaseRange;
+                UpdateOffense(p);
+            }
         }
 
         public void UpdateAttackActions(int amount)
@@ -212,7 +212,7 @@ namespace Ship_Game
 
         public void UpdateOffense(Planet p)
         {
-            if (isWeapon)
+            if (IsWeapon)
             {
                 if (TheWeapon == null)
                     CreateWeapon(p);
@@ -243,7 +243,7 @@ namespace Ship_Game
 
         public bool UpdateSpaceCombatActions(FixedSimTime timeStep, Planet p)
         {
-            if (!isWeapon && DefenseShipsCapacity == 0)
+            if (!IsWeapon && DefenseShipsCapacity == 0)
                 return false;
 
             bool canFireWeapon = false;
@@ -414,7 +414,7 @@ namespace Ship_Game
                 score += CalcDefenseShipScore();
             }
 
-            if (isWeapon && Offense == 0f)
+            if (IsWeapon && Offense == 0f)
                 UpdateOffense(p);
 
             MilitaryStrength = score + Offense * 0.1f;

--- a/Ship_Game/Building.cs
+++ b/Ship_Game/Building.cs
@@ -14,7 +14,6 @@ namespace Ship_Game
     public sealed class Building
     {
         [StarData] public string Name;
-        [StarData] public bool IsSensor;
         [StarData] public bool NoRandomSpawn;
         [StarData] public bool AllowShipBuilding;
         [StarData] public int NameTranslationIndex;
@@ -107,6 +106,8 @@ namespace Ship_Game
         public static int CapitalId, OutpostId, BiospheresId, SpacePortId, TerraformerId;
         public static int VolcanoId, ActiveVolcanoId, EruptingVolcanoId, Lava1Id, Lava2Id, Lava3Id;
         public static int Crater1Id, Crater2Id, Crater3Id, Crater4Id;
+
+        [XmlIgnore] public bool IsSensor => SensorRange > 0;
         [XmlIgnore] public bool IsWeapon => Weapon.NotEmpty();
         [XmlIgnore] public bool IsCapital          => BID == CapitalId;
         [XmlIgnore] public bool IsOutpost          => BID == OutpostId;
@@ -124,7 +125,7 @@ namespace Ship_Game
         [XmlIgnore] public float CostEffectiveness => MilitaryStrength / Cost.LowerBound(0.1f);
         [XmlIgnore] public bool HasLaunchedAllDefenseShips => CurrentNumDefenseShips <= 0;
         [XmlIgnore] private float DefenseShipStrength;
-        [XmlIgnore] public float SpaceRange = 10000f;
+        [XmlIgnore] public float SpaceRange = 20000f;
 
         // these appear in Hardcore Ruleset
         public static int FissionablesId, MineFissionablesId, FuelRefineryId;
@@ -258,7 +259,8 @@ namespace Ship_Game
             if (canFireWeapon || canLaunchShips)
             {
                 // this scan is pretty expensive
-                Ship target = p.ScanForSpaceCombatTargets(TheWeapon, SpaceRange);
+                float range = canFireWeapon && canLaunchShips ? SpaceRange.LowerBound(20000) : SpaceRange;
+                Ship target = p.ScanForSpaceCombatTargets(TheWeapon, range, canLaunchShips);
                 if (target != null)
                 {
                     if (canFireWeapon)

--- a/Ship_Game/Building.cs
+++ b/Ship_Game/Building.cs
@@ -66,7 +66,6 @@ namespace Ship_Game
         [StarData] public float PlusProdPerColonist;
         [StarData] public float PlusFlatProductionAmount;
         [StarData] public float SensorRange;
-        [StarData] public bool IsProjector;
         [StarData] public float ProjectorRange;
         [StarData] public float ShipRepair; // Note that thee is a multiplier in globals.yamls for this
         [StarData] public BuildingCategory Category;

--- a/Ship_Game/Data/ResourceManager.cs
+++ b/Ship_Game/Data/ResourceManager.cs
@@ -1015,18 +1015,6 @@ namespace Ship_Game
         public static Building CreateBuilding(Planet p, Building template)
         {
             Building newB = template.Clone();
-
-            // comp fix to ensure functionality of vanilla buildings
-            if (newB.IsCapitalOrOutpost)
-            {
-                // @todo What is going on here? Is this correct?
-                if (!newB.IsProjector && !(newB.ProjectorRange > 0f))
-                {
-                    newB.ProjectorRange = p.GetProjectorRadius(p.Owner);
-                    newB.IsProjector    = true;
-                }
-            }
-
             newB.CreateWeapon(p);
             newB.CalcMilitaryStrength(p);
             return newB;

--- a/Ship_Game/Data/ResourceManager.cs
+++ b/Ship_Game/Data/ResourceManager.cs
@@ -1025,12 +1025,6 @@ namespace Ship_Game
                     newB.ProjectorRange = p.GetProjectorRadius(p.Owner);
                     newB.IsProjector    = true;
                 }
-
-                if (!newB.IsSensor && !(newB.SensorRange > 0.0f))
-                {
-                    newB.SensorRange = 20000.0f;
-                    newB.IsSensor    = true;
-                }
             }
 
             newB.CreateWeapon(p);

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -2401,7 +2401,7 @@ namespace Ship_Game
         }
 
         public int EstimateCreditCost(float itemCost)   => (int)Math.Round(ProductionCreditCost(itemCost), 0);
-        public void ChargeCreditsHomeDefense(Ship ship) => ChargeCredits(ship.GetCost(this));
+        public void ChargeCreditsHomeDefense(Ship ship) => ChargeCredits(ship.GetCost(this) * 0.2f);
 
         public void ChargeCreditsOnProduction(QueueItem q, float spentProduction)
         {

--- a/Ship_Game/ExtensionMethods/HelperFunctions.cs
+++ b/Ship_Game/ExtensionMethods/HelperFunctions.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using Microsoft.Xna.Framework.Graphics;
 using SDGraphics;
 using SDUtils;
@@ -35,7 +36,10 @@ namespace Ship_Game
             return null;
         }
 
-        static Fleet CreateFleetFromData(UniverseState u, FleetDesign data, int fleetId, Empire owner, Vector2 position)
+        /// <summary>
+        /// Ony use in debug!
+        /// </summary>
+        static Fleet DebugCreateFleetFromData(UniverseState u, FleetDesign data, int fleetId, Empire owner, Vector2 position)
         {
             if (data == null)
                 return null;
@@ -52,7 +56,16 @@ namespace Ship_Game
             foreach (FleetDataNode node in fleet.DataNodes)
             {
                 Ship s = Ship.CreateShipAtPoint(u, node.ShipName, owner, position + node.RelativeFleetOffset);
-                if (s == null) continue;
+                if (s == null) 
+                    continue;
+
+                if (s.IsDefaultTroopShip)
+                {
+                    Troop troop = ResourceManager.GetTroopTemplatesFor(owner).First();
+                    if (ResourceManager.TryCreateTroop(troop.Name, owner, out Troop newTroop))
+                        newTroop.LandOnShip(s);
+                }
+
                 s.AI.CombatState = node.CombatState;
                 s.RelativeFleetOffset = node.RelativeFleetOffset;
                 node.Ship = s;
@@ -62,9 +75,9 @@ namespace Ship_Game
             return fleet;
         }
 
-        public static void CreateFirstFleetAt(UniverseState universe, string fleetUid, Empire owner, Vector2 position)
+        public static void DebugCreateFleetAt(UniverseState universe, string fleetUid, Empire owner, Vector2 position)
         {
-            CreateFleetFromData(universe, LoadFleetDesign(fleetUid), 1, owner, position);
+            DebugCreateFleetFromData(universe, LoadFleetDesign(fleetUid), 1, owner, position);
         }
 
         public static bool IsInUniverseBounds(float universeSize, Vector2 pos)

--- a/Ship_Game/ExtensionMethods/HelperFunctions.cs
+++ b/Ship_Game/ExtensionMethods/HelperFunctions.cs
@@ -12,6 +12,7 @@ using Ship_Game.Ships;
 using Ship_Game.Universe;
 using Vector2 = SDGraphics.Vector2;
 using Rectangle = SDGraphics.Rectangle;
+using Ship_Game.Data.Yaml;
 
 namespace Ship_Game
 {
@@ -24,11 +25,11 @@ namespace Ship_Game
 
         private static FleetDesign LoadFleetDesign(string fleetUid)
         {
-            string designPath = fleetUid + ".xml";
+            string designPath = fleetUid + ".yaml";
             FileInfo info = ResourceManager.GetModOrVanillaFile(designPath) ??
                             new FileInfo(Dir.StarDriveAppData + "/Fleet Designs/" + designPath);
             if (info.Exists)
-                return info.Deserialize<FleetDesign>();
+                return YamlParser.Deserialize<FleetDesign>(info);
 
             Log.Warning($"Failed to load fleet design '{designPath}'");
             return null;

--- a/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
@@ -593,7 +593,7 @@ namespace Ship_Game
             string selectionText = MultiLineFormat(selectedBuilding.DescriptionText);
             batch.DrawString(TextFont, selectionText, bCursor, color);
             bCursor.Y += TextFont.MeasureString(selectionText).Y + Font20.LineSpacing;
-            if (selectedBuilding.isWeapon)
+            if (selectedBuilding.IsWeapon)
                 selectedBuilding.CalcMilitaryStrength(P); // So the building will have TheWeapon for stats
 
             DrawSelectedBuildingInfo(ref bCursor, batch, selectedBuilding);

--- a/Ship_Game/Technology.cs
+++ b/Ship_Game/Technology.cs
@@ -268,7 +268,7 @@ namespace Ship_Game
                     continue;
                 }
 
-                if (building.AllowInfantry || building.isWeapon || building.IsSensor ||
+                if (building.AllowInfantry || building.IsWeapon || building.IsSensor ||
                     building.PlanetaryShieldStrengthAdded > 0 || building.CombatStrength > 0 || building.CanAttack)
                 {
                     types.Add(TechnologyType.GroundCombat);

--- a/Ship_Game/Universe/EmpireSolarSystemStatus.cs
+++ b/Ship_Game/Universe/EmpireSolarSystemStatus.cs
@@ -47,7 +47,7 @@ namespace Ship_Game.Universe
                 {
                     HostileForcesPresent = true;
                     CombatTimer = Owner.isPlayer ? 5f : 1f;
-                    if (ship.BaseStrength > 0)
+                    if (ship.BaseStrength > 0 || ship.IsDefaultTroopShip)
                     {
                         DangerousForcesPresent = true;
                         return;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -644,15 +644,16 @@ namespace Ship_Game
             return false;
         }
 
-        public Ship ScanForSpaceCombatTargets(Weapon w,  float weaponRange) // @todo FB - need to work on this
+        // FB: Beter to scan once and let each building use the result - i think
+        public Ship ScanForSpaceCombatTargets(Weapon w,  float weaponRange, bool canLaunchShips)
         {
             // don't do this expensive scan if there are no hostiles
             if (!ParentSystem.HostileForcesPresent(Owner))
                 return null;
 
             weaponRange = weaponRange.UpperBound(SensorRange);
-            float closestTroop = weaponRange*weaponRange;
-            float closestShip = weaponRange*weaponRange;
+            float closestTroop = weaponRange* weaponRange;
+            float closestShip = weaponRange* weaponRange;
             Ship troop = null;
             Ship closest = null;
 
@@ -663,13 +664,13 @@ namespace Ship_Game
             };
             SpatialObjectBase[] enemyShips = Universe.Spatial.FindNearby(ref opt);
 
-            for (int j = 0; j < enemyShips.Length; ++j)
+            for (int i = 0; i < enemyShips.Length; ++i)
             {
-                var ship = (Ship)enemyShips[j];
+                var ship = (Ship)enemyShips[i];
                 if (ship.Dying
                     || ship.IsInWarp
                     || ship.EMPDisabled && w?.EMPDamage > 0 && enemyShips.Length > 1
-                    || w != null && !w.TargetValid(ship)
+                    || w != null && !w.TargetValid(ship) && !canLaunchShips
                     || !Owner.IsEmpireAttackable(ship.Loyalty))
                 {
                     continue;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -862,7 +862,7 @@ namespace Ship_Game
                 Level = newLevel;
                 foreach (Building b in Buildings)
                 {
-                    if (b.isWeapon)
+                    if (b.IsWeapon)
                         b.UpdateOffense(this);
                 }
             }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
@@ -173,6 +173,7 @@ namespace Ship_Game
             if (!ParentSystem.OwnerList.Contains(Owner))
                 ParentSystem.OwnerList.Add(Owner);
 
+            UpdateDevelopmentLevel();
             CreateHomeWorldBuildings();
         }
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_WeCanAffordThis.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_WeCanAffordThis.cs
@@ -36,7 +36,7 @@ namespace Ship_Game
 
                 int defensiveBuildings = p.CountBuildings(def => def.SoftAttack > 0 || def.PlanetaryShieldStrengthAdded > 0 || def.TheWeapon != null);
                 int offensiveBuildings = p.BuildingsCanBuild.Count(off => off.PlanetaryShieldStrengthAdded > 0 || off.SoftAttack > 0 || off.TheWeapon != null);
-                bool isDefensive = b.SoftAttack > 0 || b.PlanetaryShieldStrengthAdded > 0 || b.isWeapon;
+                bool isDefensive = b.SoftAttack > 0 || b.PlanetaryShieldStrengthAdded > 0 || b.IsWeapon;
                 float defenseRatio = 0;
                 if (defensiveBuildings + offensiveBuildings > 0)
                     defenseRatio = (defensiveBuildings + 1) / (float)(defensiveBuildings + offensiveBuildings + 1);
@@ -233,7 +233,7 @@ namespace Ship_Game
                 return false;
             if (a.HighPri)
             {
-                if (b.isWeapon
+                if (b.IsWeapon
                     || b.IsSensor
                     || b.Defense > 0
                     || (Fertility < 1f && b.PlusFlatFoodAmount > 0)

--- a/Ship_Game/Universe/SolarBodies/PlanetInfoUIElement.cs
+++ b/Ship_Game/Universe/SolarBodies/PlanetInfoUIElement.cs
@@ -269,7 +269,7 @@ namespace Ship_Game
 
         void DrawSendTroops(SpriteBatch batch, Vector2 mousePos)
         {
-            if (P.Owner == Player || Player.IsNAPactWith(P.Owner))
+            if (P.Owner == Player || P.Owner != null && !Player.IsAtWarWith(P.Owner))
                 return; // Cannot send troops to this planet or different UI for player owner.
 
             Vector2 textPos        = new Vector2(SendTroops.X + 25, SendTroops.Y + 12 - Font12.LineSpacing / 2 - 2);
@@ -277,7 +277,7 @@ namespace Ship_Game
             Color buttonBaseColor  = ButtonTextColor;
             Color buttonHoverColor = ButtonHoverColor;
             string texName         = "UI/dan_button_blue";
-            string text = "Invade"; ;
+            string text = "Invade";
             if (P.Owner != null)
             {
                 if (incomingTroops > 0)

--- a/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
+++ b/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
@@ -113,11 +113,13 @@ namespace Ship_Game.Universe
                 else
                     ship.OrderToOrbit(planet, clearOrders, order); // Just orbit
             }
-            else if (planet.Habitable && (planet.Owner == null ||
-                                          ship.Loyalty.IsEmpireAttackable(planet.Owner)))
+            else if (planet.Habitable)
             {
-                // Land troops on unclaimed planets or enemy planets
-                ship.AI.OrderLandAllTroops(planet, clearOrders);
+                if (planet.Owner == null || ship.Loyalty.IsAtWarWith(planet.Owner))
+                {
+                    // Land troops on unclaimed planets or enemy planets
+                    ship.AI.OrderLandAllTroops(planet, clearOrders);
+                }
             }
             else
             {

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.HandleInput.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.HandleInput.cs
@@ -110,8 +110,8 @@ namespace Ship_Game
             if (input.SpawnShip)
                 Ship.CreateShipAtPoint(UState, "Bondage-Class Mk IIIa Cruiser", player, mouseWorldPos);
 
-            if (input.SpawnFleet2) HelperFunctions.CreateFirstFleetAt(UState, "Fleet 2", player, mouseWorldPos);
-            if (input.SpawnFleet1) HelperFunctions.CreateFirstFleetAt(UState, "Fleet 1", player, mouseWorldPos);
+            if (input.SpawnFleet2) HelperFunctions.DebugCreateFleetAt(UState, "Fleet 2", player, mouseWorldPos);
+            if (input.SpawnFleet1) HelperFunctions.DebugCreateFleetAt(UState, "Fleet 1", player, mouseWorldPos);
 
             if (SelectedShip != null)
             {

--- a/game/Content/Buildings/Civilian/Capital.xml
+++ b/game/Content/Buildings/Civilian/Capital.xml
@@ -20,7 +20,6 @@
   <Defense>40</Defense>
   <HardAttack>50</HardAttack>
   <Scrappable>false</Scrappable>
-  <IsSensor>true</IsSensor>
   <SensorRange>30000</SensorRange>
   <IsProjector>true</IsProjector>
   <ProjectorRange>50000</ProjectorRange>

--- a/game/Content/Buildings/Civilian/Capital.xml
+++ b/game/Content/Buildings/Civilian/Capital.xml
@@ -21,7 +21,6 @@
   <HardAttack>50</HardAttack>
   <Scrappable>false</Scrappable>
   <SensorRange>30000</SensorRange>
-  <IsProjector>true</IsProjector>
   <ProjectorRange>50000</ProjectorRange>
   <DefenseShipsCapacity>8</DefenseShipsCapacity>
   <DefenseShipsRole>fighter</DefenseShipsRole>

--- a/game/Content/Buildings/Military/Cloud Peak.xml
+++ b/game/Content/Buildings/Military/Cloud Peak.xml
@@ -12,8 +12,7 @@
     <HardAttack>60</HardAttack>
     <Defense>20</Defense>
     <Weapon>CPMissile</Weapon>
-    <isWeapon>true</isWeapon>
-    
+   
     <!-- For localization in GameText.yaml -->
     <NameTranslationIndex>5408</NameTranslationIndex>
     <DescriptionIndex>5409</DescriptionIndex>

--- a/game/Content/Buildings/Military/Gun Emplacement.xml
+++ b/game/Content/Buildings/Military/Gun Emplacement.xml
@@ -10,7 +10,6 @@
   <Defense>20</Defense>
   <SoftAttack>55</SoftAttack>
   <HardAttack>20</HardAttack>
-  <isWeapon>true</isWeapon>
   <InvadeInjurePoints>1</InvadeInjurePoints>
   <Weapon>PlanetFlak</Weapon>
   

--- a/game/Content/Buildings/Military/Heavy Autocannon.xml
+++ b/game/Content/Buildings/Military/Heavy Autocannon.xml
@@ -11,7 +11,6 @@
     <SoftAttack>60</SoftAttack>
     <HardAttack>30</HardAttack>
     <Weapon>PlanetAC</Weapon>
-    <isWeapon>true</isWeapon>
     
     <!-- For localization in GameText.yaml -->
     <NameTranslationIndex>5405</NameTranslationIndex>

--- a/game/Content/Buildings/Military/Ion Cannon.xml
+++ b/game/Content/Buildings/Military/Ion Cannon.xml
@@ -9,7 +9,6 @@
   <SoftAttack>30</SoftAttack>
   <HardAttack>20</HardAttack>
   <Weapon>IonDefenseCannon</Weapon>
-  <isWeapon>true</isWeapon>
   
   <!-- For localization in GameText.yaml -->
   <NameTranslationIndex>433</NameTranslationIndex>

--- a/game/Content/Buildings/Military/System Defence Torpedo.xml
+++ b/game/Content/Buildings/Military/System Defence Torpedo.xml
@@ -10,7 +10,6 @@
     <SoftAttack>70</SoftAttack>
     <HardAttack>60</HardAttack>
     <Weapon>System Defence Torpedo</Weapon>
-    <isWeapon>true</isWeapon>
     
     <!-- For localization in GameText.yaml -->
     <NameTranslationIndex>17712</NameTranslationIndex>


### PR DESCRIPTION
- Fix: debug creation of fleets 
- Fix: Add troop to default troopships in debug fleet creation (they were spawned with no troops)
- Fix: space to gound do not fire on troop ships if only troop ships are present (they has str 0).
- Fix: Dont show invade button and do nothing if the player tries to invade via right click if not at war (indead of orbiting the 
- planet)
- Fix: Allow home defense ships to be launched regardless of weapon range if the building can do both
- Fix: home defense ships were not launched if target as not valid - if that building has a weapon too
- Balance: Fighter defense building will cost 20% of ship cost, as they are temp.
- Refactor: Change debug fleet creation to DebugCreateFleet. 
- Refactor: Get rid of "isweapon" building xml tag. It is derived from the "weapon" tag.
- Refactor: Remove IsSensor from building XML, it is derived from SensorRange tag.
- Refactor: remove default sensor range on building creation since we deal with  it in building placement
- Refactor: remove IsProjecor xml tags and related code