### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/AI/EmpireAI/EmpireAI.RunMilitaryPlanner.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.RunMilitaryPlanner.cs
@@ -213,22 +213,6 @@ namespace Ship_Game.AI
             return militaryTask != null;
         }
 
-        public bool GetDefendClaimTaskFor(Planet planet, out MilitaryTask militaryTask)
-        {
-            militaryTask = null;
-            var filteredTasks = TaskList.Filter(task => task.Type == MilitaryTask.TaskType.DefendClaim
-                                                     && task.TargetPlanet == planet);
-
-            if (filteredTasks.Length > 0f)
-            {
-                militaryTask = filteredTasks.First();
-                if (filteredTasks.Length > 1)
-                    Log.Warning($"{OwnerEmpire.Name} Defend Claim Tasks: Found more than one task for {planet.Name}. Using the first one.");
-            }
-
-            return militaryTask != null;
-        }
-
         public void SendExplorationFleet(Planet p)
         {
             if (!TaskList.Any(t => t.Type == MilitaryTask.TaskType.Exploration && t.TargetPlanet == p))

--- a/Ship_Game/Commands/Goals/FleetGoal.cs
+++ b/Ship_Game/Commands/Goals/FleetGoal.cs
@@ -1,6 +1,7 @@
 ﻿using Ship_Game.Data.Serialization;
 using Ship_Game.AI;
 using Ship_Game.Fleets;
+using Ship_Game.AI.Tasks;
 
 namespace Ship_Game.Commands.Goals
 {
@@ -9,6 +10,7 @@ namespace Ship_Game.Commands.Goals
     public abstract class FleetGoal : Goal
     {
         [StarData] public Fleet Fleet;
+        [StarData] public MilitaryTask Task;
 
         protected FleetGoal(GoalType type, Empire owner) : base(type, owner)
         {

--- a/Ship_Game/Commands/Goals/RemnantEngageEmpire.cs
+++ b/Ship_Game/Commands/Goals/RemnantEngageEmpire.cs
@@ -67,17 +67,6 @@ namespace Ship_Game.Commands.Goals
             return TargetPlanet != null;
         }
 
-        void ChangeTaskTargetPlanet()
-        {
-            var tasks = Owner.AI.GetTasks().Filter(t => t.Fleet == Fleet);
-            switch (tasks.Length)
-            {
-                case 0:                                                                                  return;
-                case 1:  tasks[0].ChangeTargetPlanet(TargetPlanet);                                      break;
-                default: Log.Warning($"Found multiple Remnant tasks with the same fleet: {Fleet.Name}"); break;
-            }
-        }
-
         float RequiredFleetStr()
         {
             float strDiv = TargetEmpire.TotalPopBillion / (TargetEmpire.isPlayer ? 150 : 60);
@@ -127,9 +116,9 @@ namespace Ship_Game.Commands.Goals
                 Ship ship = ships[i];
                 if (i == 0)
                 {
-                    var task = MilitaryTask.CreateRemnantEngagement(TargetPlanet, Owner);
-                    Owner.AI.AddPendingTask(task);
-                    task.CreateRemnantFleet(Owner, ship, $"Ancient Fleet - {TargetPlanet.Name}", out Fleet);
+                    Task = MilitaryTask.CreateRemnantEngagement(TargetPlanet, Owner);
+                    Owner.AI.AddPendingTask(Task);
+                    Task.CreateRemnantFleet(Owner, ship, $"Ancient Fleet - {TargetPlanet.Name}", out Fleet);
                     continue;
                 }
 
@@ -254,13 +243,12 @@ namespace Ship_Game.Commands.Goals
             if (!Remnants.TargetNextPlanet(TargetEmpire, TargetPlanet, Remnants.NumBombersInFleet(Fleet), out Planet nextPlanet))
                 return ReturnToPortal();
 
-            Fleet.FleetTask.ChangeTargetPlanet(nextPlanet);
             Fleet.ClearOrders();
             int changeToStep = TargetPlanet.System == nextPlanet.System ? 5 : 1;
             TargetPlanet     = nextPlanet;
             Fleet.Name       = $"Ancient Fleet - {TargetPlanet.Name}";
             Fleet.TaskStep   = changeToStep;
-            ChangeTaskTargetPlanet();
+            Task.ChangeTargetPlanet(TargetPlanet);
             return GoalStep.TryAgain;
         }
     }

--- a/Ship_Game/Debug/Page/EmpireInfoDebug.cs
+++ b/Ship_Game/Debug/Page/EmpireInfoDebug.cs
@@ -102,7 +102,7 @@ public class EmpireInfoDebug : DebugPage
         Text.String("Gross Food: "+ e.GetGrossFoodPerTurn().String());
         Text.String("Military Str: "+ (int)e.CurrentMilitaryStrength);
         Text.String("Offensive Str: " + (int)e.OffensiveStrength);
-        Text.String($"Fleets: Str: {(int)e.ShipsReadyForFleet.AccumulatedStrength} Avail: {e.ShipsReadyForFleet.InitialUsableFleets}");
+        Text.String($"Fleets: Str: {(int)e.ShipsReadyForFleet?.AccumulatedStrength} Avail: {e.ShipsReadyForFleet.InitialUsableFleets}");
         
         for (int x = 0; x < e.AI.Goals.Count; x++)
         {

--- a/Ship_Game/Debug/Page/PerfDebug.cs
+++ b/Ship_Game/Debug/Page/PerfDebug.cs
@@ -38,6 +38,7 @@ public class PerfDebug : DebugPage
         turn.AddSubItem(new DebugStatItem(" ResetBorders", s.ResetBordersPerf, s.EmpireInfluPerf));
         turn.AddSubItem(new DebugStatItem(" PlanetScans", s.ScanFromPlanetsPerf, s.EmpireInfluPerf));
         turn.AddSubItem(new DebugStatItem(" ThreatMatrix", s.ThreatMatrixPerf, s.EmpireInfluPerf));
+        turn.AddSubItem(new DebugStatItem(" PlayerSSPScan", s.PlayerProjectorScanPerf, s.EmpireInfluPerf));
         turn.AddSubItem(new DebugStatItem("Objects", o.TotalTime, s.TurnTimePerf));
         turn.AddSubItem(new DebugStatItem("Misc", s.EmpireMiscPerf, s.TurnTimePerf));
         turn.AddSubItem(new DebugStatItem("PostEmp", s.PostEmpirePerf, s.TurnTimePerf));

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -1733,15 +1733,6 @@ namespace Ship_Game
                         return;
                     }
                 }
-
-                var playerProjectors = OwnedProjectors;
-                float scanRadius = GetProjectorRadius();
-                float timer = Universe.P.TurnTimer;
-                for (int i = 0; i < playerProjectors.Count; i++)
-                {
-                    Ship projector = playerProjectors[i];
-                    projector.AI.ProjectorScan(scanRadius, timer);
-                }
             }
 
             if (!data.IsRebelFaction)

--- a/Ship_Game/Empire_Borders.cs
+++ b/Ship_Game/Empire_Borders.cs
@@ -28,6 +28,7 @@ public sealed partial class Empire
     }
 
     float ThreatMatrixUpdateTimer;
+    float PlayerProjectorScanTimer;
 
     /// <summary>
     /// How often the ThreatMatrix is updated.
@@ -35,6 +36,8 @@ public sealed partial class Empire
     /// Somewhere around 0.5 - 1.0 seconds should be good enough
     /// </summary>
     const float ResetThreatMatrixSeconds = 1.0f;
+
+    const float ResetPlayerProjectorScanSeconds = 5.0f;
         
     public EmpireFirstContact FirstContact = new();
 
@@ -93,6 +96,31 @@ public sealed partial class Empire
             us.ThreatMatrixPerf.Start();
             AI.ThreatMatrix.Update(new(time:ResetThreatMatrixSeconds));
             us.ThreatMatrixPerf.Stop();
+        }
+
+        if (isPlayer)
+        {
+            PlayerProjectorScanTimer -= timeStep.FixedTime;
+            if (PlayerProjectorScanTimer <= 0)
+            {
+                PlayerProjectorScanTimer = ResetPlayerProjectorScanSeconds;
+
+                us.PlayerProjectorScanPerf.Start();
+                UpdatePlayerProjectorScan();
+                us.PlayerProjectorScanPerf.Stop();
+            }
+        }
+    }
+
+    // For Player Projectors to display enemy empire flags if found in projection radius
+    void UpdatePlayerProjectorScan()
+    {
+        var playerProjectors = OwnedProjectors;
+        float scanRadius = GetProjectorRadius();
+        for (int i = 0; i < playerProjectors.Count; i++)
+        {
+            Ship projector = playerProjectors[i];
+            projector.AI.ProjectorScan(scanRadius, ResetPlayerProjectorScanSeconds);
         }
     }
 

--- a/Ship_Game/Empire_RallyPlanets.cs
+++ b/Ship_Game/Empire_RallyPlanets.cs
@@ -5,6 +5,7 @@ using SDGraphics;
 using SDUtils;
 using Ship_Game.AI;
 using Ship_Game.Ships;
+using static Ship_Game.Planet;
 
 namespace Ship_Game;
 
@@ -244,13 +245,30 @@ public sealed partial class Empire
     {
         bestPorts = null;
         // If all the ports are research colonies, do not filter them
-        bool filterResearchPorts = ports.Any(p => p.CType != Planet.ColonyType.Research);
+        bool filterResearchPorts = ports.Any(p => p.CType != ColonyType.Research);
         if (ports.Count > 0)
         {
-            float averageMaxProd = ports.Average(p => p.Prod.NetMaxPotential);
+            float averageMaxProd = ports.Average(ModifiedNetMaxProductionPotential);
             bestPorts = ports.Filter(p => !p.IsCrippled
-                                     && (p.CType != Planet.ColonyType.Research || !filterResearchPorts)
+                                     && (p.CType != ColonyType.Research || !filterResearchPorts)
                                      && p.Prod.NetMaxPotential.GreaterOrEqual(averageMaxProd * portQuality));
+        }
+
+
+        float ModifiedNetMaxProductionPotential(Planet planet)
+        {
+            float maxPotential = planet.Prod.NetMaxPotential;
+            switch (planet.CType)
+            {
+                case ColonyType.TradeHub:
+                case ColonyType.Core:         maxPotential *= 0.5f;                  break;
+                case ColonyType.Agricultural: maxPotential *= 0.25f;                 break;
+                case ColonyType.Military:     maxPotential *= 0.75f;                 break;
+                case ColonyType.Research:     maxPotential *= 0.1f;                  break;
+                case ColonyType.Colony:       maxPotential  = planet.Prod.NetIncome; break;
+            }
+
+            return maxPotential;
         }
 
         return bestPorts?.Length > 0;

--- a/Ship_Game/Empire_War.cs
+++ b/Ship_Game/Empire_War.cs
@@ -103,7 +103,7 @@ namespace Ship_Game
             AI.AddPendingTask(task);
         }
 
-        public void CreateWarTask(Planet targetPlanet, Empire enemy, Goal goal)
+        public void CreateWarTask(Planet targetPlanet, Empire enemy, Goal goal, out MilitaryTask task)
         {
             // todo advanced mission types per personality or prepare for war strategy
             MilitaryTask.TaskType taskType = MilitaryTask.TaskType.StrikeForce;
@@ -125,7 +125,7 @@ namespace Ship_Game
                 }
             }
 
-            var task = new MilitaryTask(targetPlanet, this, importance)
+            task = new MilitaryTask(targetPlanet, this, importance)
             {
                 Goal = goal,
                 Type = taskType,

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -44,7 +44,6 @@ namespace Ship_Game.Fleets
 
         int DefenseTurns = 50;
         [StarData] public MilitaryTask FleetTask;
-        [StarData] MilitaryTask CoreFleetSubTask;
         [StarData] public CombatStatus TaskCombatStatus = CombatStatus.InCombat;
 
         [StarData] public int FleetIconIndex;
@@ -696,13 +695,10 @@ namespace Ship_Game.Fleets
                     TaskStep     = 1;
                     break;
                 case 1:
-                    if (!DoOrbitTaskArea(task))
-                        AttackEnemyStrengthClumpsInAO(task);
-                    else
+                    if (!DoOrbitTaskArea(task) || !AttackEnemyStrengthClumpsInAO(task))
                         EndInvalidTask(--DefenseTurns <= 0 
                                        && !Owner.SystemsWithThreat.Any(t => !t.ThreatTimedOut 
                                                                          && t.TargetSystem == task.TargetPlanet.System));
-
                     break;
             }
         }

--- a/Ship_Game/GamePlayGlobals.cs
+++ b/Ship_Game/GamePlayGlobals.cs
@@ -26,7 +26,7 @@ public class GamePlayGlobals
     [StarData] public float RemnantDesignStrMultiplier; 
     [StarData] public int CostBasedOnSizeThreshold = 2500;  // Allow tuning the change up/down
     [StarData] public float HangarCombatShipCostMultiplier = 1;
-    [StarData] public float ResearchStationProductionPerResearch = 1.5f; // Production consumed per 1 Research point
+    [StarData] public float ResearchStationProductionPerResearch = 2f; // Production consumed per 1 Research point
 
     // required empire pop ratio before expansion is considered
     [StarData] public float RequiredExpansionPopRatio = 0.4f;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
@@ -114,7 +114,26 @@ public partial class Planet
             totalTurnsToCompleteQueue += turnsToCompleteItem;
         }
 
-        return (int)totalTurnsToCompleteQueue;
+        return (int)(totalTurnsToCompleteQueue * ModifiedTotalTurnsToComplete());
+
+        // This is to consider food production flactuations
+        float ModifiedTotalTurnsToComplete()
+        {
+            if (IsCybernetic)   
+                return 1;
+
+            switch (CType)
+            {
+                default:                      
+                case ColonyType.Colony:
+                case ColonyType.TradeHub:
+                case ColonyType.Industrial:   return 1f;
+                case ColonyType.Military:     return 1.25f;
+                case ColonyType.Core:         return 1.5f;
+                case ColonyType.Research:     return 2f;
+                case ColonyType.Agricultural: return 2.5f;
+            }
+        }
     }
 
     // @return Total numbers before ship will be finished if

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
@@ -383,9 +383,9 @@ namespace Ship_Game
             float limit = 0; // it is a multiplier
             switch (goods)
             {
-                case Goods.Food:       limit = Storage.Max / NumFreightersPickingUpFood.LowerBound(1); break;
-                case Goods.Production: limit = Storage.Max / NumFreightersPickingUpProd.LowerBound(1); break;
-                case Goods.Colonists:  limit = Population * 0.2f;                                      break;
+                case Goods.Food:       limit = (Storage.Max / NumFreightersPickingUpFood.LowerBound(1)).UpperBound(FoodHere); break;
+                case Goods.Production: limit = (Storage.Max / NumFreightersPickingUpProd.LowerBound(1)).UpperBound(ProdHere); break;
+                case Goods.Colonists:  limit = Population * 0.2f;                                                             break;
             }
 
             return limit;

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.DrawDebugInfo.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.DrawDebugInfo.cs
@@ -11,6 +11,7 @@ namespace Ship_Game
         public readonly AggregatePerfTimer ResetBordersPerf  = new();
         public readonly AggregatePerfTimer ScanFromPlanetsPerf = new();
         public readonly AggregatePerfTimer ThreatMatrixPerf  = new();
+        public readonly AggregatePerfTimer PlayerProjectorScanPerf= new();
 
         public readonly AggregatePerfTimer EmpireUpdatePerf = new();
         public readonly AggregatePerfTimer EmpireMiscPerf   = new();

--- a/game/Content/Globals.yaml
+++ b/game/Content/Globals.yaml
@@ -18,7 +18,7 @@ Globals:
   GravityWellRange: 8000 # sets the default gravity well range, 0 means disabled
   StartingPlanetRichnessBonus: 1 # bonus richness for empire capitals (default is 1 for richness of 2)
   ShipMaintenanceMultiplier: 1 # default 1
-  ResearchStationProductionPerResearch: 1.5 # default 1.5
+  ResearchStationProductionPerResearch: 2 # default 2
   RushCostPercentage: 1 # default 1, How much rushing costs in percentage of production cost
   MinAcceptableShipWarpRange: 600000 # minimum ship warp range which is accepted as good
   # gameplay: repair

--- a/game/Content/PlanetTypes.yaml
+++ b/game/Content/PlanetTypes.yaml
@@ -202,7 +202,7 @@ Types:
     SpecularPower: 4
     AtmosphereType: [VolcanicRed,Clouds]
     MoonTypes: [Barren,Desert,Volcanic,Ice]
-    ResearchableChance: 3 # This only works on non habitable planets
+    ResearchableChance: 2 # This only works on non habitable planets
 
   - PlanetType:
     Id: 23 # Kahless
@@ -217,7 +217,7 @@ Types:
     SpecularPower: 4
     AtmosphereType: [VolcanicRed]
     MoonTypes: [Barren,Desert,Volcanic,Ice]
-    ResearchableChance: 3 # This only works on non habitable planets
+    ResearchableChance: 2 # This only works on non habitable planets
 
   - PlanetType: 
     Id: 44 # Hestess
@@ -231,7 +231,7 @@ Types:
     EmissiveMap:   Model/SpaceObjects/planet_23emis.dds
     SpecularPower: 4
     AtmosphereType: [VolcanicRed]
-    ResearchableChance: 3 # This only works on non habitable planets
+    ResearchableChance: 2 # This only works on non habitable planets
 
   - PlanetType:
     Id: 43 # Noldor hospitable
@@ -740,7 +740,7 @@ Types:
     AtmosphereType: [GasYellow]
     Scale: 2.5
     MoonTypes: [Barren,Desert,Volcanic,Ice]
-    ResearchableChance: 7 # This only works on non habitable planets
+    ResearchableChance: 5 # This only works on non habitable planets
 
   - PlanetType:
     Id: 6 # Blood Red Giant
@@ -756,7 +756,7 @@ Types:
     AtmosphereType: [GasOrange]
     Scale: 2.5
     MoonTypes: [Barren,Desert,Volcanic,Ice]
-    ResearchableChance: 7 # This only works on non habitable planets
+    ResearchableChance: 5 # This only works on non habitable planets
 
   - PlanetType:
     Id: 10 # Yellow Giant
@@ -772,7 +772,7 @@ Types:
     AtmosphereType: [GasYellow]
     Scale: 2.5
     MoonTypes: [Barren,Desert,Volcanic,Ice]
-    ResearchableChance: 7 # This only works on non habitable planets
+    ResearchableChance: 5 # This only works on non habitable planets
 
   - PlanetType:
     Id: 12 # Pink Giant
@@ -788,7 +788,7 @@ Types:
     AtmosphereType: [GasOrange]
     Scale: 2.5
     MoonTypes: [Barren,Desert,Volcanic,Ice]
-    ResearchableChance: 7 # This only works on non habitable planets
+    ResearchableChance: 5 # This only works on non habitable planets
 
   - PlanetType:
     Id: 15 # Polyphemus, Uranus, Cyan/LightBlue giant
@@ -804,7 +804,7 @@ Types:
     AtmosphereType: [GasAqua]
     Scale: 2.5
     MoonTypes: [Barren,Desert,Volcanic,Ice]
-    ResearchableChance: 7 # This only works on non habitable planets
+    ResearchableChance: 5 # This only works on non habitable planets
 
   - PlanetType:
     Id: 26 # Neptune, Blue giant
@@ -820,7 +820,7 @@ Types:
     AtmosphereType: [GasBlue]
     Scale: 2.5
     MoonTypes: [Barren,Desert,Volcanic,Ice]
-    ResearchableChance: 7 # This only works on non habitable planets
+    ResearchableChance: 5 # This only works on non habitable planets
 
   - PlanetType:
     Id: 28 # Jupiter, striped beige giant
@@ -836,4 +836,4 @@ Types:
     AtmosphereType: [GasYellow]
     Scale: 2.5
     MoonTypes: [Barren,Desert,Volcanic,Ice]
-    ResearchableChance: 7 # This only works on non habitable planets
+    ResearchableChance: 5 # This only works on non habitable planets

--- a/game/Content/ShipModules/Utility modules/Misc/ResearchArray.xml
+++ b/game/Content/ShipModules/Utility modules/Misc/ResearchArray.xml
@@ -32,7 +32,7 @@
   <energyreq>0</energyreq>
   
   <PowerDraw>100</PowerDraw>
-  <ResearchPerTurn>0.2</ResearchPerTurn>
+  <ResearchPerTurn>0.1</ResearchPerTurn>
   <NameIndex>4991</NameIndex>
   <DescriptionIndex>4992</DescriptionIndex>
 </ShipModule>

--- a/game/Content/ShipModules/Utility modules/Misc/ResearchLab.xml
+++ b/game/Content/ShipModules/Utility modules/Misc/ResearchLab.xml
@@ -32,7 +32,7 @@
   <energyreq>0</energyreq>
   
   <PowerDraw>450</PowerDraw>
-  <ResearchPerTurn>0.75</ResearchPerTurn>
+  <ResearchPerTurn>0.4</ResearchPerTurn>
   <NameIndex>4989</NameIndex>
   <DescriptionIndex>4990</DescriptionIndex>
 </ShipModule>


### PR DESCRIPTION
Refactor: Add Task to FleetGoal and remove unneeded code as a result.
Refactor: Better logic for best ports and turns until queue complete (consider colony types)
Perf: moved PlayerProjectorScan to Empire_Borders for performance measuring
Balance: Nerf Research station modules research per turn 
Balance: Nerf researchable chance of gas giants and volcanic planets.
Fix: goods load limit now has upperbound of relevant storage present.