### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/AI/EmpireAI/EmpireAI.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.cs
@@ -268,12 +268,16 @@ namespace Ship_Game.AI
                         return false; // They warned us, so no need to warn them
 
                     // If they stole planets from us, we will value our targets more.
-                    // If we have more pop then them, we will cut them some slack and vice versa
+                    // If we have more max pop then them, we will cut them some slack and vice versa
                     // If we have nice relations, we will cut them some slack as well
+                    // If the planet is closer to them, consider that as well
                     Planet p = goal.TargetPlanet;
+                    float sqDistToUs = p.System.Position.SqDist(OwnerEmpire.WeightedCenter);
+                    float sqDistToThem = p.System.Position.SqDist(them.WeightedCenter);
+                    float distRatio = (sqDistToThem / sqDistToUs.LowerBound(1)).Clamped(0.1f, 3);
                     float popRatio = them.MaxPopBillion / OwnerEmpire.MaxPopBillion.LowerBound(1);
                     float valueToUs = p.ColonyPotentialValue(OwnerEmpire) * (usToThem.NumberStolenClaims + 1)
-                        * popRatio * ValueToUsMultiplerByRelations();
+                        * popRatio * distRatio * ValueToUsMultiplerByRelations();
                     float valueToThem = p.ColonyPotentialValue(them);
                     float ratio = valueToUs / valueToThem.LowerBound(1);
 

--- a/Ship_Game/AI/ExpansionAI/ResearchStationPlanner.cs
+++ b/Ship_Game/AI/ExpansionAI/ResearchStationPlanner.cs
@@ -52,7 +52,7 @@ namespace Ship_Game.AI.ExpansionAI
             if (planet != null && !planet.System.InSafeDistanceFromRadiation(planet.Position))
                 return;
 
-            float str = Owner.KnownEnemyStrengthIn(system);
+            float str = Owner.KnownEnemyStrengthNoResearchStationsIn(system);
             if (str > 0)
             {
                 TryClearArea(system, influense, Owner.AI.ThreatMatrix.GetStrongestHostileAt(system), str);

--- a/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
@@ -401,7 +401,7 @@ namespace Ship_Game.AI
             if (dps == 0f) // not all ships have DPS, so equate them with a weak ship
                 dps = 100f;
 
-            float value = (10000f * dps) / (tgt.Health + tgt.ShieldPower);
+            float value = (10000f * dps) / (tgt.Health + tgt.ShieldPower).LowerBound(1);
             value *= 1f + tgt.Carrier.AllFighterHangars.Length*0.75f;
             value *= 1 + tgt.TroopCapacity*0.5f;
             value *= 1 + (tgt.HasBombs ? tgt.BombBays.Count*2 : tgt.BombBays.Count*0.5f);

--- a/Ship_Game/AI/ThreatCluster.cs
+++ b/Ship_Game/AI/ThreatCluster.cs
@@ -17,6 +17,9 @@ public sealed class ThreatCluster : SpatialObjectBase
     // If the cluster is within a solarsystem
     [StarData] public SolarSystem System;
 
+    // Strength of all known ships in this threat cluster minus research stations
+    [StarData] public float StrengthNoResearchStations;
+
     // Strength of all known ships in this threat cluster
     [StarData] public float Strength;
 

--- a/Ship_Game/AI/ThreatClusterUpdate.cs
+++ b/Ship_Game/AI/ThreatClusterUpdate.cs
@@ -145,6 +145,7 @@ public sealed class ClusterUpdate
         bool inBorders = false;
         bool hasStarBases = false;
         float strength = 0f;
+        float researchStationsStrength = 0f;
         SolarSystem system = null;
 
         for (int i = 0; i < ships.Length; ++i)
@@ -153,6 +154,9 @@ public sealed class ClusterUpdate
             strength += s.GetStrength();
             if (s.IsStation)
                 hasStarBases = true;
+
+            if (s.IsResearchStation)
+                researchStationsStrength += s.GetStrength();
 
             if (!inBorders && s.IsInBordersOf(owner))
                 inBorders = true;
@@ -179,6 +183,7 @@ public sealed class ClusterUpdate
         //bool inBorders = owner.Universe.Influence.IsInInfluenceOf(owner, AveragePos);
 
         Cluster.Strength = strength;
+        Cluster.StrengthNoResearchStations = strength - researchStationsStrength;
         Cluster.Ships = ships;
         Cluster.HasStarBases = hasStarBases;
         Cluster.InBorders = inBorders;

--- a/Ship_Game/AI/ThreatMatrix.cs
+++ b/Ship_Game/AI/ThreatMatrix.cs
@@ -113,6 +113,14 @@ public sealed partial class ThreatMatrix
         return strength;
     }
 
+    static float GetStrengthNoResearchStations(ThreatCluster[] clusters)
+    {
+        float strength = 0f;
+        for (int i = 0; i < clusters.Length; ++i) // PERF: using for loop instead of lambdas
+            strength += clusters[i].StrengthNoResearchStations;
+        return strength;
+    }
+
     /// <summary> Get all strength of a specific empire (can be this.Owner) in a system</summary>
     public float GetStrengthAt(Empire empire, Vector2 pos, float radius)
     {
@@ -131,6 +139,12 @@ public sealed partial class ThreatMatrix
     public float GetHostileStrengthAt(Vector2 pos, float radius)
     {
         return GetStrength(FindHostileClusters(pos, radius));
+    }
+
+    /// <summary> Get all strength of all hostiles in a system without Research Stations Strength</summary>
+    public float GetHostileStrengthNoResearchStationsAt(Vector2 pos, float radius)
+    {
+        return GetStrengthNoResearchStations(FindHostileClusters(pos, radius));
     }
 
     record struct ThreatAggregate(Empire Loyalty, float Strength);

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -167,6 +167,7 @@ namespace Ship_Game
         [StarData] public bool AutoPickBestColonizer;
         [StarData] public bool AutoBuildTerraformers;
         [StarData] public bool AutoPickBestResearchStation;
+        [StarData] public bool SymmetricDesignMode = true;
         [StarData] public Array<string> ObsoletePlayerShipModules;
 
         public int AtWarCount;

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -343,6 +343,11 @@ namespace Ship_Game
 
         public float KnownEnemyStrengthIn(SolarSystem s, Empire e) => AI.ThreatMatrix.GetHostileStrengthAt(e, s.Position, s.Radius);
         public float KnownEnemyStrengthIn(SolarSystem s) => AI.ThreatMatrix.GetHostileStrengthAt(s.Position, s.Radius);
+        public float KnownEnemyStrengthNoResearchStationsIn(Vector2 pos, float radius) 
+            => AI.ThreatMatrix.GetHostileStrengthNoResearchStationsAt(pos, radius);
+
+        public float KnownEnemyStrengthNoResearchStationsIn(SolarSystem s) 
+            => AI.ThreatMatrix.GetHostileStrengthNoResearchStationsAt(s.Position, s.Radius);
         public float KnownEmpireStrength(Empire e) => AI.ThreatMatrix.KnownEmpireStrength(e);
 
         public WeaponTagModifier WeaponBonuses(WeaponTag which) => data.WeaponTags[which];

--- a/Ship_Game/EmpireDifficultyModifers.cs
+++ b/Ship_Game/EmpireDifficultyModifers.cs
@@ -91,7 +91,7 @@
                     ExpansionCheckInterval = 7; // every 7 turns
                     MinStartingColonies  = 3;
                     ExpandSearchTurns    = 50;
-                    RemnantTurnsLevelUp  = 400;
+                    RemnantTurnsLevelUp  = 350;
                     RemnantResourceMod   = 0.35f;
                     RemnantNumBombers    = 0.75f;
                     BaseColonyGoals      = 2;
@@ -128,7 +128,7 @@
                     ExpansionCheckInterval = 5; // every 5 turns
                     MinStartingColonies  = 5;
                     ExpandSearchTurns    = 30;
-                    RemnantTurnsLevelUp  = 350;
+                    RemnantTurnsLevelUp  = 325;
                     RemnantResourceMod   = 0.45f;
                     RemnantNumBombers    = 1f;
                     BaseColonyGoals      = 4;
@@ -212,7 +212,7 @@
                     ExpansionCheckInterval = 1; // every turn, there is no limit!
                     MinStartingColonies  = 6;
                     ExpandSearchTurns    = 20;
-                    RemnantTurnsLevelUp  = 300;
+                    RemnantTurnsLevelUp  = 275;
                     RemnantResourceMod   = 0.7f;
                     RemnantNumBombers    = 1.5f;
                     BaseColonyGoals      = 6;

--- a/Ship_Game/EmpirePersonalityModifiers.cs
+++ b/Ship_Game/EmpirePersonalityModifiers.cs
@@ -64,7 +64,7 @@ namespace Ship_Game
                     WarSneakiness         = 0;
                     break;
                 case PersonalityType.Aggressive:
-                    ColonizationClaimRatioWarningThreshold = 0.7f;
+                    ColonizationClaimRatioWarningThreshold = 0.9f;
                     AddAngerAlliedWithEnemies3RdParty      = 75;
                     TurnsAbove95FederationNeeded = 350;
                     TurnsAbove95AllianceTreshold = 300;
@@ -92,7 +92,7 @@ namespace Ship_Game
                     WarSneakiness         = 5;
                     break;
                 case PersonalityType.Ruthless:
-                    ColonizationClaimRatioWarningThreshold = 0.6f;
+                    ColonizationClaimRatioWarningThreshold = 0.8f;
                     AddAngerAlliedWithEnemies3RdParty      = 75;
                     TurnsAbove95FederationNeeded = 420;
                     TurnsAbove95AllianceTreshold = 250;
@@ -120,7 +120,7 @@ namespace Ship_Game
                     WarSneakiness         = 0;
                     break;
                 case PersonalityType.Xenophobic:
-                    ColonizationClaimRatioWarningThreshold = 0;
+                    ColonizationClaimRatioWarningThreshold = 0.6f;
                     AddAngerAlliedWithEnemies3RdParty      = 100;
                     TurnsAbove95FederationNeeded = 600;
                     TurnsAbove95AllianceTreshold = 200;

--- a/Ship_Game/Empire_Relationship.cs
+++ b/Ship_Game/Empire_Relationship.cs
@@ -506,17 +506,6 @@ namespace Ship_Game
             DiplomacyContactQueue.Add(new DiplomacyQueueItem{ EmpireId = empire.Id, Dialog = dialog});
         }
 
-        public float ColonizationDetectionChance(Relationship usToThem, Empire them)
-        {
-            float chance = 0;
-            if (usToThem.Treaty_NAPact)      chance = 0.25f;
-            if (usToThem.Treaty_Trade)       chance = 0.5f;
-            if (usToThem.Treaty_OpenBorders) chance = 0.75f;
-            if (usToThem.Treaty_Alliance)    chance = 1;
-
-            return IsCunning ? chance * 2 : chance;
-        }
-
         public bool TryGetActiveWars(out Array<War> activeWars)
         {
             activeWars = new Array<War>();

--- a/Ship_Game/Empire_Relationship.cs
+++ b/Ship_Game/Empire_Relationship.cs
@@ -628,12 +628,12 @@ namespace Ship_Game
             }
         }
 
-        // Aggressive AIs will surrender to the enemy if the enemy is aggressive.
+        // Aggressive AIs will surrender to the enemy if the enemy is aggressive or is the player.
         // If not, they will try to merge with the strongest allied empire or
-        // the strongets empire which is at war.
+        // the strongest empire which is at war.
         bool TryMergeOrSurrenderAggressive(Empire enemy, Empire[] potentialEmpires)
         {
-            if (enemy.IsAggressive)
+            if (enemy.IsAggressive || enemy.isPlayer)
                 return MergeWith(enemy, enemy);
             
             var strongest = potentialEmpires.FindMax(e => e.CurrentMilitaryStrength);
@@ -677,8 +677,8 @@ namespace Ship_Game
             return false;
         }
 
-        // Pacifist AIs will try to merge with the closest empires which are not at war
-        // or with closest Pacifist empire.
+        // Pacifist AIs will try to merge with the closest empire which is not at war with someone
+        // or with closest Pacifist/Player empire.
         bool TryMergeOrSurrenderPacifist(Empire enemy, Empire[] potentialEmpires)
         {
             var closestNotAtWar = potentialEmpires
@@ -687,7 +687,7 @@ namespace Ship_Game
             if (closestNotAtWar == null)
             {
                 var closestPacifist = potentialEmpires
-                    .FindMinFiltered(e => e.IsPacifist, e => e.WeightedCenter.SqDist(WeightedCenter));
+                    .FindMinFiltered(e => e.IsPacifist || e.isPlayer, e => e.WeightedCenter.SqDist(WeightedCenter));
 
                 if (closestPacifist != null)
                     return MergeWith(closestPacifist, enemy);
@@ -700,10 +700,10 @@ namespace Ship_Game
             return false;
         }
 
-        // Cunning AIs will try to merge with the biggest empire around
+        // Cunning AIs will try to merge with the best empire around (including the enemies)
         bool TryMergeOrSurrenderCunning(Empire enemy, Empire[] potentialEmpires)
         {
-            var biggest = potentialEmpires.FindMax(e => e.TotalPopBillion);
+            var biggest = potentialEmpires.FindMax(e => e.TotalScore);
             if (biggest != null)
                 return MergeWith(biggest, enemy);
             return false;

--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignScreen.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignScreen.cs
@@ -88,7 +88,7 @@ namespace Ship_Game
 
         public HangarOptions HangarDesignation => HangarOptionsList.ActiveValue;
 
-        public bool IsSymmetricDesignMode { get; set; } = true; // start with enabled by default
+        public bool IsSymmetricDesignMode => Player.SymmetricDesignMode; // start with enabled by default
 
         public bool IsFilterOldModulesMode
         {

--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignScreenInput.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignScreenInput.cs
@@ -414,8 +414,8 @@ namespace Ship_Game
 
         void OnSymmetricDesignToggle()
         {
-            IsSymmetricDesignMode    = !IsSymmetricDesignMode;
-            BtnSymmetricDesign.Style = SymmetricDesignBtnStyle;
+            Player.SymmetricDesignMode = !Player.SymmetricDesignMode;
+            BtnSymmetricDesign.Style   = SymmetricDesignBtnStyle;
         }
 
         void OnFilterModuleToggle()

--- a/Ship_Game/Gameplay/WeaponTemplate.cs
+++ b/Ship_Game/Gameplay/WeaponTemplate.cs
@@ -284,53 +284,53 @@ namespace Ship_Game.Gameplay
             }
 
             //Doctor: Guided weapons attract better offensive rating than unguided - more likely to hit
-            off *= t.Tag_Guided ? 3f : 1f;
+            off *= t.Tag_Guided ? 2.5f : 1f;
 
             off *= 1 + t.ArmorPen * 0.2f;
             // FB: simpler calcs for these.
-            off *= t.EffectVsArmor > 1 ? 1f + (t.EffectVsArmor - 1f) / 2f : 1f;
-            off *= t.EffectVsArmor < 1 ? 1f - (1f - t.EffectVsArmor) / 2f : 1f;
-            off *= t.EffectVsShields > 1 ? 1f + (t.EffectVsShields - 1f) / 2f : 1f;
-            off *= t.EffectVsShields < 1 ? 1f - (1f - t.EffectVsShields) / 2f : 1f;
+            off *= t.EffectVsArmor > 1 ? 1f + (t.EffectVsArmor - 1f) * 0.5f : 1f;
+            off *= t.EffectVsArmor < 1 ? 1f - (1f - t.EffectVsArmor) * 0.5f : 1f;
+            off *= t.EffectVsShields > 1 ? 1f + (t.EffectVsShields - 1f) * 0.5f : 1f;
+            off *= t.EffectVsShields < 1 ? 1f - (1f - t.EffectVsShields) * 0.5f : 1f;
 
             off *= t.TruePD ? 0.2f : 1f;
             off *= t.Tag_Intercept && (t.Tag_Missile || t.Tag_Torpedo) ? 0.8f : 1f;
             off *= t.ProjectileSpeed > 1 ? t.ProjectileSpeed / t.BaseRange : 1f;
 
             // FB: Missiles which can be intercepted might get str modifiers
-            off *= t.Tag_Intercept && t.RotationRadsPerSecond > 1 ? 1 + t.HitPoints / 50 / t.ProjectileRadius.LowerBound(2) : 1;
+            off *= t.Tag_Intercept && t.RotationRadsPerSecond > 1 ? 1 + t.HitPoints * 0.02f / t.ProjectileRadius.LowerBound(2) : 1;
 
             // FB: offense calcs for damage radius
-            off *= t.ExplosionRadius > 16 && !t.TruePD ? t.ExplosionRadius / 16 : 1f;
+            off *= t.ExplosionRadius > 16 && !t.TruePD ? t.ExplosionRadius * 0.0625f : 1f;
 
             // FB: Added shield pen chance
-            off *= 1 + t.ShieldPenChance / 100;
+            off *= 1 + t.ShieldPenChance * 0.01f;
 
             if (t.TerminalPhaseAttack)
             {
                 if (t.TerminalPhaseSpeedMod > 1)
-                    off *= 1 + t.TerminalPhaseDistance * t.TerminalPhaseSpeedMod / 50000;
+                    off *= 1 + t.TerminalPhaseDistance * t.TerminalPhaseSpeedMod * 0.00002f;
                 else
-                    off *= t.TerminalPhaseSpeedMod / 2;
+                    off *= t.TerminalPhaseSpeedMod * 0.5f;
             }
 
             if (t.DelayedIgnition.Greater(0))
-                off *= 1 - (t.DelayedIgnition / 10).UpperBound(0.95f);
+                off *= 1 - (t.DelayedIgnition * 0.1f).UpperBound(0.95f);
 
 
             // FB: Added correct exclusion offense calcs
             float exclusionMultiplier = 1;
-            if (t.ExcludesFighters) exclusionMultiplier -= 0.15f;
+            if (t.ExcludesFighters)  exclusionMultiplier -= 0.15f;
             if (t.ExcludesCorvettes) exclusionMultiplier -= 0.15f;
-            if (t.ExcludesCapitals) exclusionMultiplier -= 0.45f;
-            if (t.ExcludesStations) exclusionMultiplier -= 0.25f;
+            if (t.ExcludesCapitals)  exclusionMultiplier -= 0.45f;
+            if (t.ExcludesStations)  exclusionMultiplier -= 0.25f;
             off *= exclusionMultiplier;
 
             // Imprecision gets worse when range gets higher
-            off *= !t.Tag_Guided ? (1 - t.FireImprecisionAngle * 0.01f * (t.BaseRange / 2000)).LowerBound(0.1f) : 1f;
+            off *= !t.Tag_Guided ? (1 - t.FireImprecisionAngle * 0.01f * (t.BaseRange * 0.0005f)).LowerBound(0.1f) : 1f;
 
             // FB: Range margins are less steep for missiles
-            off *= (!t.Tag_Guided ? (t.BaseRange / 4000) * (t.BaseRange / 4000) : (t.BaseRange / 4000));
+            off *= (!t.Tag_Guided ? (t.BaseRange * 0.00025f) * (t.BaseRange * 0.00025f) : (t.BaseRange * 0.00025f));
 
             // Multiple warheads
             if (t.IsMirv)
@@ -353,7 +353,7 @@ namespace Ship_Game.Gameplay
 
             // FB: Field of Fire is also important
             if (!t.IsMirv) // Only for non Mirv since this should be calculated once
-                off *= (m.FieldOfFire / (RadMath.PI / 3)).Clamped(1,4);
+                off *= (m.FieldOfFire / (RadMath.PI * 0.34f)).Clamped(1,4);
 
             // Doctor: If there are manual XML override modifiers to a weapon for manual balancing, apply them.
             return off * t.OffPowerMod;

--- a/Ship_Game/Remnants.cs
+++ b/Ship_Game/Remnants.cs
@@ -1008,7 +1008,7 @@ namespace Ship_Game
 
         void AddGuardians(int numShips, RemnantShipType type, Planet p)
         {
-            int divider = 7 * ((int)Universe.P.Difficulty).LowerBound(1); // harder game = earlier activation
+            int divider = 8 * ((int)Universe.P.Difficulty).LowerBound(1); // harder game = earlier activation
             for (int i = 0; i < numShips; ++i)
             {
                 Vector2 pos = p.Position.GenerateRandomPointInsideCircle(p.Radius * 2, Random);
@@ -1046,29 +1046,6 @@ namespace Ship_Game
             AncientPeaceKeepers
         }
     }
-
-    /*
-    public void CheckArmageddon()
-    {
-        if (Armageddon)
-        {
-            if (!Paused) ArmageddonTimer -= elapsedTime;
-            if (ArmageddonTimer < 0.0)
-            {
-                ArmageddonTimer = 300f;
-                ++ArmageddonCounter;
-                if (ArmageddonCounter > 5)
-                    ArmageddonCounter = 5;
-                for (int i = 0; i < ArmageddonCounter; ++i)
-                {
-                    Ship exterminator = Ship.CreateShipAtPoint("Remnant Exterminator", EmpireManager.Remnants,
-                            player.GetWeightedCenter() + new Vector2(RandomMath.RandomBetween(-500000f, 500000f),
-                                RandomMath.RandomBetween(-500000f, 500000f)));
-                    exterminator.AI.DefaultAIState = AIState.Exterminate;
-                }
-            }
-        }
-    }*/
 
     public enum RemnantShipType
     {

--- a/Ship_Game/Remnants.cs
+++ b/Ship_Game/Remnants.cs
@@ -177,7 +177,7 @@ namespace Ship_Game
             switch (Story)
             {
                 case RemnantStory.AncientExterminators: return 1.2f;
-                case RemnantStory.AncientRaidersRandom: return 0.9f;
+                case RemnantStory.AncientRaidersRandom: return 0.8f;
                 default:                                return 1;
             }
         }
@@ -377,7 +377,8 @@ namespace Ship_Game
                                                                     && s.Loyalty == Owner 
                                                                     && s.IsGuardian
                                                                     && !s.IsPlatformOrStation
-                                                                    && !s.InCombat);
+                                                                    && !s.InCombat
+                                                                    && s.AI.State != AIState.Resupply);
             if (availableShips.Length == 0)
                 return false;
 
@@ -1026,15 +1027,13 @@ namespace Ship_Game
             if (Universe.P.DisableRemnantStory)
                 return RemnantStory.None;
 
-            switch (Random.RollDie(5))
-            {
-                default:
-                case 1: return RemnantStory.AncientBalancers;
-                case 2: return RemnantStory.AncientExterminators;
-                case 3: return RemnantStory.AncientRaidersRandom;
-                case 4: return RemnantStory.AncientWarMongers;
-                case 5: return RemnantStory.AncientPeaceKeepers;
-            }
+            float roll = Random.RollDie(100);
+            if (roll <= 10)  return RemnantStory.AncientPeaceKeepers;
+            if (roll <= 20)  return RemnantStory.AncientWarMongers;
+            if (roll <= 40)  return RemnantStory.AncientExterminators;
+            if (roll <= 60)  return RemnantStory.AncientRaidersRandom;
+
+            return RemnantStory.AncientBalancers;
         }
 
         public enum RemnantStory

--- a/Ship_Game/Ships/Ship_ModuleGrid.cs
+++ b/Ship_Game/Ships/Ship_ModuleGrid.cs
@@ -530,8 +530,6 @@ namespace Ship_Game.Ships
                 {
                     if (mq.Module.DamageExplosive(damageSource, ref rootDamage))
                         return; // Root module absorbed all the explosion
-                    else
-                        damageAmount = remainingDamage = diagonalDamage = rootDamage * 0.25f; // This is the new damage after root module exploded
                 }
                 else
                 {

--- a/UnitTests/AITests/Empire/TestEmpireAI.cs
+++ b/UnitTests/AITests/Empire/TestEmpireAI.cs
@@ -76,7 +76,7 @@ namespace UnitTests.AITests.Empire
                 // create the ship
                 var ship = SpawnShip(shipName, Player, Vector2.Zero);
                 float shipMaint = ship.GetMaintCost();
-                AssertLessThan(shipMaint, roleUnitMaint, "Ship maintenance must be less than role unit maintenance");
+                AssertLessThanOrEqual(shipMaint, roleUnitMaint, "Ship maintenance must be less than or equal role unit maintenance");
 
                 float currentMaint = build.RoleCurrentMaintenance(combatRole);
                 AssertEqual(roleUnitMaint * count, currentMaint, "Current maintenance should equal projected");

--- a/UnitTests/StarDriveTest.Assert.cs
+++ b/UnitTests/StarDriveTest.Assert.cs
@@ -271,8 +271,18 @@ public partial class StarDriveTest
             throw new AssertFailedException($"Greater Than failed: {actual} > {greaterThan}  {message}");
     }
 
+    /// <summary>
+    /// Asserts that `actual` value is less than or equals the provided value
+    /// e.g. AssertLessThanOrEqual(healthPercent, 0.5f);
+    /// </summary>
+    public static void AssertLessThanOrEqual<T>(T actual, T lessThan, string message = "") where T : IComparable<T>
+    {
+        if (actual.CompareTo(lessThan) > 0)
+            throw new AssertFailedException($"LessThanOrEqual failed: {actual} < {lessThan}  {message}");
+    }
+
     /////////////////////////////////////////////////////////////////////////////////////////////
-            
+
     static string Msg(string message, object expected, object actual)
     {
         string expectedString = Stringify(expected);


### PR DESCRIPTION
Feature: Sticky Symmetric design button (brought it back, with save stickiness)
Balance: Minor tweaks to surrender logic
Balance: Remnant Tweaks
Fix: Improve Defense Fleet dispatch logic for research station defense.
Fix: Don't build SSP node if they are killed by remnants / hostiles for sometime ,even after threat is not seen.
Balance: Claim logic. remove detection chances and only use ability to see to discover colonization efforts. AI will less likely to warn if having good relations. But also consider distance of the claim from empire centers
Fix: Some cases allowed smaller empires to absorb bigger empires in peaceful merge