### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/Building.cs
+++ b/Ship_Game/Building.cs
@@ -445,7 +445,7 @@ namespace Ship_Game
         {
             int level = (p?.Owner != null ? p.Level : 0);
             float baseRepairRate = ShipRepair * GlobalStats.Defaults.BaseShipyardRepair;
-            float levelBonus = 1f + level * GlobalStats.Defaults.BonusRepairPerColonyLevel;
+            float levelBonus = level * GlobalStats.Defaults.BonusRepairPerColonyLevel;
             return baseRepairRate * levelBonus;
         }
 

--- a/Ship_Game/Commands/Goals/BuildOrbital.cs
+++ b/Ship_Game/Commands/Goals/BuildOrbital.cs
@@ -55,8 +55,9 @@ namespace Ship_Game.Commands.Goals  // Created by Fat Bastard
         {
             PlanetBuildingAt = planetBuildingAt;
             IShipDesign constructor = BuildableShip.GetConstructor(Owner);
-            PlanetBuildingAt.Construction.Enqueue(QueueItemType.Orbital, ToBuild, constructor, rush: false, this);
 
+            PlanetBuildingAt.Construction.Enqueue(ToBuild.IsResearchStation ? QueueItemType.OrbitalUrgent : QueueItemType.Orbital,
+                ToBuild, constructor, rush: false, this);
         }
 
         GoalStep OrderDeployOrbital()

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -2095,6 +2095,8 @@ namespace Ship_Game
             {
                 foreach (Troop troop in planet.Troops.GetTroopsOf(target))
                     troop.ChangeLoyalty(this);
+
+                planet.Troops.UpdateFactionTroopsPresentHere(this);
             }
 
             target.ClearAllPlanets();

--- a/Ship_Game/GameScreens/ColonyScreen/QueueItem.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/QueueItem.cs
@@ -131,7 +131,7 @@ namespace Ship_Game
         }
 
         // This also increases the priority bonus of the item. So it will be bumped up in the list a little next time
-        public float GetAndUpdatePriority(Planet planet,int totalFreighters)
+        public float GetAndUpdatePriorityForAI(Planet planet,int totalFreighters)
         {
             float priority = 5000;
             Empire owner = planet.Owner;
@@ -155,7 +155,7 @@ namespace Ship_Game
                     break;
             }
 
-            if (!owner.isPlayer && owner.IsAtWarWithMajorEmpire)
+            if (owner.IsAtWarWithMajorEmpire)
             {
                 switch (QType)
                 {

--- a/Ship_Game/Troops/Troop.cs
+++ b/Ship_Game/Troops/Troop.cs
@@ -128,6 +128,8 @@ namespace Ship_Game
         public void ChangeLoyalty(Empire newOwner)
         {
             Loyalty = newOwner;
+            if (HostPlanet != null)
+                HostPlanet.Troops.UpdateFactionTroopsPresentHere(Loyalty);
         }
 
         public void DoAttack()

--- a/Ship_Game/Universe/SolarBodies/ColonyStorage.cs
+++ b/Ship_Game/Universe/SolarBodies/ColonyStorage.cs
@@ -51,6 +51,10 @@ namespace Ship_Game.Universe.SolarBodies
         public float ProdRatio => ProdValue / Max;
         public float PopRatio  => Ground.MaxPopulation.AlmostZero() ? 0 : PopValue  / Ground.MaxPopulation;
 
+        public float FoodRatioWithIncoming => (FoodValue + Ground.IncomingFood) / Max;
+
+        public float ProdRatioWithIncoming => (ProdValue + Ground.IncomingProd) / Max;
+
         public float MostGoodsInStorage => Ground.IsCybernetic ? RaceFood : Math.Max(FoodValue, ProdValue);
 
         public void AddCommodity(string goodId, float amount)

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_WorkDistribution.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_WorkDistribution.cs
@@ -44,7 +44,7 @@ namespace Ship_Game
             float farmers = Food.EstPercentForNetIncome(wantedIncome);
 
             // modify nominal farmers by overage or underage
-            farmers += CalculateMod(percent, Storage.FoodRatio).UpperBound(0.5f);
+            farmers += CalculateMod(percent, Storage.FoodRatioWithIncoming).UpperBound(0.5f);
             return farmers.Clamped(0f, 0.9f);
         }
 
@@ -55,7 +55,7 @@ namespace Ship_Game
 
             float workers = Prod.EstPercentForNetIncome(wantedIncome);
 
-            workers += CalculateMod(percent, Storage.ProdRatio).Clamped(-0.35f, 0.5f);
+            workers += CalculateMod(percent, Storage.ProdRatioWithIncoming).Clamped(-0.35f, 0.5f);
             return workers.Clamped(0f, 1f);
         }
 

--- a/Ship_Game/Universe/SolarBodies/PlanetInfoUIElement.cs
+++ b/Ship_Game/Universe/SolarBodies/PlanetInfoUIElement.cs
@@ -456,17 +456,19 @@ namespace Ship_Game
                 {
                     GameAudio.EchoAffirmative();
                     troopShip.AI.OrderLandAllTroops(P, clearOrders:true);
+                    if (Player.Universe.Paused) 
+                        Player.Universe.Objects.UpdateLists();
                 }
                 else
                     GameAudio.BlipClick();
             }
-            if (ResearchStationRect.HitTest(input.CursorPosition) && input.InGameSelect)
+            if (P.IsResearchable && ResearchStationRect.HitTest(input.CursorPosition) && input.InGameSelect)
             {
                 if      (Player.AI.HasGoal(g => g.IsResearchStationGoal(P))) Player.AI.CancelResearchStation(P);
                 else if (Player.CanBuildResearchStations)                    Player.AI.AddGoalAndEvaluate(new ProcessResearchStation(Player, P));
                 else                                                         GameAudio.NegativeClick();
 
-            GameAudio.EchoAffirmative();
+                GameAudio.EchoAffirmative();
             }
 
             if (P.Owner != null && P.Owner != Player 

--- a/Ship_Game/Universe/SolarBodies/PlanetListScreenItem.cs
+++ b/Ship_Game/Universe/SolarBodies/PlanetListScreenItem.cs
@@ -319,7 +319,7 @@ namespace Ship_Game
         bool TryGetIncomingTroops(out int incomingTroops, out Array<Ship> incomingTroopShips)
         {
             incomingTroopShips = new Array<Ship>();
-            incomingTroops      = 0;
+            incomingTroops     = 0;
             var ships = Player.OwnedShips;
             for (int i = 0; i < ships.Count; i++)
             {
@@ -361,13 +361,14 @@ namespace Ship_Game
                 GameAudio.EchoAffirmative();
                 troopShip.AI.OrderLandAllTroops(Planet, clearOrders:true);
                 Screen.RefreshSendTroopButtonsVisibility();
+                Player.Universe.Objects.UpdateLists();
                 UpdateButtonSendTroops();
             }
             else
                 GameAudio.NegativeClick();
         }
 
-        void OnSendTroopsRightClick()
+        void OnSendTroopsRightClick() // cancel one incoming troop
         {
             if (!TryGetIncomingTroops(out _, out Array<Ship> incomingTroopShips))
                 return;

--- a/Ship_Game/Universe/SolarBodies/SBProduction.cs
+++ b/Ship_Game/Universe/SolarBodies/SBProduction.cs
@@ -412,9 +412,11 @@ namespace Ship_Game.Universe.SolarBodies
             lock (ConstructionQueue)
             {
                 ConstructionQueue.Add(item);
-                int totalFreighters = Owner.TotalFreighters;
-                if (P.CType != Planet.ColonyType.Colony)
-                    ConstructionQueue.Sort(q => q.GetAndUpdatePriority(P,totalFreighters));
+                if (!P.OwnerIsPlayer)
+                {
+                    int totalFreighters = Owner.TotalFreighters;
+                    ConstructionQueue.Sort(q => q.GetAndUpdatePriorityForAI(P, totalFreighters));
+                }
             }
         }
 

--- a/Ship_Game/Universe/SolarBodies/TroopManager.cs
+++ b/Ship_Game/Universe/SolarBodies/TroopManager.cs
@@ -85,12 +85,17 @@ namespace Ship_Game
                     if (tile == null || !tile.TroopsHere.Remove(troop))
                         Ground.SearchAndRemoveTroopFromAllTiles(troop);
 
-                    bool anyLeftHere = WeHaveTroopsHereUncached(troop.Loyalty);
-                    FactionTroopsPresentHere.SetValue(troop.Loyalty.Id, anyLeftHere);
+                    UpdateFactionTroopsPresentHere(troop.Loyalty);
                     return true;
                 }
                 return false;
             }
+        }
+
+        public void UpdateFactionTroopsPresentHere(Empire empire)
+        {
+            bool anyLeftHere = WeHaveTroopsHereUncached(empire);
+            FactionTroopsPresentHere.SetValue(empire.Id, anyLeftHere);
         }
 
         #endregion

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.HandleInput.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.HandleInput.cs
@@ -688,11 +688,6 @@ namespace Ship_Game
 
         bool HandleSelectionBox(InputState input)
         {
-            if (SelectedShipList.Count == 1)
-            {
-                SetSelectedShip(SelectedShipList[0]);
-            }
-
             if (input.LeftMouseHeld(0.1f)) // we started dragging selection box
             {
                 SelectionBox = input.LeftHold.GetSelectionBox();

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.SetSelectedItem.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.SetSelectedItem.cs
@@ -56,7 +56,7 @@ public partial class UniverseScreen
     public void UpdateSelectedShips()
     {
         SelectedShipList.RemoveInActiveObjects();
-        if (SelectedShipList.Count >= 1)
+        if (SelectedShipList.Count > 0)
             SetSelectedShipList(SelectedShipList, SelectedFleet);
         else if (SelectedShip != null)
             SetSelectedShip(SelectedShip, SelectedFleet);
@@ -107,18 +107,11 @@ public partial class UniverseScreen
 
     public void SetSelectedShipList(IReadOnlyList<Ship> ships, Fleet fleet)
     {
-        if (ships.Count == 1)
-        {
-            SetSelectedShip(ships[0], fleet: fleet);
-        }
-        else
-        {
-            ClearSelectedItems(clearShipList: false, fleet: fleet);
-            // if SetSelectedShipList(SelectedShipList) then this is a no-op
-            // but otherwise always clone the ship list
-            SelectedShipList = ReferenceEquals(ships, SelectedShipList) ? SelectedShipList : new(ships);
-            shipListInfoUI.SetShipList(SelectedShipList, fleet != null);
-        }
+        ClearSelectedItems(clearShipList: false, fleet: fleet);
+        // if SetSelectedShipList(SelectedShipList) then this is a no-op
+        // but otherwise always clone the ship list
+        SelectedShipList = ReferenceEquals(ships, SelectedShipList) ? SelectedShipList : new(ships);
+        shipListInfoUI.SetShipList(SelectedShipList, fleet != null);
     }
 
     public void SetSelectedFleet(Fleet fleet, Array<Ship> selectedShips = null)
@@ -126,11 +119,7 @@ public partial class UniverseScreen
         SelectedSomethingTimer = 3f;
         Array<Ship> ships = selectedShips ?? fleet.Ships;
 
-        if (ships.Count == 1)
-        {
-            SetSelectedShip(ships.First, fleet: fleet);
-        }
-        else if (ships.Count > 1)
+        if (ships.Count > 0)
         {
             SetSelectedShipList(ships, fleet: fleet);
         }

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -11571,9 +11571,7 @@ AutoResearch:
  SPA: "Investigación automática"
 ShipRepair:
  Id: 6137
- ENG: "Ship Repair"
- RUS: "ремонт кораблей"
- SPA: "Reparación de naves"
+ ENG: "Ship Repair Per Second"
 AutoTaxes:
  Id: 6138
  ENG: "Auto Taxes"


### PR DESCRIPTION
Fix: FactionTroopsPresentHere not changed when empire is absorbed.
Fix: Do not prioritize queue items for human players.
Fix: allow fleet selection of 1 ship, as well as double click to snap
Fix: Send troops button does not update if game is paused (in planets array and planet info ui)
Fix: calc errors in building actual ship repair which cause diffs in total planet repair and the sum of all buildings repair
Fix: consider incoming food and prod when determining workers percentage needed.
Balance - mark research station as urent orbital for AI empires.
@gkapulis 