### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/AI/EmpireAI/EmpireAI.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.cs
@@ -174,6 +174,12 @@ namespace Ship_Game.AI
                 goal.RemoveTask(task);
         }
 
+        public void RemoveFleetFromGoals(Fleet fleet)
+        {
+            foreach (Goal goal in Goals)
+                goal.RemoveFleet(fleet);
+        }
+
         public void DebugRunResearchPlanner()
         {
             // unlock 5 techs with a focus on ship tech

--- a/Ship_Game/AI/EmpireAI/EmpireAI.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.cs
@@ -168,6 +168,12 @@ namespace Ship_Game.AI
             TasksToRemove.Clear();
         }
 
+        public void RemoveTaskFromGoals(MilitaryTask task)
+        {
+            foreach (Goal goal in Goals)
+                goal.RemoveTask(task);
+        }
+
         public void DebugRunResearchPlanner()
         {
             // unlock 5 techs with a focus on ship tech

--- a/Ship_Game/AI/Goal.cs
+++ b/Ship_Game/AI/Goal.cs
@@ -7,6 +7,7 @@ using Ship_Game.Universe;
 using Vector2 = SDGraphics.Vector2;
 using Ship_Game.Commands.Goals;
 using Ship_Game.AI.Tasks;
+using Ship_Game.Fleets;
 
 namespace Ship_Game.AI
 {
@@ -149,6 +150,8 @@ namespace Ship_Game.AI
         public virtual void RemoveTask(MilitaryTask task)
         { }
 
+        public virtual void RemoveFleet(Fleet fleet)
+        { }
         /////////////////////////////////////////////////////
 
         public string TypeName => GetType().GetTypeName();

--- a/Ship_Game/AI/Goal.cs
+++ b/Ship_Game/AI/Goal.cs
@@ -6,6 +6,7 @@ using Ship_Game.Data.Serialization;
 using Ship_Game.Universe;
 using Vector2 = SDGraphics.Vector2;
 using Ship_Game.Commands.Goals;
+using Ship_Game.AI.Tasks;
 
 namespace Ship_Game.AI
 {
@@ -144,6 +145,9 @@ namespace Ship_Game.AI
         public virtual bool IsWarMissionTarget(Empire empire) => false;
         /** @return True if this is an Inhibitor Invesgitation in the area */
         public virtual bool IsInvsestigationHere(Vector2 pos) => false;
+
+        public virtual void RemoveTask(MilitaryTask task)
+        { }
 
         /////////////////////////////////////////////////////
 

--- a/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
@@ -324,9 +324,10 @@ namespace Ship_Game.AI
 
         bool DoExploreSystem(FixedSimTime timeStep)
         {
-            if (Owner.System == ExplorationTarget 
+            if (Owner.System != null 
                 && BadGuysNear 
-                && ExplorationTarget.ShipList.Any(s => s.AI.Target == Owner))
+                && Owner.System.ShipList.Any(s => s.AI.Target == Owner)
+                && !Owner.IsInWarp)
             {
                 ClearOrders();
                 if (Owner.TryGetScoutFleeVector(out Vector2 escapePos))

--- a/Ship_Game/AI/Tasks/MilitaryTask.cs
+++ b/Ship_Game/AI/Tasks/MilitaryTask.cs
@@ -404,16 +404,16 @@ namespace Ship_Game.AI.Tasks
                 default:
                 case TaskType.ReclaimPlanet:
                 case TaskType.GlassPlanet:
-                case TaskType.AssaultPlanet:        priority = 5;                                                   break;
-                case TaskType.ClearAreaOfEnemies:   priority = TargetSystem.DefenseTaskPriority(Owner, Importance); break;
-                case TaskType.StageFleet:           priority = 2 * (numWars * 2).LowerBound(1);                     break;
-                case TaskType.GuardBeforeColonize:  priority = 3 + numWars;                                         break;
-                case TaskType.DefendVsRemnants:     priority = 0;                                                   break;
-                case TaskType.StrikeForce:          priority = 2;                                                   break;
-                case TaskType.Exploration:          priority = GetExplorationPriority();                            break;
-                case TaskType.DefendClaim:          priority = 5 + numWars * 2;                                     break;
-                case TaskType.AssaultPirateBase:    priority = GetAssaultPirateBasePriority();                      break;
-                case TaskType.InhibitorInvestigate: priority = 3;                                                   break;
+                case TaskType.AssaultPlanet:        priority = 5;                                            break;
+                case TaskType.ClearAreaOfEnemies:   priority = TargetSystem.DefenseTaskPriority(Importance); break;
+                case TaskType.StageFleet:           priority = 2 * (numWars * 2).LowerBound(1);              break;
+                case TaskType.GuardBeforeColonize:  priority = 3 + numWars;                                  break;
+                case TaskType.DefendVsRemnants:     priority = 0;                                            break;
+                case TaskType.StrikeForce:          priority = 2;                                            break;
+                case TaskType.Exploration:          priority = GetExplorationPriority();                     break;
+                case TaskType.DefendClaim:          priority = 5 + numWars * 2;                              break;
+                case TaskType.AssaultPirateBase:    priority = GetAssaultPirateBasePriority();               break;
+                case TaskType.InhibitorInvestigate: priority = 3;                                            break;
             }
 
             if (TargetEmpire == Owner.Universe.Player && Owner.Universe.Player.AllActiveWars.Length <= Owner.DifficultyModifiers.WarTaskPriorityMod)

--- a/Ship_Game/AI/Tasks/MilitaryTask.cs
+++ b/Ship_Game/AI/Tasks/MilitaryTask.cs
@@ -230,7 +230,7 @@ namespace Ship_Game.AI.Tasks
                 return;
 
             Owner.AI.QueueForRemoval(this);
-
+            Owner.AI.RemoveTaskFromGoals(this);
 
             if (Owner.IsFaction)
             {

--- a/Ship_Game/AI/Tasks/MilitaryTask_Requistions.cs
+++ b/Ship_Game/AI/Tasks/MilitaryTask_Requistions.cs
@@ -141,7 +141,8 @@ namespace Ship_Game.AI.Tasks
 
         void RequisitionDefenseForce()
         {
-            if (!Owner.SystemsWithThreat.Any(t => !t.ThreatTimedOut && t.TargetSystem == TargetSystem)
+            if (!Owner.IsSystemUnderThreatForUs(TargetSystem) 
+                && !Owner.IsSystemUnderThreatForAllies(TargetSystem)
                 && !TargetSystem.DangerousForcesPresent(Owner))
             {
                 EndTask();
@@ -373,8 +374,8 @@ namespace Ship_Game.AI.Tasks
             switch (Importance)
             {
                 default:
-                case MilitaryTaskImportance.Normal:    minStr = MinimumTaskForceStrength; break;
-                case MilitaryTaskImportance.Important: minStr = Owner.OffensiveStrength;  break;
+                case MilitaryTaskImportance.Normal:    minStr = MinimumTaskForceStrength;       break;
+                case MilitaryTaskImportance.Important: minStr = Owner.OffensiveStrength * 0.5f; break;
             }
 
             return minStr * GetBuildCapacityMultiplier();

--- a/Ship_Game/Commands/Goals/EmpireDefense.cs
+++ b/Ship_Game/Commands/Goals/EmpireDefense.cs
@@ -60,7 +60,7 @@ namespace Ship_Game.Commands.Goals
                         minStr *= Owner.GetFleetStrEmpireMultiplier(threatenedSystem.Enemies[0]).UpperBound(Owner.OffensiveStrength / 5);
 
                     var importance = systemOwner == Owner ? MilitaryTaskImportance.Important : MilitaryTaskImportance.Normal;
-                    int fleetswanted = 5 - targetSys.DefenseTaskPriority(systemOwner, importance);
+                    int fleetswanted = 3 - (int)importance;
                     Owner.AddDefenseSystemGoal(targetSys, minStr, importance, fleetswanted, systemOwner);
                 }
             }
@@ -135,7 +135,7 @@ namespace Ship_Game.Commands.Goals
 
         bool ShouldConsiderDefendingAlly(SolarSystem system, Empire ally)
         {
-            float  priority = (system.DefenseTaskPriority(ally) * 0.2f).Clamped(0.2f, 1f);  // lower is more important
+            float  priority = (system.DefenseTaskPriority() * 0.2f).Clamped(0.1f, 1f);  // lower is more important
             float distanceToThem = system.Position.Distance(ally.WeightedCenter);
             float distanceToUs   = system.Position.Distance(Owner.WeightedCenter) * priority;
             float ratio = distanceToUs / distanceToThem.LowerBound(1);

--- a/Ship_Game/Commands/Goals/FleetGoal.cs
+++ b/Ship_Game/Commands/Goals/FleetGoal.cs
@@ -21,5 +21,11 @@ namespace Ship_Game.Commands.Goals
             if (Task == task)
                 Task = null;    
         }
+
+        public override void RemoveFleet(Fleet fleet)
+        {
+            if (Fleet == fleet)
+                Fleet = null;
+        }
     }
 }

--- a/Ship_Game/Commands/Goals/FleetGoal.cs
+++ b/Ship_Game/Commands/Goals/FleetGoal.cs
@@ -15,5 +15,11 @@ namespace Ship_Game.Commands.Goals
         protected FleetGoal(GoalType type, Empire owner) : base(type, owner)
         {
         }
+
+        public override void RemoveTask(MilitaryTask task)
+        {
+            if (Task == task)
+                Task = null;    
+        }
     }
 }

--- a/Ship_Game/Commands/Goals/ScoutSystem.cs
+++ b/Ship_Game/Commands/Goals/ScoutSystem.cs
@@ -83,6 +83,7 @@ namespace Ship_Game.Commands.Goals
                 return GoalStep.RestartGoal;
 
             if (FinishedShip.AI.BadGuysNear
+                && !FinishedShip.IsInWarp
                 && FinishedShip.System == FinishedShip.AI.ExplorationTarget
                 && FinishedShip.System.ShipList.Any(s => s.AI.Target == FinishedShip))
             {

--- a/Ship_Game/Commands/Goals/WarMission.cs
+++ b/Ship_Game/Commands/Goals/WarMission.cs
@@ -74,8 +74,8 @@ namespace Ship_Game.Commands.Goals
 
             if (LifeTime > Owner.PersonalityModifiers.WarTasksLifeTime && Task.Fleet == null) // check for timeout
             {
-                Task.EndTask();
                 Log.Info(ConsoleColor.Green, $"---- WarMission: Timed out {Task.Type} vs. {TargetEmpire.Name} ----");
+                Task.EndTask();
                 return GoalStep.GoalFailed;
             }
 

--- a/Ship_Game/Debug/DebugInfoScreen.cs
+++ b/Ship_Game/Debug/DebugInfoScreen.cs
@@ -146,6 +146,7 @@ public sealed partial class DebugInfoScreen : GameScreen
             DebugModes.Tasks => new TasksDebug(this),
             DebugModes.Perf => new PerfDebug(this),
             DebugModes.SpaceRoads=> new SpaceRoadsDebug(this),
+            DebugModes.Goals => new EmpireGoalsDebug(this),
             _ => null
         };
     }

--- a/Ship_Game/Debug/DebugModes.cs
+++ b/Ship_Game/Debug/DebugModes.cs
@@ -25,6 +25,7 @@ public enum DebugModes
     Tasks,
     Particles,
     SpaceRoads,
+    Goals,
 
 
     // this should always be the last valid page

--- a/Ship_Game/Debug/Page/EmpireGoalsDebug.cs
+++ b/Ship_Game/Debug/Page/EmpireGoalsDebug.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+using SDUtils;
+using Ship_Game.AI;
+using Ship_Game.Commands.Goals;
+using Ship_Game.Gameplay;
+using Ship_Game.Ships;
+using System.Linq;
+using System.Reflection;
+
+namespace Ship_Game.Debug.Page;
+
+public class EmpireGoalsDebug : DebugPage
+{
+    bool ShowGoalStep = false;
+    public EmpireGoalsDebug(DebugInfoScreen parent) : base(parent, DebugModes.Goals)
+    {
+        var list = AddList(50, 160);
+        list.AddCheckbox(() => ShowGoalStep, "Show Goalsteps", "Show Goalsteps");
+    }
+
+    public override void Draw(SpriteBatch batch, DrawTimes elapsed)
+    {
+        if (!Visible)
+            return;
+
+        int column = 0;
+        foreach (Empire e in Universe.MajorEmpires)
+        {
+            if (!e.IsDefeated)
+            {
+                DrawEmpireGoals(e, column);
+                ++column;
+            }
+        }
+        base.Draw(batch, elapsed);
+    }
+
+    void DrawEmpireGoals(Empire e, int column)
+    {
+        Text.SetCursor(Parent.Win.X + 10 + 255 * column, Parent.Win.Y + 95, e.EmpireColor);
+        Text.String(e.data.Traits.Name);
+        Text.String(e.EmpireColor, "----------------------");
+        Text.String(e.EmpireColor, $"Total Goals: {e.AI.Goals.Count.String()}");
+        Text.String(e.EmpireColor, "----------------------");
+        Text.NewLine();
+
+        Text.String(e.EmpireColor, "New Goals");
+        Text.String(e.EmpireColor, "---------------------");
+        int counter = 0;
+        for (int i = e.AI.Goals.Count - 1; i >= 0; i--)
+        {
+            Goal goal = e.AI.Goals[i];
+            DrawGoals(goal.LifeTime, goal.TypeName, goal.StepName, e.EmpireColor, ref counter, newGoal: true);
+        }
+
+        Text.NewLine(2);
+        Text.String(e.EmpireColor, $"Older Goals:");
+        Text.String(e.EmpireColor, "----------------------");
+        counter = 0;
+        for (int i = e.AI.Goals.Count - 1; i >= 0; i--) 
+        {
+            Goal goal = e.AI.Goals[i];
+            DrawGoals(goal.LifeTime, goal.TypeName, goal.StepName, e.EmpireColor, ref counter, newGoal: false);
+        }
+    }
+
+
+    void DrawGoals(float lifetimeInt, string name, string step, Color color, ref int counter, bool newGoal)
+    {
+        lifetimeInt = (int)((lifetimeInt + 0.01) * 10);
+        if (newGoal && lifetimeInt <= 20 || !newGoal && lifetimeInt > 20)
+        {
+            counter++;
+            Text.String(color, $"{counter}) {name} ({lifetimeInt.String()})");
+            if (ShowGoalStep)
+                Text.String(color, $"   -> {step}");
+        }
+    }
+    public override bool HandleInput(InputState input)
+    {
+        return base.HandleInput(input);
+    }
+    /*
+    public override void Update(float fixedDeltaTime)
+    {
+        base.Update(fixedDeltaTime);
+    }*/
+}

--- a/Ship_Game/Debug/Page/EmpireGoalsDebug.cs
+++ b/Ship_Game/Debug/Page/EmpireGoalsDebug.cs
@@ -14,7 +14,7 @@ public class EmpireGoalsDebug : DebugPage
     bool ShowGoalStep = false;
     public EmpireGoalsDebug(DebugInfoScreen parent) : base(parent, DebugModes.Goals)
     {
-        var list = AddList(50, 160);
+        var list = AddList(550, 130);
         list.AddCheckbox(() => ShowGoalStep, "Show Goalsteps", "Show Goalsteps");
     }
 
@@ -37,7 +37,7 @@ public class EmpireGoalsDebug : DebugPage
 
     void DrawEmpireGoals(Empire e, int column)
     {
-        Text.SetCursor(Parent.Win.X + 10 + 255 * column, Parent.Win.Y + 95, e.EmpireColor);
+        Text.SetCursor(Parent.Win.X + 10 + 255 * column, Parent.Win.Y + 65, e.EmpireColor);
         Text.String(e.data.Traits.Name);
         Text.String(e.EmpireColor, "----------------------");
         Text.String(e.EmpireColor, $"Total Goals: {e.AI.Goals.Count.String()}");

--- a/Ship_Game/Debug/Page/EmpireInfoDebug.cs
+++ b/Ship_Game/Debug/Page/EmpireInfoDebug.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 using SDUtils;
 using Ship_Game.AI;
-using Ship_Game.AI.Tasks;
 using Ship_Game.Commands.Goals;
 using Ship_Game.Gameplay;
 using Ship_Game.Ships;

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -2383,18 +2383,27 @@ namespace Ship_Game
             return rel?.IsHostile == true;
         }
 
-        public IEnumerable<IncomingThreat> AlliedSystemsWithThreat()
+        public IEnumerable<IncomingThreat> AlliedSystemsWithThreat(bool checkAttackable = false)
         {
             foreach (Empire e in Universe.MajorEmpires.Filter(e => e.IsAlliedWith(this)))
             {
                 for (int i = e.SystemsWithThreat.Length - 1; i >= 0; i--)
                 {
                     IncomingThreat threat = e.SystemsWithThreat[i];
-                    if (!threat.TargetSystem.HasPlanetsOwnedBy(this))
+                    if (!threat.TargetSystem.HasPlanetsOwnedBy(this)
+                        && (!checkAttackable || threat.Enemies.Any(e => IsEmpireAttackable(e))))
+                    {
                         yield return threat;
+                    }
                 }
             }
         }
+
+        public bool IsSystemUnderThreatForUs(SolarSystem system)
+            => SystemsWithThreat.Any(t => !t.ThreatTimedOut && t.TargetSystem == system);
+
+        public bool IsSystemUnderThreatForAllies(SolarSystem system) 
+            => AlliedSystemsWithThreat().Any(t => !t.ThreatTimedOut && t.TargetSystem == system);
 
         public bool WillInhibit(Empire e) => e != this && !e.WeAreRemnants && IsAtWarWith(e);
 

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -2383,6 +2383,19 @@ namespace Ship_Game
             return rel?.IsHostile == true;
         }
 
+        public IEnumerable<IncomingThreat> AlliedSystemsWithThreat()
+        {
+            foreach (Empire e in Universe.MajorEmpires.Filter(e => e.IsAlliedWith(this)))
+            {
+                for (int i = e.SystemsWithThreat.Length - 1; i >= 0; i--)
+                {
+                    IncomingThreat threat = e.SystemsWithThreat[i];
+                    if (!threat.TargetSystem.HasPlanetsOwnedBy(this))
+                        yield return threat;
+                }
+            }
+        }
+
         public bool WillInhibit(Empire e) => e != this && !e.WeAreRemnants && IsAtWarWith(e);
 
         public Planet FindPlanet(int planetId)

--- a/Ship_Game/EmpirePersonalityModifiers.cs
+++ b/Ship_Game/EmpirePersonalityModifiers.cs
@@ -33,6 +33,7 @@ namespace Ship_Game
         public readonly float PlayerWarContributionRatioThreshold; // How much player sub-contribution ratio the AI can tolerate for allied wars
         public readonly int PlayerWarContributionMaxWarnings; // How many warning of lesser player requested war is needed by AI to do something about it
         public readonly bool CanWeSurrenderToPlayerAfterBetrayal; // Will the AI be able to surrender to player after s/he betrayed them in allied war
+        public readonly float DistanceToDefendAllyThreshold; // Defend Allies' systems if they are closer to us, basaed on this threshold lower is closer
 
         public PersonalityModifiers(PersonalityType type)
         {
@@ -43,6 +44,7 @@ namespace Ship_Game
                     AddAngerAlliedWithEnemies3RdParty      = 25;
                     PlayerWarContributionRatioThreshold    = 1f;
                     PlayerWarContributionMaxWarnings       = 2;
+                    DistanceToDefendAllyThreshold = 1f;
                     TurnsAbove95FederationNeeded = 250;
                     TurnsAbove95AllianceTreshold = 100;
                     AllianceValueAlliedWithEnemy = 0.5f;
@@ -73,6 +75,7 @@ namespace Ship_Game
                     AddAngerAlliedWithEnemies3RdParty      = 75;
                     PlayerWarContributionRatioThreshold    = 1f;
                     PlayerWarContributionMaxWarnings       = 1;
+                    DistanceToDefendAllyThreshold = 0.8f;
                     TurnsAbove95FederationNeeded = 350;
                     TurnsAbove95AllianceTreshold = 300;
                     AllianceValueAlliedWithEnemy = 0.4f;
@@ -103,6 +106,7 @@ namespace Ship_Game
                     AddAngerAlliedWithEnemies3RdParty      = 75;
                     PlayerWarContributionRatioThreshold    = 1.1f;
                     PlayerWarContributionMaxWarnings       = 1;
+                    DistanceToDefendAllyThreshold = 0.6f;
                     TurnsAbove95FederationNeeded = 420;
                     TurnsAbove95AllianceTreshold = 250;
                     AllianceValueAlliedWithEnemy = 0.5f;
@@ -133,6 +137,7 @@ namespace Ship_Game
                     AddAngerAlliedWithEnemies3RdParty      = 100;
                     PlayerWarContributionRatioThreshold    = 1.15f;
                     PlayerWarContributionMaxWarnings       = 1;
+                    DistanceToDefendAllyThreshold = 0.7f;
                     TurnsAbove95FederationNeeded = 600;
                     TurnsAbove95AllianceTreshold = 200;
                     AllianceValueAlliedWithEnemy = 0.5f;
@@ -164,6 +169,7 @@ namespace Ship_Game
                     AddAngerAlliedWithEnemies3RdParty      = 50;
                     PlayerWarContributionRatioThreshold    = 1.15f;
                     PlayerWarContributionMaxWarnings       = 2;
+                    DistanceToDefendAllyThreshold = 0.9f;
                     TurnsAbove95FederationNeeded = 320;
                     TurnsAbove95AllianceTreshold = 150;
                     AllianceValueAlliedWithEnemy = 0.6f;
@@ -194,6 +200,7 @@ namespace Ship_Game
                     AddAngerAlliedWithEnemies3RdParty      = 100;
                     PlayerWarContributionRatioThreshold    = 1.1f;
                     PlayerWarContributionMaxWarnings       = 1;
+                    DistanceToDefendAllyThreshold = 1.25f;
                     TurnsAbove95FederationNeeded = 250;
                     TurnsAbove95AllianceTreshold = 125;
                     AllianceValueAlliedWithEnemy = 0.5f;
@@ -224,6 +231,7 @@ namespace Ship_Game
                     AddAngerAlliedWithEnemies3RdParty      = 25;
                     PlayerWarContributionRatioThreshold    = 1.1f;
                     PlayerWarContributionMaxWarnings       = 2;
+                    DistanceToDefendAllyThreshold = 1.4f;
                     TurnsAbove95FederationNeeded = 300;
                     TurnsAbove95AllianceTreshold = 100;
                     AllianceValueAlliedWithEnemy = 0.8f;

--- a/Ship_Game/Empire_War.cs
+++ b/Ship_Game/Empire_War.cs
@@ -215,9 +215,10 @@ namespace Ship_Game
             return !AI.HasGoal(g => g.Type == GoalType.EmpireDefense);
         }
 
-        public void AddDefenseSystemGoal(SolarSystem system, float strengthWanted, MilitaryTaskImportance importance, int fleetCount = 1)
+        public void AddDefenseSystemGoal(SolarSystem system, float strengthWanted, MilitaryTaskImportance importance, 
+            int fleetCount = 1, Empire targetEmpire = null)
         {
-            AI.AddGoal(new DefendSystem(this, system, strengthWanted, fleetCount, importance));
+            AI.AddGoal(new DefendSystem(this, system, strengthWanted, fleetCount, importance, targetEmpire));
         }
 
         public bool HasWarTaskTargetingSystem(SolarSystem system)

--- a/Ship_Game/Empires/Components/IncomingThreat.cs
+++ b/Ship_Game/Empires/Components/IncomingThreat.cs
@@ -11,7 +11,7 @@ namespace Ship_Game.Empires.Components;
 [StarDataType]
 public class IncomingThreat
 {
-    [StarData] readonly Empire Owner;
+    [StarData] public readonly Empire Owner;
     [StarData] public readonly SolarSystem TargetSystem;
 
     [StarData] public float ThreatTimer { get; private set; }

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -698,8 +698,7 @@ namespace Ship_Game.Fleets
                 case 1:
                     if (!DoOrbitTaskArea(task) || !AttackEnemyStrengthClumpsInAO(task))
                         EndInvalidTask(--DefenseTurns <= 0 
-                                       && !Owner.SystemsWithThreat.Any(t => !t.ThreatTimedOut 
-                                                                         && t.TargetSystem == task.TargetPlanet.System));
+                            && !Owner.IsSystemUnderThreatForUs(task.TargetPlanet.System));
                     break;
             }
         }
@@ -1501,7 +1500,9 @@ namespace Ship_Game.Fleets
                 task.TargetEmpire = Owner.AI.ThreatMatrix.GetStrongestHostileAt(FleetTask.TargetSystem);
 
             float enemyStrength = Owner.AI.ThreatMatrix.GetHostileStrengthAt(task.AO, task.AORadius);
-            bool threatIncoming = Owner.SystemsWithThreat.Any(t => !t.ThreatTimedOut && t.TargetSystem == FleetTask.TargetSystem);
+            bool threatIncoming = Owner.IsSystemUnderThreatForUs(FleetTask.TargetSystem)
+                || Owner.IsSystemUnderThreatForAllies(FleetTask.TargetSystem);
+
             if (threatIncoming && EndInvalidTask(!CanTakeThisFight(enemyStrength*0.5f, task))) 
                 return; // If no threat is incoming, stay put to clear remaining lone ships
 

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -2292,6 +2292,7 @@ namespace Ship_Game.Fleets
         public void Reset(bool returnShipsToEmpireAI = true, bool clearOrders = true)
         {
             RemoveAllShips(returnShipsToEmpireAI, clearOrders: clearOrders);
+            Owner.AI?.RemoveFleetFromGoals(this);
             TaskStep = 0;
             FleetTask = null;
             Key = 0;

--- a/Ship_Game/Ships/Ship_Movement.cs
+++ b/Ship_Game/Ships/Ship_Movement.cs
@@ -327,8 +327,10 @@ namespace Ship_Game.Ships
             }
         }
 
-        public bool TryGetScoutFleeVector(out Vector2 escapePos) => GetEscapeJumpPosition(out escapePos, 100000, true);
-        public bool TryGetEscapeVector(out Vector2 escapePos) => GetEscapeJumpPosition(out escapePos, 20000, false);
+        public bool TryGetScoutFleeVector(out Vector2 escapePos) => GetEscapeJumpPosition(out escapePos, 100000, 
+            ignoreNonCombat: true, reverseIfInWell: true);
+        public bool TryGetEscapeVector(out Vector2 escapePos) => GetEscapeJumpPosition(out escapePos, 20000,
+            ignoreNonCombat: false, reverseIfInWell: false);
 
         /// <summary>
         /// Calculates an escape jump position to disengage from combat
@@ -337,9 +339,10 @@ namespace Ship_Game.Ships
         /// <param name="desiredDistance"></param>
         /// <param name="ignoreNonCombat"></param>
         /// <returns>TRUE if an escape vector was found, FALSE if ship should go straight to resupply target</returns>
-        public bool GetEscapeJumpPosition(out Vector2 escapePos, float desiredDistance, bool ignoreNonCombat)
+        public bool GetEscapeJumpPosition(out Vector2 escapePos, float desiredDistance,
+            bool ignoreNonCombat, bool reverseIfInWell)
         {
-            escapePos = Position + Direction * desiredDistance; // default position - straight through
+            escapePos = Position + Direction*desiredDistance; // default position - straight through
             if (!InCombat && !ignoreNonCombat) // No need for escape position if not in combat - turn around
                 return false;
 
@@ -356,7 +359,8 @@ namespace Ship_Game.Ships
             Planet gravityWell = System.IdentifyGravityWell(this);
             if (gravityWell != null)
             {
-                escapePos = GetEscapePosInGravityWell(gravityWell, desiredDistance);
+                escapePos = reverseIfInWell ? Position - Direction*desiredDistance
+                                            : GetEscapePosInGravityWell(gravityWell, desiredDistance);
                 return true;
             }
 

--- a/Ship_Game/Ships/Ship_Movement.cs
+++ b/Ship_Game/Ships/Ship_Movement.cs
@@ -327,8 +327,12 @@ namespace Ship_Game.Ships
             }
         }
 
-        public bool TryGetScoutFleeVector(out Vector2 escapePos) => GetEscapeJumpPosition(out escapePos, 100000, 
-            ignoreNonCombat: true, reverseIfInWell: true);
+        public bool TryGetScoutFleeVector(out Vector2 escapePos)
+        {
+            TryAddResearchableStarNotification();
+            System.SetExploredBy(Loyalty);
+            return GetEscapeJumpPosition(out escapePos, 100000, ignoreNonCombat: true, reverseIfInWell: true);
+        }
         public bool TryGetEscapeVector(out Vector2 escapePos) => GetEscapeJumpPosition(out escapePos, 20000,
             ignoreNonCombat: false, reverseIfInWell: false);
 

--- a/Ship_Game/Ships/Ship_Update.cs
+++ b/Ship_Game/Ships/Ship_Update.cs
@@ -175,9 +175,7 @@ namespace Ship_Game.Ships
             {
                 if (!System.IsExploredBy(Loyalty) && Position.InRadius(System.Position, ExploreSystemDistance))
                 {
-                    if (Loyalty.isPlayer && System.IsResearchable) 
-                        Universe.Screen.NotificationManager?.AddReseachableStar(System);
-
+                    TryAddResearchableStarNotification();
                     System.SetExploredBy(Loyalty); // Arrived to a system for the first time
                 }
 
@@ -212,15 +210,16 @@ namespace Ship_Game.Ships
                         Universe.Screen.NotificationManager?.AddReseachablePlanet(p);
 
                     p.SetExploredBy(Loyalty);
-
-                    if (!System.IsExploredBy(Loyalty) && Loyalty.isPlayer && System.IsResearchable)
-                        Universe.Screen.NotificationManager.AddReseachableStar(System);
-
-
                     System.SetExploredBy(Loyalty); // in case no one was on sensor range from the Star itself
                     System.UpdateFullyExploredBy(Loyalty);
                 }
             }
+        }
+        
+        public void TryAddResearchableStarNotification()
+        {
+            if (System != null && Loyalty.isPlayer && System.IsResearchable && !System.IsExploredBy(Loyalty))
+                Universe.Screen.NotificationManager?.AddReseachableStar(System);
         }
 
         public void UpdateThrusters(FixedSimTime timeStep)

--- a/Ship_Game/Universe/MiniMap.cs
+++ b/Ship_Game/Universe/MiniMap.cs
@@ -158,12 +158,12 @@ namespace Ship_Game
             float ringRad = 0.023f * pulseTime;
             foreach (IncomingThreat threat in Player.SystemsWithThreat)
             {
-                var system = threat.TargetSystem;
-                Vector2 miniSystemPos = WorldToMiniPos(system.Position);
-                float pulseRad = radius + ringRad;
-                batch.Draw(Node1, miniSystemPos, Color.Red, 0f, Node.CenterF, pulseRad + 0.009f, SpriteEffects.None, 0f);
-                batch.Draw(Node1, miniSystemPos, Color.Black, 0f, Node.CenterF, pulseRad + 0.002f, SpriteEffects.None, 0f);
-                batch.Draw(Node1, miniSystemPos, Color.Red, 0f, Node.CenterF, radius , SpriteEffects.None, 0f);
+                DrawThreats(Color.Red, threat);
+            }
+
+            foreach (IncomingThreat threat in Player.AlliedSystemsWithThreat())
+            {
+                DrawThreats(Color.Orange, threat);
             }
 
             foreach (var system in Player.AI.ThreatMatrix.GetAllSystemsWithFactions())
@@ -184,6 +184,16 @@ namespace Ship_Game
                 batch.Draw(Node1, point, warningColor, 0f, Node.CenterF, radius, SpriteEffects.None, 1f);
                 batch.Draw(Node1, point, Color.Black, 0f, Node.CenterF, radius - 0.005f, SpriteEffects.None, 1f);
                 batch.Draw(Node1, point, c.Loyalty.EmpireColor, 0f, Node.CenterF, 0.012f, SpriteEffects.None, 1f);
+            }
+
+            void DrawThreats(Color color, IncomingThreat threat)
+            {
+                var system = threat.TargetSystem;
+                Vector2 miniSystemPos = WorldToMiniPos(system.Position);
+                float pulseRad = radius + ringRad;
+                batch.Draw(Node1, miniSystemPos, color, 0f, Node.CenterF, pulseRad + 0.009f, SpriteEffects.None, 0f);
+                batch.Draw(Node1, miniSystemPos, Color.Black, 0f, Node.CenterF, pulseRad + 0.002f, SpriteEffects.None, 0f);
+                batch.Draw(Node1, miniSystemPos, color, 0f, Node.CenterF, radius, SpriteEffects.None, 0f);
             }
         }
 

--- a/Ship_Game/Universe/SolarSystem.cs
+++ b/Ship_Game/Universe/SolarSystem.cs
@@ -307,32 +307,18 @@ namespace Ship_Game
         /// Checks the priority of this system for defense tasks
         /// </summary>
         /// <param name="empire"></param>
-        /// <returns>priority between 0 to 4 (0 is the highest)</returns>
-        public int DefenseTaskPriority(Empire empire, MilitaryTaskImportance importance = MilitaryTaskImportance.Normal)
+        /// <returns>priority between 0 to 10 (0 is the highest)</returns>
+        public int DefenseTaskPriority(MilitaryTaskImportance importance = MilitaryTaskImportance.Normal)
         {
-            int priority = 4 - (int)importance;
-            var planetsToCheck = PlanetList.Filter(p => p.Owner == empire);
-            if (planetsToCheck.Length == 0)
+            int priority = 5 - (int)importance; // For sysyems with no owner (like researchable)
+            if (OwnerList.Count > 0)
             {
-                if (OwnerList.Any(empire.IsAtWarWith))
-                    planetsToCheck = PlanetList.Filter(p => p.Owner != null);
-            }
-
-            if (planetsToCheck.Length > 0)
-            {
-                int totalLevels = 0;
-                int totalWeights = 0;
                 // Using weighted level here
-                foreach (Planet p in planetsToCheck)
-                {
-                    totalLevels += p.Level;
-                    totalWeights += p.Level*p.Level;
-                }
-
-                priority = 5 - totalWeights / totalLevels.LowerBound(1);
+                int totalWeights = PlanetList.Sum(p => p.Level * p.Level * (p.HasCapital ? 2 : 1)).LowerBound(1);
+                priority = 60 / totalWeights;
             }
 
-            return priority;
+            return priority.UpperBound(10);
         }
 
         public float PotentialValueFor(Empire e)

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Render.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Render.cs
@@ -172,18 +172,29 @@ namespace Ship_Game
 
         void DrawSystemThreatCirclesAnimation(SpriteBatch batch)
         {
-            var red = new Color(Color.Red, 40);
+            var red = new Color(Color.Red, 80);
+            var orange = new Color(Color.Orange, 80);
             var black = new Color(Color.Black, 40);
 
             foreach (IncomingThreat threat in Player.SystemsWithThreat)
             {
+                DrawThreat(red, threat);
+            }
+
+            foreach (IncomingThreat threat in Player.AlliedSystemsWithThreat())
+            {
+                DrawThreat(orange, threat);
+            }
+
+            void DrawThreat(Color color, IncomingThreat threat)
+            {
                 var system = threat.TargetSystem;
-                float pulseRad = PulseTimer * (threat.TargetSystem.Radius * 1.5f);
+                float pulseRad = PulseTimer * (system.Radius * 1.5f);
 
                 Vector2d posOnScreen = ProjectToScreenPosition(system.Position);
-                batch.DrawCircle(posOnScreen, ProjectToScreenSize(pulseRad), red, 10);
+                batch.DrawCircle(posOnScreen, ProjectToScreenSize(pulseRad), color, 10);
                 batch.DrawCircle(posOnScreen, ProjectToScreenSize(pulseRad * 1.001f), black, 5);
-                batch.DrawCircle(posOnScreen, ProjectToScreenSize(pulseRad * 1.3f), red, 10);
+                batch.DrawCircle(posOnScreen, ProjectToScreenSize(pulseRad * 1.3f), color, 10);
                 batch.DrawCircle(posOnScreen, ProjectToScreenSize(pulseRad * 1.301f), black, 5);
             }
         }

--- a/StarDrive.csproj
+++ b/StarDrive.csproj
@@ -201,6 +201,7 @@
     <Compile Include="Ship_Game\Debug\DebugInfoScreen_VisualizeShipGoals.cs" />
     <Compile Include="Ship_Game\Debug\DebugModes.cs" />
     <Compile Include="Ship_Game\Debug\Page\AgentsDebug.cs" />
+    <Compile Include="Ship_Game\Debug\Page\EmpireGoalsDebug.cs" />
     <Compile Include="Ship_Game\Debug\Page\InfluenceDebug.cs" />
     <Compile Include="Ship_Game\Debug\Page\SpaceRoadsDebug.cs" />
     <Compile Include="Ship_Game\Debug\Page\DefenseCoordinatorDebug.cs" />


### PR DESCRIPTION
Feature: Allow player to view allied empires threatened systems (marked in orange)
Feature: Allow AI to create defense fleets to protect allies.
Fix: Scouts do not id gravity well and continue straight to their death in remnant system
Fix: Scouts will now escape if their are caught in a well even if the system is not the target explore system.
Fix: Scouts - Explore Sun if escaping
Fix: Remove refs to Tasks and Fleets in FleetGoal if task is ending
Fix: crash in WarMission when Task is null
Refactor: DefenseTaskPriority to support allied defense
Debug: Added debug screen for empire goals
