### PR TITLE
Feature quadrant explosion damage

### DIFF
--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -1252,7 +1252,7 @@ namespace Ship_Game.Ships
                 ReturnHome();
 
             // Ship Repair
-            if (HealthPercent < 0.999f)
+            if (HealthPercent < 0.9999999f)
                 Repair(timeSinceLastUpdate);
 
             UpdateResupply();

--- a/Ship_Game/Ships/ShipModule.cs
+++ b/Ship_Game/Ships/ShipModule.cs
@@ -1017,7 +1017,7 @@ namespace Ship_Game.Ships
                 if (Explodes)
                 {
                     // ShipModule has died and will now explode internally
-                    // the 1,1 vector substruction ensures the Northwest quardrant is hit (floating point issues)
+                    // the 1,1 vector substruction ensures the Northwest quadrant is hit (floating point issues)
                     Parent.DamageExplosive(source, ExplosionDamage, Position - new Vector2(1,1), ExplosionRadius, true);
                 }
             }

--- a/Ship_Game/Ships/ShipModule.cs
+++ b/Ship_Game/Ships/ShipModule.cs
@@ -741,22 +741,11 @@ namespace Ship_Game.Ships
         }
 
         // return TRUE if all damage was absorbed (damageInOut is less or equal to 0)
-        public bool DamageExplosive(GameObject source, Vector2 worldHitPos, float damageRadius, ref float damageInOut)
+        public bool DamageExplosive(GameObject source, ref float damageInOut, int damageDivider = 1)
         {
-            float damage = GetExplosiveDamage(worldHitPos, damageRadius, damageInOut);
-            if (damage <= 0.1f)
-                return true;
-
             //Empire.Universe?.DebugWin?.DrawCircle(DebugModes.SpatialManager, Center, Radius, 1.5f);
-
-            Damage(source, damageInOut, out damageInOut);
+            Damage(source, damageInOut / damageDivider, out damageInOut);
             return damageInOut <= 0f;
-        }
-
-        float GetExplosiveDamage(Vector2 worldHitPos, float damageRadius, float damageAmount)
-        {
-            float moduleRadius = ShieldsAreActive ? ShieldHitRadius : Radius;
-            return damageAmount * DamageFalloff(worldHitPos, Position, damageRadius, moduleRadius);
         }
 
         void EvtDamageInflicted(GameObject source, float amount)
@@ -1026,7 +1015,7 @@ namespace Ship_Game.Ships
                 if (Explodes)
                 {
                     // ShipModule has died and will now explode internally
-                    Parent.DamageExplosive(source, ExplosionDamage, Position, ExplosionRadius, true);
+                    Parent.DamageExplosive(source, ExplosionDamage, Position - new  Vector2(1,1), ExplosionRadius, true);
                 }
             }
         }

--- a/Ship_Game/Ships/ShipModule.cs
+++ b/Ship_Game/Ships/ShipModule.cs
@@ -1017,7 +1017,8 @@ namespace Ship_Game.Ships
                 if (Explodes)
                 {
                     // ShipModule has died and will now explode internally
-                    Parent.DamageExplosive(source, ExplosionDamage, Position - new  Vector2(1,1), ExplosionRadius, true);
+                    // the 1,1 vector substruction ensures the Northwest quardrant is hit (floating point issues)
+                    Parent.DamageExplosive(source, ExplosionDamage, Position - new Vector2(1,1), ExplosionRadius, true);
                 }
             }
         }

--- a/Ship_Game/Ships/ShipModule.cs
+++ b/Ship_Game/Ships/ShipModule.cs
@@ -743,6 +743,8 @@ namespace Ship_Game.Ships
         // return TRUE if all damage was absorbed (damageInOut is less or equal to 0)
         public bool DamageExplosive(GameObject source, ref float damageInOut, int damageDivider = 1)
         {
+            if (damageInOut <= 0f)
+                return true;
             //Empire.Universe?.DebugWin?.DrawCircle(DebugModes.SpatialManager, Center, Radius, 1.5f);
             Damage(source, damageInOut / damageDivider, out damageInOut);
             return damageInOut <= 0f;

--- a/Ship_Game/Ships/Ship_ModuleGrid.cs
+++ b/Ship_Game/Ships/Ship_ModuleGrid.cs
@@ -218,7 +218,7 @@ namespace Ship_Game.Ships
             return Grid.GetModulesAt(ModuleSlotList, gridPos, checkShields);
         }
 
-        // Enumarates all Shipmodules under (worldPoint, radius) divided to quardrant.
+        // Enumarates all Shipmodules under (worldPoint, radius) divided to quadrant.
         // starting from the center and in an order for explotion spread. The sturct returns
         // also contains damage divider instead of damage fall off function
         //    NW (1) NE (2)
@@ -238,7 +238,7 @@ namespace Ship_Game.Ships
         //    3 2 1 1 2 3      
         //    3 2 2 2 2 3
         //    3 3 3 3 3 3
-        IEnumerable<ModuleQuardrant> EnumModulesQuadrants(Vector2 worldPos, float radius, bool checkShields)
+        IEnumerable<ModuleQuadrant> EnumModulesQuadrants(Vector2 worldPos, float radius, bool checkShields)
         {
             // Create an optimized integer rectangle
             // a---+
@@ -270,15 +270,15 @@ namespace Ship_Game.Ships
             // check the first center module
             // this will keep returning shields first, and then underlying module
             foreach (ShipModule m in GetModulesAt(c, checkShields))
-                yield return new ModuleQuardrant(m, DamageTransfer.Root, distance: 1, quardrant: 1);
+                yield return new ModuleQuadrant(m, DamageTransfer.Root, distance: 1, quardrant: 1);
 
             // special case: radius is very small and could only ever hit 1 slot
             if (firstX == lastX && firstY == lastY)
                 yield break;
 
             int curX, curY;
-            
-            // Check Northwest Quardrant
+
+            // Check Northwest quadrant
             int counter = 0;
             for (int nw = c.X; nw >= firstX; nw--)
             {
@@ -295,11 +295,11 @@ namespace Ship_Game.Ships
                             if (diagonalModule)
                             {
                                 diagonalModule = false;
-                                yield return new ModuleQuardrant(m, DamageTransfer.Diagonal, distance, 1);
+                                yield return new ModuleQuadrant(m, DamageTransfer.Diagonal, distance, 1);
                             }
                             else
                             {
-                                yield return new ModuleQuardrant(m, DamageTransfer.Orthogonal, distance, 1);
+                                yield return new ModuleQuadrant(m, DamageTransfer.Orthogonal, distance, 1);
                             }
                         }
                         diagonalModule = false;
@@ -315,7 +315,7 @@ namespace Ship_Game.Ships
                     {
                         var p = new Point(curX, curY);
                         foreach (ShipModule m in GetModulesAt(p, checkShields))
-                            yield return new ModuleQuardrant(m, DamageTransfer.Orthogonal, distance, 1);
+                            yield return new ModuleQuadrant(m, DamageTransfer.Orthogonal, distance, 1);
 
                         distance++;
                     }
@@ -323,8 +323,8 @@ namespace Ship_Game.Ships
 
                 counter++;
             }
-            
-            // Check Northweast Quardrant
+
+            // Check Northweast quadrant
             counter = 0;
             for (int ne = c.X + 1; ne <= lastX; ne++)
             {
@@ -341,11 +341,11 @@ namespace Ship_Game.Ships
                             if (diagonalModule)
                             {
                                 diagonalModule = false;
-                                yield return new ModuleQuardrant(m, DamageTransfer.Diagonal, distance, 2);
+                                yield return new ModuleQuadrant(m, DamageTransfer.Diagonal, distance, 2);
                             }
                             else
                             {
-                                yield return new ModuleQuardrant(m, DamageTransfer.Orthogonal, distance, 2);
+                                yield return new ModuleQuadrant(m, DamageTransfer.Orthogonal, distance, 2);
                             }
                         }
                         diagonalModule = false;
@@ -361,7 +361,7 @@ namespace Ship_Game.Ships
                     {
                         var p = new Point(curX, curY);
                         foreach (ShipModule m in GetModulesAt(p, checkShields))
-                            yield return new ModuleQuardrant(m, DamageTransfer.Orthogonal, distance, 2);
+                            yield return new ModuleQuadrant(m, DamageTransfer.Orthogonal, distance, 2);
 
                         distance++;
                     }
@@ -370,7 +370,7 @@ namespace Ship_Game.Ships
                 counter++;
             }
 
-            // Check Southeast Quardrant
+            // Check Southeast quadrant
             counter = 0;
             for (int se = c.X + 1; se <= lastX; se++)
             {
@@ -387,11 +387,11 @@ namespace Ship_Game.Ships
                             if (diagonalModule)
                             {
                                 diagonalModule = false;
-                                yield return new ModuleQuardrant(m, DamageTransfer.Diagonal, distance, 3);
+                                yield return new ModuleQuadrant(m, DamageTransfer.Diagonal, distance, 3);
                             }
                             else
                             {
-                                yield return new ModuleQuardrant(m, DamageTransfer.Orthogonal, distance, 3);
+                                yield return new ModuleQuadrant(m, DamageTransfer.Orthogonal, distance, 3);
                             }
                         }
                         diagonalModule = false;
@@ -407,7 +407,7 @@ namespace Ship_Game.Ships
                     {
                         var p = new Point(curX, curY);
                         foreach (ShipModule m in GetModulesAt(p, checkShields))
-                            yield return new ModuleQuardrant(m, DamageTransfer.Orthogonal, distance, 3);
+                            yield return new ModuleQuadrant(m, DamageTransfer.Orthogonal, distance, 3);
 
                         distance++;
                     }
@@ -416,7 +416,7 @@ namespace Ship_Game.Ships
                 counter++;
             }
 
-            // Check Southwest Quardrant
+            // Check Southwest quadrant
             counter = 0;
             for (int sw = c.X; sw >= firstX; sw--)
             {
@@ -433,11 +433,11 @@ namespace Ship_Game.Ships
                             if (diagonalModule)
                             {
                                 diagonalModule = false;
-                                yield return new ModuleQuardrant(m, DamageTransfer.Diagonal, distance, 4);
+                                yield return new ModuleQuadrant(m, DamageTransfer.Diagonal, distance, 4);
                             }
                             else
                             {
-                                yield return new ModuleQuardrant(m, DamageTransfer.Orthogonal, distance, 4);
+                                yield return new ModuleQuadrant(m, DamageTransfer.Orthogonal, distance, 4);
                             }
                         }
                         diagonalModule = false;
@@ -453,7 +453,7 @@ namespace Ship_Game.Ships
                     {
                         var p = new Point(curX, curY);
                         foreach (ShipModule m in GetModulesAt(p, checkShields))
-                            yield return new ModuleQuardrant(m, DamageTransfer.Orthogonal, distance, 4);
+                            yield return new ModuleQuadrant(m, DamageTransfer.Orthogonal, distance, 4);
 
                         distance++;
                     }
@@ -470,7 +470,7 @@ namespace Ship_Game.Ships
         public ShipModule FindClosestModule(Vector2 worldPos)
         {
             if (!Active) return null;
-            foreach (ModuleQuardrant mq in EnumModulesQuadrants(worldPos, Radius, checkShields:false))
+            foreach (ModuleQuadrant mq in EnumModulesQuadrants(worldPos, Radius, checkShields:false))
                 return mq.Module;
             return null;
         }
@@ -479,7 +479,7 @@ namespace Ship_Game.Ships
         public ShipModule HitTestSingle(Vector2 worldHitPos, float hitRadius, bool ignoreShields)
         {
             if (!Active) return null;
-            foreach (ModuleQuardrant mq in EnumModulesQuadrants(worldHitPos, hitRadius, !ignoreShields))
+            foreach (ModuleQuadrant mq in EnumModulesQuadrants(worldHitPos, hitRadius, !ignoreShields))
                 return mq.Module;
             return null;
         }
@@ -497,10 +497,10 @@ namespace Ship_Game.Ships
 
             float remainingDamage = damageAmount;
             float diagonalDamage = damageAmount;
-            int currentQuardrant = 1;
+            int currentQuadrant = 1;
             int currentDistance = 0;
 
-            // Logic for each quardrant - example here is the nw quardrant
+            // Logic for each quadrant - example here is the nw quadrant
             //    3   3   3 
             //      D ↑   ↑   
             //    3 ← 2   2 
@@ -512,12 +512,12 @@ namespace Ship_Game.Ships
             // Then it will start from module 2 Diagonaly and repeat the logic. 
             // These numbers are also divider for any excess damage transfered to the next module in the generator
             // Excess damage is transferred diagonally as well.
-            foreach (ModuleQuardrant mq in EnumModulesQuadrants(worldHitPos, hitRadius, !ignoreShields))
+            foreach (ModuleQuadrant mq in EnumModulesQuadrants(worldHitPos, hitRadius, !ignoreShields))
             {
-                if (mq.Qaurdrant != currentQuardrant)
+                if (mq.Quadrant != currentQuadrant)
                 {
                     // starting a new quardrant, reset the damage to the initial damage
-                    currentQuardrant = mq.Qaurdrant;
+                    currentQuadrant = mq.Quadrant;
                     remainingDamage = damageAmount;
                     diagonalDamage = damageAmount;
                 }
@@ -782,18 +782,18 @@ namespace Ship_Game.Ships
         }
     }
 
-    public struct ModuleQuardrant
+    public struct ModuleQuadrant
     {
         public ShipModule Module;
         public DamageTransfer Type;
         public int Distance;
-        public int Qaurdrant;
-        public ModuleQuardrant(ShipModule module, DamageTransfer type, int distance, int quardrant)
+        public int Quadrant;
+        public ModuleQuadrant(ShipModule module, DamageTransfer type, int distance, int quadrant)
         {
             Module = module;
             Type   = type;
             Distance = distance;
-            Qaurdrant = quardrant;
+            Quadrant = quadrant;
         }
     }
     public enum DamageTransfer

--- a/Ship_Game/Ships/Ship_ModuleGrid.cs
+++ b/Ship_Game/Ships/Ship_ModuleGrid.cs
@@ -495,9 +495,6 @@ namespace Ship_Game.Ships
             if (Loyalty.data.ExplosiveRadiusReduction > 0f)
                 hitRadius *= 1f - Loyalty.data.ExplosiveRadiusReduction;
 
-            /*var lala = EnumModulesQuadrants(worldHitPos, hitRadius, !ignoreShields);
-            var lala2 = lala.ToArray();*/
-
             float remainingDamage = damageAmount;
             float diagonalDamage = damageAmount;
             int currentQuardrant = 1;
@@ -511,9 +508,10 @@ namespace Ship_Game.Ships
             //    3 ← 2 ← 1 
 
             // If point 1 absorbs the damage it wont spread to other points.  
-            // Damage is spread from point 1 to point 3 upwards, then from point 1 to point 3 backwords.
-            // Then it will stard from module 2 Diagonaly and repeat the logic. 
-            // These number are also divider for any excess damage transfered to the next module in the generator
+            // Damage is spread from point 1 to point 3 upwards, then from point 1 to point 3 backwards.
+            // Then it will start from module 2 Diagonaly and repeat the logic. 
+            // These numbers are also divider for any excess damage transfered to the next module in the generator
+            // Excess damage is transferred diagonally as well.
             foreach (ModuleQuardrant mq in EnumModulesQuadrants(worldHitPos, hitRadius, !ignoreShields))
             {
                 if (mq.Qaurdrant != currentQuardrant)

--- a/Ship_Game/Ships/Ship_ModuleGrid.cs
+++ b/Ship_Game/Ships/Ship_ModuleGrid.cs
@@ -487,7 +487,6 @@ namespace Ship_Game.Ships
 
             float remainingDamage = damageAmount;
             float diagonalDamage = damageAmount;
-            bool rootModuleWasDamaged = false;
             int currentQuardrant = 1;
             int currentDistance = 0;
 
@@ -505,20 +504,20 @@ namespace Ship_Game.Ships
                     remainingDamage = diagonalDamage; // start checking from diagonal module
                 }
 
-                if (mq.Type != DamageTransfer.Root || !rootModuleWasDamaged)
+                if (mq.Module.DamageExplosive(damageSource, ref remainingDamage, mq.Distance)
+                    && mq.Type == DamageTransfer.Root)
                 {
-                    if (mq.Module.DamageExplosive(damageSource, ref remainingDamage, mq.Distance))
-                    {
-                        if (mq.Type == DamageTransfer.Root)
-                            return; // Root module absorbed all the explosion
-                    }
-
-                    if (mq.Type == DamageTransfer.Root)
-                        rootModuleWasDamaged|= true;
-
-                    if (mq.Type is DamageTransfer.Diagonal or DamageTransfer.Root)
-                        diagonalDamage = remainingDamage;
+                    return; // Root module absorbed all the explosion
                 }
+
+                if (mq.Type == DamageTransfer.Root)
+                {
+                    // explosion damage will now be whats left after root module exploded
+                    damageAmount = remainingDamage; 
+                }
+                if (mq.Type is DamageTransfer.Diagonal or DamageTransfer.Root)
+                    diagonalDamage = remainingDamage;
+                
                 currentDistance = mq.Distance;
             }
         }

--- a/Ship_Game/Ships/Ship_ModuleGrid.cs
+++ b/Ship_Game/Ships/Ship_ModuleGrid.cs
@@ -748,7 +748,8 @@ namespace Ship_Game.Ships
         ShipModule TargetRandomInternalModule(Vector2 projPos, int level, float sqSearchRange)
         {
             if (projPos.InRadius(Position, Radius+50))
-                return null;
+                return null; // Dont shoot on top of us!
+
             ShipModule[] modules = ModuleSlotList.Filter(m => m.Active && projPos.SqDist(m.Position) < sqSearchRange);
             if (modules.Length == 0)
                 return null;

--- a/Ship_Game/Ships/Ship_Repair.cs
+++ b/Ship_Game/Ships/Ship_Repair.cs
@@ -113,7 +113,7 @@ public partial class Ship
     /// <param name="repairLevel">Level which improves repair decisions</param>
     public void ApplyAllRepair(float repairAmount, float repairInterval, int repairLevel)
     {
-        if (HealthPercent > 0.999f || repairAmount.AlmostEqual(0))
+        if (HealthPercent > 0.9999999f || repairAmount.AlmostEqual(0))
         {
             CurrentRepairPerSecond = 0;
             return;


### PR DESCRIPTION
Use quadrant explosion model where modules can absorb damage while still using a generator.
Fix ships not repairing to full health
Dont pick a module as a target if Origin of the weapon is within the Ship target Radius. to avoid skipping armor and hitting internal module