### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
@@ -634,15 +634,17 @@ namespace Ship_Game.AI
                 }
             }
 
+            if (Owner.InCombat)
+                ClearOrders();
+
             ThrustOrWarpToPos(Owner.HomePlanet.Position, timeStep);
-            if (Owner.Position.InRadius(Owner.HomePlanet.Position, Owner.HomePlanet.Radius + 150f))
+            if (Owner.SecondsAlive > 5
+                && !Owner.OnHighAlert
+                && Owner.Position.InRadius(Owner.HomePlanet.Position, Owner.HomePlanet.Radius + 150f))
             {
                 Owner.HomePlanet.LandDefenseShip(Owner);
                 Owner.QueueTotalRemoval();
             }
-
-            if (Owner.InCombat)
-                ClearOrders();
         }
 
         void DoRebaseToShip(FixedSimTime timeStep)

--- a/Ship_Game/AutomationWindow.cs
+++ b/Ship_Game/AutomationWindow.cs
@@ -27,7 +27,7 @@ namespace Ship_Game
         {
             Screen = screen;
             const int windowWidth = 220;
-            Rect = new Rectangle(ScreenWidth - 15 - windowWidth, 130, windowWidth, 540);
+            Rect = new Rectangle(ScreenWidth - 15 - windowWidth, 130, windowWidth, 565);
         }
 
         class CheckedDropdown : UIElementV2
@@ -79,6 +79,7 @@ namespace Ship_Game
                 rest.AddCheckbox(() => UState.Player.AutoPickBestResearchStation, title: GameText.AutoPickResearchStation, tooltip: GameText.AutoPickResearchStationTip);
 
             rest.AddCheckbox(() => RushConstruction,                      title: GameText.RushAllConstruction, tooltip: GameText.RushAllConstructionTip);
+            rest.AddCheckbox(() => UState.P.AllowPlayerInterTrade,        title: GameText.AllowPlayerInterTradeTitle, tooltip: GameText.AllowPlayerInterTradeTip);
             rest.AddCheckbox(() => UState.P.SuppressOnBuildNotifications, title: GameText.DisableBuildingAlerts, tooltip: GameText.NormallyWhenYouManuallyAdd);
             rest.AddCheckbox(() => UState.P.DisableInhibitionWarning,     title: GameText.DisableInhibitionAlerts, tooltip: GameText.InhibitionAlertsAreDisplayedWhen);
             rest.AddCheckbox(() => UState.P.DisableVolcanoWarning,        title: GameText.DisableVolcanoAlerts, tooltip: GameText.DisableVolcanoActivationOrDeactivation);

--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -4497,7 +4497,10 @@ namespace Ship_Game
         ResearchStationBuiltPlanetNotify = 4434,
         /// <summary>Research Station was deployed in system</summary>
         ResearchStationBuiltSystemNotify = 4435,
-
+        /// <summary>Allow Empire Inter Trade</summary>
+        AllowPlayerInterTradeTitle = 4436,
+        /// <summary>Allows your idle freighters to transfer</summary>
+        AllowPlayerInterTradeTip = 4437,
 
 
 

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -193,7 +193,7 @@ namespace Ship_Game
         public bool IsGeneralists                => data.EconomicPersonality?.Name == "Generalists";
         public bool IsMilitarists                => data.EconomicPersonality?.Name == "Militarists";
         public bool IsTechnologists              => data.EconomicPersonality?.Name == "Technologists";
-        public float HomeDefenseShipCostMultiplier => DifficultyModifiers.CreditsMultiplier
+        public float HomeDefenseShipCostMultiplier => DifficultyModifiers.CreditsMultiplier;
 
         public float MoneySpendOnProductionThisTurn { get; private set; }
 

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -193,6 +193,7 @@ namespace Ship_Game
         public bool IsGeneralists                => data.EconomicPersonality?.Name == "Generalists";
         public bool IsMilitarists                => data.EconomicPersonality?.Name == "Militarists";
         public bool IsTechnologists              => data.EconomicPersonality?.Name == "Technologists";
+        public float HomeDefenseShipCostMultiplier => DifficultyModifiers.CreditsMultiplier
 
         public float MoneySpendOnProductionThisTurn { get; private set; }
 
@@ -2399,7 +2400,7 @@ namespace Ship_Game
         }
 
         public int EstimateCreditCost(float itemCost)   => (int)Math.Round(ProductionCreditCost(itemCost), 0);
-        public void ChargeCreditsHomeDefense(Ship ship) => ChargeCredits(ship.GetCost(this) * 0.2f);
+        public void ChargeCreditsHomeDefense(Ship ship) => ChargeCredits(ship.GetCost(this) * DifficultyModifiers.CreditsMultiplier);
 
         public void ChargeCreditsOnProduction(QueueItem q, float spentProduction)
         {

--- a/Ship_Game/EmpireDifficultyModifers.cs
+++ b/Ship_Game/EmpireDifficultyModifers.cs
@@ -162,7 +162,7 @@
                     ShipLevel            = 3;
                     HideTacticalData     = true;
                     MaxDesiredPlanets    = 1f;
-                    CreditsMultiplier    = empire.isPlayer ? 0.5f : 0.05f;
+                    CreditsMultiplier    = empire.isPlayer ? 0.4f : 0.075f;
                     EnemyTroopStrength   = 1.8f;
                     MineralDecayDivider  = 40;
                     PiratePayModifier    = 1.5f;

--- a/Ship_Game/EmpirePersonalityModifiers.cs
+++ b/Ship_Game/EmpirePersonalityModifiers.cs
@@ -12,6 +12,7 @@ namespace Ship_Game
         public readonly float AllianceValueAlliedWithEnemy;
         public readonly float WantedAgentMissionMultiplier;
         public readonly int TurnsAbove95FederationNeeded;
+        public readonly int TurnsAbove95AllianceTreshold; // how many turns we need above trust 95 to offer alliance
         public readonly float FederationPopRatioWar;
         public readonly float PlanetStoleTrustMultiplier;
         public readonly float WarGradeThresholdForPeace; // How bad should our total wars grade be to request peace
@@ -38,6 +39,7 @@ namespace Ship_Game
                     ColonizationClaimRatioWarningThreshold = 1;
                     AddAngerAlliedWithEnemies3RdParty      = 25;
                     TurnsAbove95FederationNeeded = 250;
+                    TurnsAbove95AllianceTreshold = 100;
                     AllianceValueAlliedWithEnemy = 0.5f;
                     WantedAgentMissionMultiplier = 0.1f;
                     PlanetStoleTrustMultiplier   = 0.75f;
@@ -65,6 +67,7 @@ namespace Ship_Game
                     ColonizationClaimRatioWarningThreshold = 0.7f;
                     AddAngerAlliedWithEnemies3RdParty      = 75;
                     TurnsAbove95FederationNeeded = 350;
+                    TurnsAbove95AllianceTreshold = 300;
                     AllianceValueAlliedWithEnemy = 0.4f;
                     WantedAgentMissionMultiplier = 0.115f;
                     WarGradeThresholdForPeace    = 0.3f * War.MaxWarGrade;
@@ -92,6 +95,7 @@ namespace Ship_Game
                     ColonizationClaimRatioWarningThreshold = 0.6f;
                     AddAngerAlliedWithEnemies3RdParty      = 75;
                     TurnsAbove95FederationNeeded = 420;
+                    TurnsAbove95AllianceTreshold = 250;
                     AllianceValueAlliedWithEnemy = 0.5f;
                     WantedAgentMissionMultiplier = 0.115f;
                     WarGradeThresholdForPeace    = 0.3f * War.MaxWarGrade;
@@ -119,6 +123,7 @@ namespace Ship_Game
                     ColonizationClaimRatioWarningThreshold = 0;
                     AddAngerAlliedWithEnemies3RdParty      = 100;
                     TurnsAbove95FederationNeeded = 600;
+                    TurnsAbove95AllianceTreshold = 200;
                     AllianceValueAlliedWithEnemy = 0.5f;
                     WantedAgentMissionMultiplier = 0.13f;
                     PlanetStoleTrustMultiplier   = 0.1f;
@@ -146,6 +151,7 @@ namespace Ship_Game
                     ColonizationClaimRatioWarningThreshold = 1;
                     AddAngerAlliedWithEnemies3RdParty      = 50;
                     TurnsAbove95FederationNeeded = 320;
+                    TurnsAbove95AllianceTreshold = 150;
                     AllianceValueAlliedWithEnemy = 0.6f;
                     WantedAgentMissionMultiplier = 0.13f;
                     PlanetStoleTrustMultiplier   = 0.7f;
@@ -173,6 +179,7 @@ namespace Ship_Game
                     ColonizationClaimRatioWarningThreshold = 1;
                     AddAngerAlliedWithEnemies3RdParty      = 100;
                     TurnsAbove95FederationNeeded = 250;
+                    TurnsAbove95AllianceTreshold = 125;
                     AllianceValueAlliedWithEnemy = 0.5f;
                     WantedAgentMissionMultiplier = 0.1f;
                     PlanetStoleTrustMultiplier   = 0.4f;
@@ -200,6 +207,7 @@ namespace Ship_Game
                     ColonizationClaimRatioWarningThreshold = 1.25f;
                     AddAngerAlliedWithEnemies3RdParty      = 25;
                     TurnsAbove95FederationNeeded = 300;
+                    TurnsAbove95AllianceTreshold = 100;
                     AllianceValueAlliedWithEnemy = 0.8f;
                     WantedAgentMissionMultiplier = 0.1f;
                     WarGradeThresholdForPeace    = 0.75f * War.MaxWarGrade;

--- a/Ship_Game/Empire_Trade.cs
+++ b/Ship_Game/Empire_Trade.cs
@@ -70,7 +70,7 @@ namespace Ship_Game
 
             // Finally, add Inter Empire Trade Tariff
             if (this != planet.Owner) 
-                taxedGoods += goods * 0.5f;
+                taxedGoods += goods * 2f;
 
             TradeMoneyAddedThisTurn += taxedGoods;
             AllTimeTradeIncome      += (int)taxedGoods;
@@ -98,14 +98,17 @@ namespace Ship_Game
                 DispatchOrBuildFreighters(Goods.Production, OwnedPlanets, false);
             }
 
-            var interTradePlanets = TradingEmpiresPlanetList();
-            if (interTradePlanets.Count > 0)
+            if (!isPlayer || Universe.P.AllowPlayerInterTrade)
             {
-                // export stuff to Empires which have trade treaties with us
-                if (NonCybernetic)
-                    DispatchOrBuildFreighters(Goods.Food, interTradePlanets, true);
+                var interTradePlanets = TradingEmpiresPlanetList();
+                if (interTradePlanets.Count > 0)
+                {
+                    // export stuff to Empires which have trade treaties with us
+                    if (NonCybernetic)
+                        DispatchOrBuildFreighters(Goods.Food, interTradePlanets, true);
 
-                DispatchOrBuildFreighters(Goods.Production, interTradePlanets, true);
+                    DispatchOrBuildFreighters(Goods.Production, interTradePlanets, true);
+                }
             }
 
             UpdateFreighterTimersAndScrap();

--- a/Ship_Game/Gameplay/Relationship.cs
+++ b/Ship_Game/Gameplay/Relationship.cs
@@ -835,7 +835,7 @@ namespace Ship_Game.Gameplay
 
             if (isTrader)
             {
-                if (Treaty_Trade)
+                if (Treaty_NAPact || Treaty_Trade)
                     return false;
 
                 if (DoWeShareATradePartner(targetEmpire, attackingEmpire))
@@ -958,7 +958,7 @@ namespace Ship_Game.Gameplay
 
         void OfferAlliance(Empire us)
         {
-            if (TurnsAbove95 < 100
+            if (TurnsAbove95 < us.PersonalityModifiers.TurnsAbove95AllianceTreshold
                 || turnsSinceLastContact < 100
                 || Treaty_Alliance
                 || !Treaty_Trade

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -547,12 +547,8 @@ namespace Ship_Game.Ships
                 if (attackerToUs.AttackForTransgressions(attacker.data.DiplomaticPersonality))
                     return true;
 
-                //if (LastDamagedBy?.GetLoyalty() == attacker)
-                  //  return true;
                 if (AI.Target?.GetLoyalty() == attacker)
                     return true;
-                //if (attacker.isPlayer && !attackerToUs.Treaty_NAPact) 
-                //    return true;
             }
 
             if (attackerToUs.Treaty_Trade && IsFreighter && AI.State == AIState.SystemTrader)

--- a/Ship_Game/Universe/UniverseParams.cs
+++ b/Ship_Game/Universe/UniverseParams.cs
@@ -62,6 +62,7 @@ public class UniverseParams
     [StarData(DefaultValue=true)] public bool PlanetsScreenHideInhospitable = true;
     [StarData(DefaultValue=true)] public bool DisableInhibitionWarning = true;
     [StarData(DefaultValue=false)] public bool EnableStarvationWarning = false;
+    [StarData(DefaultValue = true)] public bool AllowPlayerInterTrade  = true;
     [StarData] public bool SuppressOnBuildNotifications;
     [StarData] public bool PlanetScreenHideOwned;
     [StarData] public bool ShipListFilterPlayerShipsOnly;

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -10415,6 +10415,12 @@ ResearchStationBuiltPlanetNotify:
 ResearchStationBuiltSystemNotify: 
  Id: 4435
  ENG: "(Research Station) was\ndeployed in system"      
+AllowPlayerInterTradeTitle:
+ Id: 4436
+ ENG: "Allow Empire Inter Trade"      
+AllowPlayerInterTradeTip:
+ Id: 4437
+ ENG: "Allows your idle freighters to transfer goods to empires you have trade treaties with them if internal demand is satisfied. You can still disable this for specific freighters. Transferring goods to other empires yields large credit bonus of 2 credits per good along with any other yields of a normal trade"      
 ResearchLabName:
  Id: 4989
  ENG: "Research Lab"


### PR DESCRIPTION
Feature: Added ability to disable empire intertrade in Automation window. 
Balance: set dynamic time for alliance request based on personality. 
Balance: Increased bonus of inter trade to 2 credits per transferred goods.
Fix: Add NAPact to isAttackable
Fix: homedefense ships possible extra increase of credits when landing. 
Fix: ship credit charge on brutal


