### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/AI/ExpansionAI/ExpansionPlanner.cs
+++ b/Ship_Game/AI/ExpansionAI/ExpansionPlanner.cs
@@ -185,7 +185,7 @@ namespace Ship_Game.AI.ExpansionAI
             return s.IsExploredBy(Owner)
                 && !s.HasPlanetsOwnedBy(Owner)
                 && s.PlanetList.Any(p => p.Habitable)
-                && Owner.KnownEnemyStrengthIn(s).LessOrEqual(Owner.OffensiveStrength/3)
+                && Owner.KnownEnemyStrengthIn(s) <= Owner.OffensiveStrength * 0.334f
                 && !s.OwnerList.Any(o=> !o.IsFaction && Owner.IsAtWarWith(o));
         }
 

--- a/Ship_Game/AI/ExpansionAI/ResearchStationPlanner.cs
+++ b/Ship_Game/AI/ExpansionAI/ResearchStationPlanner.cs
@@ -52,9 +52,10 @@ namespace Ship_Game.AI.ExpansionAI
             if (planet != null && !planet.System.InSafeDistanceFromRadiation(planet.Position))
                 return;
 
-            if (Owner.KnownEnemyStrengthIn(system) > 0)
+            float str = Owner.KnownEnemyStrengthIn(system);
+            if (str > 0)
             {
-                TryClearArea(system, influense, Owner.AI.ThreatMatrix.GetStrongestHostileAt(system));
+                TryClearArea(system, influense, Owner.AI.ThreatMatrix.GetStrongestHostileAt(system), str);
             }
             else
             {
@@ -65,9 +66,9 @@ namespace Ship_Game.AI.ExpansionAI
             }
         }
 
-        void TryClearArea(SolarSystem system, InfluenceStatus influense, Empire enemy)
+        void TryClearArea(SolarSystem system, InfluenceStatus influense, Empire enemy, float knownStr)
         {
-            if (Owner.isPlayer)
+            if (Owner.isPlayer || knownStr > Owner.OffensiveStrength * 0.334f)
                 return; 
 
             bool shouldClearArea = !Owner.PersonalityModifiers.ClearNeutralExoticSystems && influense == InfluenceStatus.Friendly

--- a/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
@@ -205,6 +205,12 @@ namespace Ship_Game.AI
                 }
             }
 
+            if (g.Goal is RefitOrbital && g.Goal.OldShip?.Active == false)
+            {
+                OrderScrapShip();
+                return;
+            }
+
             ThrustOrWarpToPos(g.Goal.BuildPosition, timeStep);
             if (g.Goal.BuildPosition.Distance(Owner.Position) > 50)
                 return;
@@ -250,6 +256,12 @@ namespace Ship_Game.AI
 
             Planet target = bg.TetherPlanet;
             if (target == null || target.Owner != Owner.Loyalty) // FB - Planet owner has changed
+            {
+                OrderScrapShip();
+                return;
+            }
+
+            if (g.Goal is RefitOrbital && g.Goal.OldShip?.Active == false)
             {
                 OrderScrapShip();
                 return;

--- a/Ship_Game/AI/ThreatCluster.cs
+++ b/Ship_Game/AI/ThreatCluster.cs
@@ -85,6 +85,11 @@ public sealed class ThreatCluster : SpatialObjectBase
     {
         // Important to check `threatMatrixOwner` hostileTo `Loyalty`,
         // because that is the correct way from ThreatMatrix perspective
-        return Loyalty != threatMatrixOwner && threatMatrixOwner.IsEmpireHostile(Loyalty);
+        if (threatMatrixOwner.WeAreRemnants || Ships.Any(s => !s.IsResearchStation))
+            return Loyalty != threatMatrixOwner && threatMatrixOwner.IsEmpireHostile(Loyalty);
+
+        // If the matrix has only research stations, we are hostiles only at war
+        return threatMatrixOwner.IsAtWarWith(Loyalty);  
+
     }
 }

--- a/Ship_Game/Commands/Goals/ProjectorBridge.cs
+++ b/Ship_Game/Commands/Goals/ProjectorBridge.cs
@@ -39,7 +39,7 @@ namespace Ship_Game.Commands.Goals
             ProjectorBridgeEndCondition endCondition) : this(e)
         {
             TargetSystem = targetSystem;
-            float distanceToDeploy = Owner.GetProjectorRadius() * 0.5f;
+            float distanceToDeploy = Owner.GetProjectorRadius() * 0.6f;
             Vector2 dir = targetSystem.Position.DirectionToTarget(originPos);
             StaticBuildPosition = TargetSystem.Position + dir * distanceToDeploy;
             BuildGoal = new BuildConstructionShip(StaticBuildPosition, "Subspace Projector", Owner, rush: true);

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -1774,7 +1774,7 @@ namespace Ship_Game.Fleets
             ThreatCluster[] clusters = Owner.AI.ThreatMatrix.FindHostileClustersByDist(task.AO, task.AORadius);
             if (clusters.Length == 0)
                 return false;
-            
+
             var availableShips = new Array<Ship>(ships);
             while (availableShips.Count > 0)
             {

--- a/Ship_Game/GamePlayGlobals.cs
+++ b/Ship_Game/GamePlayGlobals.cs
@@ -59,7 +59,8 @@ public class GamePlayGlobals
     [StarData] public float InCombatSelfRepairModifier = 0.2f;
     // Shield power multiply
     [StarData] public float ShieldPowerMultiplier = 1f;
-
+    // Projectile Hit Points Multiplier
+    [StarData] public float ProjectileHitpointsMultiplier = 1f;
 
     // feature flags
     [StarData] public bool UseHullBonuses;

--- a/Ship_Game/Gameplay/Projectile.cs
+++ b/Ship_Game/Gameplay/Projectile.cs
@@ -235,7 +235,7 @@ namespace Ship_Game.Gameplay
             DamageAmount          = Weapon.GetDamageWithBonuses(Owner);
             DamageRadius          = Weapon.ExplosionRadius;
             ExplosionRadiusMod    = Weapon.ExplosionRadiusVisual;
-            Health                = Weapon.HitPoints;
+            Health                = Weapon.HitPoints * GlobalStats.Defaults.ProjectileHitpointsMultiplier;
             Speed                 = Weapon.ProjectileSpeed;
             TrailOffset           = Weapon.TrailOffset;
             WeaponType            = Weapon.WeaponType;

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -519,7 +519,7 @@ namespace Ship_Game.Ships
 
         public override bool IsAttackable(Empire attacker, Relationship attackerToUs)
         {
-            if (IsResearchStation && !attackerToUs.AtWar)
+            if (IsResearchStation && !attacker.WeAreRemnants && !attackerToUs.AtWar)
                 return false; 
 
             if (attackerToUs.CanAttack == false && !attackerToUs.Treaty_Alliance)

--- a/game/Content/Globals.yaml
+++ b/game/Content/Globals.yaml
@@ -29,7 +29,8 @@ Globals:
   SelfRepairMultiplier: 1.0 # base repair rate from ship command/engineering modules per SECOND
   BonusRepairPerCrewLevel: 0.2 # +bonus rate based on crew level, 0.2 would be +20% increase per each crew level
   InCombatSelfRepairModifier: 0.2 # repair rate modifier for command/engineering self repair when in combat
-  ShieldPowerMultiplier: 1
+  ShieldPowerMultiplier: 1.0 # Global multiplier for Shields
+  ProjectileHitpointsMultiplier: 1.0 # Global multiplier for Projectile Hit Points (mainly affects missiles)
 
   # feature flags
   DisableShipPicker: true

--- a/game/Content/ShipModules/Secret/PirateAssaultBay.xml
+++ b/game/Content/ShipModules/Secret/PirateAssaultBay.xml
@@ -10,7 +10,7 @@
   <FrigateModule>true</FrigateModule>
   <DestroyerModule>true</DestroyerModule>
   <CruiserModule>true</CruiserModule>
-  <CarrierModule>true</CarrierModule>
+  <BattleshipModule>true</BattleshipModule>
   <CapitalModule>true</CapitalModule>
   
   <FreighterModule>true</FreighterModule>

--- a/game/Content/ShipModules/Secret/RemnantEngine2.xml
+++ b/game/Content/ShipModules/Secret/RemnantEngine2.xml
@@ -10,7 +10,7 @@
   <FrigateModule>true</FrigateModule>
   <DestroyerModule>true</DestroyerModule>
   <CruiserModule>true</CruiserModule>
-  <CarrierModule>true</CarrierModule>
+  <BattleshipModule>true</BattleshipModule>
   <CapitalModule>true</CapitalModule>
   
   <FreighterModule>true</FreighterModule>

--- a/game/Content/ShipModules/Secret/RemnantEngine3.xml
+++ b/game/Content/ShipModules/Secret/RemnantEngine3.xml
@@ -10,7 +10,7 @@
   <FrigateModule>true</FrigateModule>
   <DestroyerModule>true</DestroyerModule>
   <CruiserModule>true</CruiserModule>
-  <CarrierModule>true</CarrierModule>
+  <BattleshipModule>true</BattleshipModule>
   <CapitalModule>true</CapitalModule>
   
   <FreighterModule>true</FreighterModule>

--- a/game/Content/ShipModules/Secret/RemnantEngine4.xml
+++ b/game/Content/ShipModules/Secret/RemnantEngine4.xml
@@ -10,7 +10,7 @@
   <FrigateModule>true</FrigateModule>
   <DestroyerModule>true</DestroyerModule>
   <CruiserModule>true</CruiserModule>
-  <CarrierModule>true</CarrierModule>
+  <BattleshipModule>true</BattleshipModule>
   <CapitalModule>true</CapitalModule>
   
   <FreighterModule>true</FreighterModule>

--- a/game/Content/ShipModules/Secret/RemnantPort.xml
+++ b/game/Content/ShipModules/Secret/RemnantPort.xml
@@ -10,7 +10,7 @@
   <FrigateModule>true</FrigateModule>
   <DestroyerModule>true</DestroyerModule>
   <CruiserModule>true</CruiserModule>
-  <CarrierModule>true</CarrierModule>
+  <BattleshipModule>true</BattleshipModule>
   <CapitalModule>true</CapitalModule>
   
   <FreighterModule>true</FreighterModule>

--- a/game/Content/ShipModules/Utility modules/Armour/Ceramic Armor Small.xml
+++ b/game/Content/ShipModules/Utility modules/Armour/Ceramic Armor Small.xml
@@ -8,7 +8,7 @@
   <FrigateModule>true</FrigateModule>
   <DestroyerModule>true</DestroyerModule>
   <CruiserModule>true</CruiserModule>
-  <CarrierModule>true</CarrierModule>
+  <BattleshipModule>true</BattleshipModule>
   <CapitalModule>true</CapitalModule>
   
   <FreighterModule>true</FreighterModule>

--- a/game/Content/ShipModules/Utility modules/Armour/CompositeAlloys Small.xml
+++ b/game/Content/ShipModules/Utility modules/Armour/CompositeAlloys Small.xml
@@ -8,7 +8,7 @@
   <FrigateModule>true</FrigateModule>
   <DestroyerModule>true</DestroyerModule>
   <CruiserModule>true</CruiserModule>
-  <CarrierModule>true</CarrierModule>
+  <BattleshipModule>true</BattleshipModule>
   <CapitalModule>true</CapitalModule>
   
   <FreighterModule>true</FreighterModule>

--- a/game/Content/ShipModules/Utility modules/Armour/Crystal Armor Small.xml
+++ b/game/Content/ShipModules/Utility modules/Armour/Crystal Armor Small.xml
@@ -8,7 +8,7 @@
   <FrigateModule>true</FrigateModule>
   <DestroyerModule>true</DestroyerModule>
   <CruiserModule>true</CruiserModule>
-  <CarrierModule>true</CarrierModule>
+  <BattleshipModule>true</BattleshipModule>
   <CapitalModule>true</CapitalModule>
   
   <FreighterModule>true</FreighterModule>

--- a/game/Content/ShipModules/Utility modules/Events/AncientArmor_1x1.xml
+++ b/game/Content/ShipModules/Utility modules/Events/AncientArmor_1x1.xml
@@ -10,7 +10,7 @@
   <FrigateModule>true</FrigateModule>
   <DestroyerModule>true</DestroyerModule>
   <CruiserModule>true</CruiserModule>
-  <CarrierModule>true</CarrierModule>
+  <BattleshipModule>true</BattleshipModule>
   <CapitalModule>true</CapitalModule>
   
   <FreighterModule>true</FreighterModule>

--- a/game/Content/ShipModules/Utility modules/Events/AncientArmor_2x2.xml
+++ b/game/Content/ShipModules/Utility modules/Events/AncientArmor_2x2.xml
@@ -10,7 +10,7 @@
   <FrigateModule>true</FrigateModule>
   <DestroyerModule>true</DestroyerModule>
   <CruiserModule>true</CruiserModule>
-  <CarrierModule>true</CarrierModule>
+  <BattleshipModule>true</BattleshipModule>
   <CapitalModule>true</CapitalModule>
   
   <FreighterModule>true</FreighterModule>

--- a/game/Content/ShipModules/Utility modules/Events/AncientArmor_3x3.xml
+++ b/game/Content/ShipModules/Utility modules/Events/AncientArmor_3x3.xml
@@ -10,7 +10,7 @@
   <FrigateModule>true</FrigateModule>
   <DestroyerModule>true</DestroyerModule>
   <CruiserModule>true</CruiserModule>
-  <CarrierModule>true</CarrierModule>
+  <BattleshipModule>true</BattleshipModule>
   <CapitalModule>true</CapitalModule>
   
   <FreighterModule>true</FreighterModule>

--- a/game/Content/ShipModules/Utility modules/Misc/ConstructionArray.xml
+++ b/game/Content/ShipModules/Utility modules/Misc/ConstructionArray.xml
@@ -7,7 +7,7 @@
   <FrigateModule>false</FrigateModule>
   <DestroyerModule>false</DestroyerModule>
   <CruiserModule>false</CruiserModule>
-  <CarrierModule>false</CarrierModule>
+  <BattleshipModule>false</BattleshipModule>
   <CapitalModule>false</CapitalModule>
   <FreighterModule>true</FreighterModule>
   <PlatformModule>false</PlatformModule>

--- a/game/Content/ShipModules/Utility modules/Misc/MeteorPart.xml
+++ b/game/Content/ShipModules/Utility modules/Misc/MeteorPart.xml
@@ -6,7 +6,7 @@
   <FrigateModule>false</FrigateModule>
   <DestroyerModule>false</DestroyerModule>
   <CruiserModule>false</CruiserModule>
-  <CarrierModule>false</CarrierModule>
+  <BattleshipModule>false</BattleshipModule>
   <CapitalModule>false</CapitalModule>
   <FreighterModule>false</FreighterModule>
   <PlatformModule>true</PlatformModule>

--- a/game/Content/ShipModules/Utility modules/Misc/ResearchArray.xml
+++ b/game/Content/ShipModules/Utility modules/Misc/ResearchArray.xml
@@ -7,7 +7,7 @@
   <FrigateModule>false</FrigateModule>
   <DestroyerModule>false</DestroyerModule>
   <CruiserModule>false</CruiserModule>
-  <CarrierModule>false</CarrierModule>
+  <BattleshipModule>false</BattleshipModule>
   <CapitalModule>false</CapitalModule>
   <FreighterModule>false</FreighterModule>
   <PlatformModule>true</PlatformModule>

--- a/game/Content/ShipModules/Utility modules/Misc/ResearchLab.xml
+++ b/game/Content/ShipModules/Utility modules/Misc/ResearchLab.xml
@@ -7,7 +7,7 @@
   <FrigateModule>false</FrigateModule>
   <DestroyerModule>false</DestroyerModule>
   <CruiserModule>false</CruiserModule>
-  <CarrierModule>false</CarrierModule>
+  <BattleshipModule>false</BattleshipModule>
   <CapitalModule>false</CapitalModule>
   <FreighterModule>false</FreighterModule>
   <PlatformModule>true</PlatformModule>

--- a/game/Content/ShipModules/Weapons/Events/DarkMatterCannon_1x2.xml
+++ b/game/Content/ShipModules/Weapons/Events/DarkMatterCannon_1x2.xml
@@ -10,7 +10,7 @@
   <FrigateModule>true</FrigateModule>
   <DestroyerModule>true</DestroyerModule>
   <CruiserModule>true</CruiserModule>
-  <CarrierModule>true</CarrierModule>
+  <BattleshipModule>true</BattleshipModule>
   <CapitalModule>true</CapitalModule>
   
   <FreighterModule>false</FreighterModule>

--- a/game/Content/ShipModules/Weapons/Events/DarkMatterCannon_2x2.xml
+++ b/game/Content/ShipModules/Weapons/Events/DarkMatterCannon_2x2.xml
@@ -10,7 +10,7 @@
   <FrigateModule>true</FrigateModule>
   <DestroyerModule>true</DestroyerModule>
   <CruiserModule>true</CruiserModule>
-  <CarrierModule>true</CarrierModule>
+  <BattleshipModule>true</BattleshipModule>
   <CapitalModule>true</CapitalModule>
   
   <FreighterModule>true</FreighterModule>

--- a/game/Content/ShipModules/Weapons/Events/DarkMatterCannon_3x3.xml
+++ b/game/Content/ShipModules/Weapons/Events/DarkMatterCannon_3x3.xml
@@ -10,7 +10,7 @@
   <FrigateModule>true</FrigateModule>
   <DestroyerModule>true</DestroyerModule>
   <CruiserModule>true</CruiserModule>
-  <CarrierModule>true</CarrierModule>
+  <BattleshipModule>true</BattleshipModule>
   <CapitalModule>true</CapitalModule>
   
   <FreighterModule>true</FreighterModule>


### PR DESCRIPTION
Feature: Introduce global multiplier for projectiles health (mainly for missiles)
Fix: AI - Excess number of defense fleet of AI for research stations. 
Fix: AI - Remnant ignoring research stations.
Fix: AI - Dont add defense fleet goal if too weak do complete it
Fix: Refit Research station continued even if the older station was destroyed.
Fix: Content - Using wrong CarrierModule insdead of BattleshipModule in xml (mainly causing ability to fit research modules on battleships)
