### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/AI/EmpireAI/EmpireAI.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.cs
@@ -309,7 +309,8 @@ namespace Ship_Game.AI
                 if (ship.AI.BadGuysNear
                     || ship.AI.HasPriorityOrder
                     || ship.AI.HasPriorityTarget
-                    || !ship.CanBeRefitted)
+                    || !ship.CanBeRefitted
+                    || ship.IsResearchStation)
                 {
                     continue;
                 }

--- a/Ship_Game/AI/ExpansionAI/ResearchStationPlanner.cs
+++ b/Ship_Game/AI/ExpansionAI/ResearchStationPlanner.cs
@@ -89,7 +89,8 @@ namespace Ship_Game.AI.ExpansionAI
             {
                 if (solarBody.IsExploredBy(Owner)
                     && !solarBody.IsResearchStationDeployedBy(Owner) // this bit is for performance - faster than HasGoal
-                    && !Owner.AI.HasGoal(g => g.IsResearchStationGoal(solarBody)))
+                    && !Owner.AI.HasGoal(g => g.IsResearchStationGoal(solarBody))
+                    && !Owner.Universe.Remnants.AI.HasGoal(g => g is RemnantPortal && g.TargetShip.System == solarBody))
                 {
                     solarBodies.Add(solarBody);
                 }

--- a/Ship_Game/AI/ExpansionAI/ResearchStationPlanner.cs
+++ b/Ship_Game/AI/ExpansionAI/ResearchStationPlanner.cs
@@ -45,14 +45,18 @@ namespace Ship_Game.AI.ExpansionAI
                 return; // Leave killing research stations to war logic
 
             SolarSystem system = solarBody.System ?? solarBody as SolarSystem;
+            Planet planet = solarBody as Planet;
+            if (planet != null && !planet.System.InSafeDistanceFromRadiation(planet.Position))
+                return;
+
             if (Owner.KnownEnemyStrengthIn(system) > 0)
             {
                 TryClearArea(system, influense);
             }
             else
             {
-                if (solarBody is Planet)
-                    Owner.AI.AddGoalAndEvaluate(new ProcessResearchStation(Owner, solarBody as Planet));
+                if (planet != null)
+                    Owner.AI.AddGoalAndEvaluate(new ProcessResearchStation(Owner, planet));
                 else
                     Owner.AI.AddGoalAndEvaluate(new ProcessResearchStation(Owner, system, system.SelectStarResearchStationPos()));
             }
@@ -90,7 +94,8 @@ namespace Ship_Game.AI.ExpansionAI
                 if (solarBody.IsExploredBy(Owner)
                     && !solarBody.IsResearchStationDeployedBy(Owner) // this bit is for performance - faster than HasGoal
                     && !Owner.AI.HasGoal(g => g.IsResearchStationGoal(solarBody))
-                    && !Owner.Universe.Remnants.AI.HasGoal(g => g is RemnantPortal && g.TargetShip.System == solarBody))
+                    && (Owner.Universe.Remnants == null 
+                        || !Owner.Universe.Remnants.AI.HasGoal(g => g is RemnantPortal && g.TargetShip.System == solarBody)))
                 {
                     solarBodies.Add(solarBody);
                 }

--- a/Ship_Game/AI/ThreatMatrix_Update.cs
+++ b/Ship_Game/AI/ThreatMatrix_Update.cs
@@ -48,7 +48,7 @@ public sealed partial class ThreatMatrix
     /// <summary>
     /// Time to Live in seconds for unobserved In-System clusters
     /// </summary>
-    public const float TimeToLiveInSystem = 10 * 60;
+    public const float TimeToLiveInSystem = 20 * 60;
 
     /// <summary>
     /// Time to Live in seconds for unobserved Deep Space clusters

--- a/Ship_Game/Commands/Goals/ProcessResearchStation.cs
+++ b/Ship_Game/Commands/Goals/ProcessResearchStation.cs
@@ -67,6 +67,7 @@ namespace Ship_Game.Commands.Goals
             : this(owner)
         {
             StarDateAdded = owner.Universe.StarDate;
+            TargetShip = researchStation;
             Planet planet = researchStation.GetTether();
             if (planet != null)
                 TargetPlanet = planet;
@@ -128,8 +129,12 @@ namespace Ship_Game.Commands.Goals
             return GoalStep.GoalFailed; // construction goal was canceled
         }
 
+        // Factions do not research and pirate owners will set scuttle (see PiratePostChangeLoyalty)
         GoalStep Research()
         {
+            if (Owner.IsFaction) 
+                return GoalStep.TryAgain;
+
             if (ResearchStation == null || !ResearchStation.Active)
                 return GoalStep.GoalFailed;
 

--- a/Ship_Game/Commands/Goals/SupplyGoodsToStation.cs
+++ b/Ship_Game/Commands/Goals/SupplyGoodsToStation.cs
@@ -48,7 +48,7 @@ namespace Ship_Game.Commands.Goals
             {
                 Planet exportPlanet = exportAndFreighter.Planet;
                 FinishedShip = exportAndFreighter.Freighter;
-                FinishedShip.AI.SetupFreighterPlan(exportPlanet, TargetStation, Goods);
+                exportAndFreighter.Freighter.AI.SetupFreighterPlan(exportPlanet, TargetStation, Goods);
                 return GoalStep.GoToNextStep;
             }
 

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -335,8 +335,8 @@ namespace Ship_Game.Ships
         {
             if (Loyalty.WeArePirates)
             {
-                if (IsSubspaceProjector)
-                    ScuttleTimer = 10;
+                if (IsSubspaceProjector || IsResearchStation)
+                    ScuttleTimer = 20;
                 else
                     AI.OrderPirateFleeHome();
             }

--- a/Ship_Game/Ships/Ship_Events.cs
+++ b/Ship_Game/Ships/Ship_Events.cs
@@ -106,7 +106,10 @@ namespace Ship_Game.Ships
                 Loyalty.AI.SpaceRoadsManager.RemoveProjectorFromRoadList(this);
 
             if (Loyalty.CanBuildPlatforms)
-                Loyalty.AI.SpaceRoadsManager.SetupProjectorBridgeIfNeeded(this);
+            {
+                Loyalty.AI.SpaceRoadsManager.SetupProjectorBridgeIfNeeded(this,
+                    pSource != null ? ProjectorBridgeEndCondition.NoHostiles : ProjectorBridgeEndCondition.Timer);
+            }
 
             if (IsResearchStation)
             {
@@ -130,7 +133,6 @@ namespace Ship_Game.Ships
 
             DamageRelationsOnDeath(pSource);
             CreateEventOnDeath();
-
         }
     }
 }

--- a/Ship_Game/Universe/SolarBodies/ColonyResource.cs
+++ b/Ship_Game/Universe/SolarBodies/ColonyResource.cs
@@ -196,7 +196,7 @@ namespace Ship_Game.Universe.SolarBodies
             YieldPerColonist = ProdYieldFormula(richness, plusPerColonist);
 
             // Cybernetics consume production and will starve at 100% tax, so ease up on them
-            Tax = Planet.NonCybernetic ? Planet.Owner.data.TaxRate : Planet.Owner.data.TaxRate  * 0.5f;
+            Tax = Planet.NonCybernetic || Planet.OwnerIsPlayer ? Planet.Owner.data.TaxRate : Planet.Owner.data.TaxRate  * 0.5f;
         }
 
         protected override float AvgResourceConsumption()

--- a/Ship_Game/Universe/SolarSystem.cs
+++ b/Ship_Game/Universe/SolarSystem.cs
@@ -256,15 +256,15 @@ namespace Ship_Game
 
         public bool InSafeDistanceFromRadiation(Vector2 center)
         {
-            return Sun.RadiationDamage.AlmostZero() || center.Distance(Position) > Sun.RadiationRadius + 10000;
+            return Sun.RadiationDamage.AlmostZero() || center.Distance(Position) > Sun.RadiationRadius+ 2000;
         }
 
         public bool InSafeDistanceFromRadiation(float distance)
         {
-            return Sun.RadiationDamage.AlmostZero() || distance > Sun.RadiationRadius + 10000;
+            return Sun.RadiationDamage.AlmostZero() || distance > Sun.RadiationRadius + 2000;
         }
 
-        public float SunDangerRadius => Sun.RadiationDamage.AlmostZero() ? 0 : Sun.RadiationRadius + 10000; 
+        public float SunDangerRadius => Sun.RadiationDamage.AlmostZero() ? 0 : Sun.RadiationRadius + 2000; 
 
         // overload for ship info UI or AI maybe
         public bool ShipWithinRadiationRadius(Ship ship)

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -1298,7 +1298,7 @@ ShipWillAttemptToHold:
  SPA: "La nave intentará mantener la posición y no se moverá para enfrentarse a los enemigos"
 TaxesAreCollectedFromYour:
  Id: 264
- ENG: "Taxes are collected from your planets as a portion of their populations income. The negative side of taxes is that they reduce moral and productivity. For instance, a tax rate of 25% means that research and industrial output will be reduced by 25% across all planets. Production output reduction for Cybernetics is 50% of the tax rate."
+ ENG: "Taxes are collected from your planets as a portion of their populations income. The negative side of taxes is that they reduce moral and productivity. For instance, a tax rate of 25% means that research and industrial output will be reduced by 25% across all planets."
  RUS: "Налоги с планет собираются в виде доли ее промышленного и исследовательского потенциала. Например, налог в 25% означает, что промышленное производство и исследования на всех планетах сократятся на 25%. За счет налогов ваша империя будет получать эти потерянные ресурсы в виде кредитов."
  SPA: "Los impuestos se recaudan en los planetas como una parte de su rendimiento de producción e investigación. Por ejemplo, un tipo impositivo del 25% reducirá la capacidad industrial e investigadora en ese mismo 25% en todos los planetas. Tu imperio transformará en créditos la producción e investigación perdidas."
 LaunchThisTroopIntoOrbit:


### PR DESCRIPTION
- Fix: Crash in ResearchStation Supply. 
- Fix: Do not try to place reserach stations in systems with remnant portal
- Fix: Do not try to refit research stations in TriggerRefit
- Fix: Bugs in research station capture.
- Fix: Do not deploy research station on  planets within radiation radius of stars.
- Fix: Remove/Add research station list when station is captured.
- Balance: Decrease safe distance from radiation damage from 10k to 2k.
- Balance: double system threat matrix timer
- Feature: Projector bridge now has ability to be constructed to cover construction ships and research station supply freighters With TTL of 200 turns. 

@gkapulis 