### PR TITLE
Feature - Renable enemy symbols based on projector radius for players

### DIFF
--- a/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
@@ -177,9 +177,6 @@ namespace Ship_Game.AI
                 // enemy is known by our Empire - this information is used by our Empire later
                 // the enemy itself does not care about it
                 us.AI.ThreatMatrix.SetSeen(enemy, fromBackgroundThread:true);
-                // and our ship has seen other empire
-                sensorShip.HasSeenEmpires.SetSeen(other);
-
                 if (!us.IsKnown(other))
                 {
                     us.FirstContact.SetReadyForContact(other);

--- a/Ship_Game/AI/ShipAI/ShipAI.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.cs
@@ -877,7 +877,7 @@ namespace Ship_Game.AI
                 if (!enemy.Active || enemy.Dying || enemy.BaseStrength == 0)
                     continue;
 
-                projector.HasSeenEmpires.SetSeen(enemy.Loyalty, time);
+                projector.PlayerProjectorHasSeenEmpires.SetSeen(enemy.Loyalty, time);
             }
         }
 

--- a/Ship_Game/AI/ShipAI/ShipAI.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.cs
@@ -10,6 +10,7 @@ using SDUtils;
 using Ship_Game.Data.Serialization;
 using Ship_Game.Fleets;
 using Vector2 = SDGraphics.Vector2;
+using Ship_Game.Spatial;
 #pragma warning disable CA2213
 
 namespace Ship_Game.AI
@@ -853,6 +854,30 @@ namespace Ship_Game.AI
             {
                 Owner.AI.SetPriorityOrder(true);
                 Orbit.Orbit(escortTarget, timeStep);
+            }
+        }
+
+
+        // This is done for player projectors to visualize empires in projection radius
+        public void ProjectorScan(float sensorRadius, float time)
+        {
+            Ship projector = Owner;
+            Empire us = projector.Loyalty;
+            var findEnemies = new SearchOptions(projector.Position, sensorRadius, GameObjectType.Ship)
+            {
+                MaxResults = 32,
+                Exclude = projector,
+                ExcludeLoyalty = us,
+            };
+
+            SpatialObjectBase[] enemies = projector.Universe.Spatial.FindNearby(ref findEnemies);
+            for (int i = 0; i < enemies.Length; ++i)
+            {
+                var enemy = (Ship)enemies[i];
+                if (!enemy.Active || enemy.Dying || enemy.BaseStrength == 0)
+                    continue;
+
+                projector.HasSeenEmpires.SetSeen(enemy.Loyalty, time);
             }
         }
 

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -1724,13 +1724,23 @@ namespace Ship_Game
                     }
                 }
 
-                foreach (Planet planet in OwnedPlanets)
+                for (int i = 0; i < OwnedPlanets.Count; i++)
                 {
+                    Planet planet = OwnedPlanets[i];
                     if (planet.HasWinBuilding)
                     {
                         Universe.Screen.OnPlayerWon(GameText.AsTheRemnantExterminatorsSweep);
                         return;
                     }
+                }
+
+                var playerProjectors = OwnedProjectors;
+                float scanRadius = GetProjectorRadius();
+                float timer = Universe.P.TurnTimer;
+                for (int i = 0; i < playerProjectors.Count; i++)
+                {
+                    Ship projector = playerProjectors[i];
+                    projector.AI.ProjectorScan(scanRadius, timer);
                 }
             }
 

--- a/Ship_Game/Ships/Components/KnownByEmpire.cs
+++ b/Ship_Game/Ships/Components/KnownByEmpire.cs
@@ -59,10 +59,10 @@ namespace Ship_Game.Ships.Components
         /// Sets if the ship has been seen by an empire;
         /// </summary>
         /// <param name="empire">The empire.</param>
-        public void SetSeen(Empire empire)
+        public void SetSeen(Empire empire, float timer = EmpireConstants.KnownContactTimer)
         {
             float[] seenById = GetSeenByID(empire.Universe);
-            seenById[empire.Id-1] = EmpireConstants.KnownContactTimer;
+            seenById[empire.Id-1] = timer;
         }
 
         /// <summary>

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -117,7 +117,7 @@ namespace Ship_Game.Ships
         public float BonusEMPProtection;
         public bool InPlayerSensorRange => KnownByEmpires.KnownByPlayer(Universe);
         public KnownByEmpire KnownByEmpires;
-        public KnownByEmpire HasSeenEmpires;
+        public KnownByEmpire PlayerProjectorHasSeenEmpires;
         public bool EMPDisabled;
         public float TractorDamage { get; private set; }
         private bool BeingTractored;
@@ -1157,8 +1157,8 @@ namespace Ship_Game.Ships
 
             // update our knowledge of the surrounding universe
             KnownByEmpires.Update(timeStep, Loyalty);
-            if (IsSubspaceProjector)
-                HasSeenEmpires.Update(timeStep, Loyalty);
+            if (Loyalty.isPlayer && IsSubspaceProjector)
+                PlayerProjectorHasSeenEmpires.Update(timeStep, Loyalty);
 
             // scan universe and make decisions for combat
             AI.ScanForTargets(timeStep);
@@ -1684,7 +1684,7 @@ namespace Ship_Game.Ships
             Mothership = null;
             JumpSfx?.Destroy();
             KnownByEmpires = null;
-            HasSeenEmpires = null;
+            PlayerProjectorHasSeenEmpires = null;
             PlanetCrash = null;
             HomePlanet = null;
             RemoveSceneObject();

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -1157,7 +1157,8 @@ namespace Ship_Game.Ships
 
             // update our knowledge of the surrounding universe
             KnownByEmpires.Update(timeStep, Loyalty);
-            HasSeenEmpires.Update(timeStep, Loyalty);
+            if (IsSubspaceProjector)
+                HasSeenEmpires.Update(timeStep, Loyalty);
 
             // scan universe and make decisions for combat
             AI.ScanForTargets(timeStep);

--- a/Ship_Game/Ships/Ship_Initialize.cs
+++ b/Ship_Game/Ships/Ship_Initialize.cs
@@ -91,7 +91,7 @@ namespace Ship_Game.Ships
         {
             Stats = new(this);
             KnownByEmpires = new(us);
-            HasSeenEmpires = new(us);
+            PlayerProjectorHasSeenEmpires = new(us);
         }
 
         protected static Ship GetShipTemplate(string shipName)

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Render.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Render.cs
@@ -157,7 +157,7 @@ namespace Ship_Game
                 for (int j = 0; j < enemies.Count; j++)
                 {
                     var enemy = enemies[j];
-                    if (projector.HasSeenEmpires.KnownBy(enemy))
+                    if (projector.PlayerProjectorHasSeenEmpires.KnownBy(enemy))
                     {
                         var screenPos = ProjectToScreenPosition(projector.Position);
                         var flag = enemy.data.Traits.FlagIndex;


### PR DESCRIPTION
This is done by letting player projectors scan for enemies on their projector radius once per turn and use HasSeenEmpire as intended for this feature. 
`HasSeenEmpires `only updates for player projectors. And it is only used in UI to display empire symbols when the projectors sense them.