### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/Commands/Goals/ScrapShip.cs
+++ b/Ship_Game/Commands/Goals/ScrapShip.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Xna.Framework;
 using Ship_Game.AI;
 using Ship_Game.Data.Serialization;
 using Ship_Game.Ships;
@@ -101,6 +102,17 @@ namespace Ship_Game.Commands.Goals  // Created by Fat Bastard
 
             if (OldShip?.Active == true)
             {
+                if (OldShip.IsResearchStation)
+                {
+                    Planet planet = OldShip.GetTether();
+                    if (planet != null)
+                        Owner.Universe.RemoveEmpireFromResearchableList(Owner, planet);
+                    else if (OldShip.System != null)
+                        Owner.Universe.RemoveEmpireFromResearchableList(Owner, OldShip.System);
+                    else
+                        Log.Error($"Scrap Ship - research station {OldShip.Name} System was null!");
+                }
+
                 OldShip.ScuttleTimer = 1;
                 OldShip.AI.ClearOrders(AIState.Scuttle, priority: true);
                 OldShip.QueueTotalRemoval(); // fbedard

--- a/Ship_Game/DeepSpaceBuildingWindow.cs
+++ b/Ship_Game/DeepSpaceBuildingWindow.cs
@@ -20,6 +20,7 @@ namespace Ship_Game
         Planet TargetPlanet;
         SolarSystem TargetSystem;
         ShipInfoOverlayComponent ShipInfoOverlay;
+        const float MinimumBuildDistanceFromSun = 20000;
 
         public DeepSpaceBuildingWindow(UniverseScreen screen)
         {
@@ -154,8 +155,8 @@ namespace Ship_Game
                 Vector2 worldPos = Screen.CursorWorldPosition2D;
                 if (ShipToBuild.IsResearchStation)
                 {
-                    if (TargetPlanet != null)      Player.AI.AddGoalAndEvaluate(new ProcessResearchStation(Player, TargetPlanet));
-                    else if (TargetSystem != null) Player.AI.AddGoalAndEvaluate(new ProcessResearchStation(Player, TargetSystem, worldPos));
+                    if (TargetPlanet != null)      Player.AI.AddGoalAndEvaluate(new ProcessResearchStation(Player, TargetPlanet, ShipToBuild));
+                    else if (TargetSystem != null) Player.AI.AddGoalAndEvaluate(new ProcessResearchStation(Player, TargetSystem, worldPos, ShipToBuild));
                 }
                 else
                 {
@@ -180,7 +181,9 @@ namespace Ship_Game
             if (ShipToBuild == null)
                 return false;
 
-            if (targetSystem != null && !targetSystem.InSafeDistanceFromRadiation(Screen.CursorWorldPosition2D))
+            if (targetSystem != null 
+                && (Screen.CursorWorldPosition2D.InRadius(targetSystem.Position, MinimumBuildDistanceFromSun) 
+                   ||!targetSystem.InSafeDistanceFromRadiation(Screen.CursorWorldPosition2D)))
                 return false;
 
             if (targetPlanet != null)
@@ -242,8 +245,8 @@ namespace Ship_Game
                     }
                 }
 
-                Screen.DrawCircleProjected(system.Position, system.SunDangerRadius, new Color(255, 0, 0, 100), 2f,
-                    nodeTex, new Color(255, 0, 0, 50));
+                Screen.DrawCircleProjected(system.Position, system.SunDangerRadius.LowerBound(MinimumBuildDistanceFromSun),
+                    new Color(255, 0, 0, 100), 2f, nodeTex, new Color(255, 0, 0, 50));
             }
 
             base.Draw(batch, elapsed);

--- a/Ship_Game/GamePlayGlobals.cs
+++ b/Ship_Game/GamePlayGlobals.cs
@@ -52,7 +52,7 @@ public class GamePlayGlobals
     // multiplier of EMP damage removed from shipyard repair when orbiting a colony
     [StarData] public float BonusColonyEMPRecovery = 5.0f;
     // base repair rate from ship command/engineering modules per SECOND
-    [StarData] public float BaseSelfRepair = 10.0f;
+    [StarData] public float SelfRepairMultiplier = 1f;
     // +bonus rate based on crew level, 0.2 would be +20% increase per each crew level
     [StarData] public float BonusRepairPerCrewLevel = 0.2f;
     // repair rate modifier for command/engineering self repair when in combat

--- a/Ship_Game/GamePlayGlobals.cs
+++ b/Ship_Game/GamePlayGlobals.cs
@@ -57,7 +57,9 @@ public class GamePlayGlobals
     [StarData] public float BonusRepairPerCrewLevel = 0.2f;
     // repair rate modifier for command/engineering self repair when in combat
     [StarData] public float InCombatSelfRepairModifier = 0.2f;
-  
+    // Shield power multiply
+    [StarData] public float ShieldPowerMultiplier = 1f;
+
 
     // feature flags
     [StarData] public bool UseHullBonuses;

--- a/Ship_Game/Ships/EmpireHullBonuses.cs
+++ b/Ship_Game/Ships/EmpireHullBonuses.cs
@@ -26,9 +26,8 @@ namespace Ship_Game.Ships
 
             FuelCellMod   = EmpireDataMod(empire.data.FuelCellModifier);
             PowerFlowMod  = EmpireDataMod(empire.data.PowerFlowMod);
-            RepairRateMod = EmpireDataMod(empire.data.Traits.RepairMod) * hullBonus.RepairModifier;
-            RepairRateMod *= GlobalStats.Defaults.BaseSelfRepair;
-            ShieldMod     = EmpireDataMod(empire.data.ShieldPowerMod)   * hullBonus.ShieldModifier;
+            RepairRateMod = EmpireDataMod(empire.data.Traits.RepairMod) * hullBonus.RepairModifier * GlobalStats.Defaults.SelfRepairMultiplier;
+            ShieldMod     = EmpireDataMod(empire.data.ShieldPowerMod) * hullBonus.ShieldModifier * GlobalStats.Defaults.ShieldPowerMultiplier;
             HealthMod     = EmpireDataMod(empire.data.Traits.ModHpModifier);
         }
 

--- a/Ship_Game/Ships/ShipModule.cs
+++ b/Ship_Game/Ships/ShipModule.cs
@@ -303,7 +303,7 @@ namespace Ship_Game.Ships
         {
             // only amplify dedicated shields
             float actualAmplify = ModuleType == ShipModuleType.Shield ? shieldAmplify : 0;
-            ActualShieldPowerMax = ShieldPowerMax*Bonuses.ShieldMod + actualAmplify;
+            ActualShieldPowerMax = GlobalStats.Defaults.ShieldPowerMultiplier*ShieldPowerMax*Bonuses.ShieldMod + actualAmplify;
         }
 
         public bool IsAmplified => ActualShieldPowerMax-0.1f > ShieldPowerMax * Bonuses.ShieldMod;

--- a/Ship_Game/Ships/ShipModule.cs
+++ b/Ship_Game/Ships/ShipModule.cs
@@ -303,7 +303,7 @@ namespace Ship_Game.Ships
         {
             // only amplify dedicated shields
             float actualAmplify = ModuleType == ShipModuleType.Shield ? shieldAmplify : 0;
-            ActualShieldPowerMax = GlobalStats.Defaults.ShieldPowerMultiplier*ShieldPowerMax*Bonuses.ShieldMod + actualAmplify;
+            ActualShieldPowerMax = ShieldPowerMax*Bonuses.ShieldMod + actualAmplify;
         }
 
         public bool IsAmplified => ActualShieldPowerMax-0.1f > ShieldPowerMax * Bonuses.ShieldMod;

--- a/Ship_Game/Ships/Ship_Events.cs
+++ b/Ship_Game/Ships/Ship_Events.cs
@@ -110,6 +110,8 @@ namespace Ship_Game.Ships
 
             if (IsResearchStation)
             {
+                // must use the goal planet/system, since tether was removed when the ship died and no way to know
+                // if it was researching  a planet or a star
                 Goal researchGoal = Loyalty.AI.FindGoal(g => g is ProcessResearchStation && g.TargetShip == this);
                 if (researchGoal != null)
                 {

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
@@ -386,7 +386,7 @@ public partial class Planet
     }
 
     // path where full recalculation is done
-    void UpdatePlanetStatsByRecalculation()
+    public void UpdatePlanetStatsByRecalculation()
     {
         TotalBuildings = TilesList.Count(tile => tile.BuildingOnTile);
         Storage.Max = SumBuildings(bb => bb.StorageAdded).Clamped(10, 10000000);

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
@@ -75,7 +75,6 @@ namespace Ship_Game
         {
             GenerateNewFromPlanetType(random, type, scale, preDefinedPop);
             AddEventsAndCommodities();
-            UpdatePlanetStatsByRecalculation();
         }
 
         // FB - this is a more comprehensive method of choosing planet type.

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Resources.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Resources.cs
@@ -56,7 +56,7 @@ namespace Ship_Game
                 Food.AutoBalanceWorkers();
         }
 
-        public float PopulationBillion { get; private set; }
+        [StarData] public float PopulationBillion { get; private set; }
         public float PlusFlatPopulationPerTurn { get; private set; }
 
         public bool HasProduction    => Prod.GrossIncome > 1.0f;

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.cs
@@ -369,6 +369,7 @@ namespace Ship_Game
                 foreach (Planet planet in system.PlanetList)
                 {
                     planet.InitializePlanetMesh();
+                    planet.UpdatePlanetStatsByRecalculation();
                 }
             }
         }

--- a/game/Content/Globals.yaml
+++ b/game/Content/Globals.yaml
@@ -26,7 +26,7 @@ Globals:
   BonusRepairPerColonyLevel: 0.1 # +bonus based on colony level, 0.1 would be +10% increase per level
   InCombatRepairModifier: 0.5 # repair rate modifier when a ship or planet is in combat
   BonusColonyEMPRecovery: 5.0 # multiplier of EMP damage removed from shipyard repair when orbiting a colony
-  BaseSelfRepair: 1.0 # base repair rate from ship command/engineering modules per SECOND
+  SelfRepairMultiplier: 1.0 # base repair rate from ship command/engineering modules per SECOND
   BonusRepairPerCrewLevel: 0.2 # +bonus rate based on crew level, 0.2 would be +20% increase per each crew level
   InCombatSelfRepairModifier: 0.2 # repair rate modifier for command/engineering self repair when in combat
   ShieldPowerMultiplier: 1

--- a/game/Content/Globals.yaml
+++ b/game/Content/Globals.yaml
@@ -29,6 +29,7 @@ Globals:
   BaseSelfRepair: 1.0 # base repair rate from ship command/engineering modules per SECOND
   BonusRepairPerCrewLevel: 0.2 # +bonus rate based on crew level, 0.2 would be +20% increase per each crew level
   InCombatSelfRepairModifier: 0.2 # repair rate modifier for command/engineering self repair when in combat
+  ShieldPowerMultiplier: 1
 
   # feature flags
   DisableShipPicker: true


### PR DESCRIPTION
- Fix - zero free tiles after load
- Fix - display issue in deep space build
- Fix - scrapping research station not unsetting empire in explorable
- Fix - deep space build always picks the designated ship in AI window.
- Fix -  maxpopulation is 0 after loading a game when BombingIntesitiy is high.
- Feature - Add global shield power multiplier
- Refactor - change name of selfrepair global 
