### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -2036,11 +2036,7 @@ namespace Ship_Game
 
         void CalculateScore(bool fromSave = false)
         {
-            TechScore = 0;
-            foreach (TechEntry entry in TechEntries)
-                if (entry.Unlocked) TechScore += entry.TechCost;
-            TechScore /= 100;
-
+            TechScore = TechEntries.Sum(e => e.Unlocked ? e.TechCost : 0) * 0.01f;
             IndustrialScore = 0;
             ExpansionScore  = 0;
             for (int i = 0; i < OwnedPlanets.Count; i++)
@@ -2049,7 +2045,7 @@ namespace Ship_Game
                 ExpansionScore  += p.Fertility*10 + p.MineralRichness*10 + p.PopulationBillion;
                 IndustrialScore += p.SumBuildings(b => b.ActualCost);
             }
-            IndustrialScore /= 20;
+            IndustrialScore *= 0.05f;
 
             if (fromSave)
                 MilitaryScore = data.MilitaryScoreAverage;

--- a/Ship_Game/EmpireData.cs
+++ b/Ship_Game/EmpireData.cs
@@ -433,7 +433,7 @@ namespace Ship_Game
         {
             // exponential moving average
             float newRatio = 0.1f;
-            float score = currentStr / 1000;
+            float score = currentStr *= 0.001f;
             MilitaryScoreAverage = MilitaryScoreAverage*(1f-newRatio) + score*newRatio;
             return MilitaryScoreAverage;
         }

--- a/Ship_Game/EmpirePersonalityModifiers.cs
+++ b/Ship_Game/EmpirePersonalityModifiers.cs
@@ -34,6 +34,7 @@ namespace Ship_Game
         public readonly int PlayerWarContributionMaxWarnings; // How many warning of lesser player requested war is needed by AI to do something about it
         public readonly bool CanWeSurrenderToPlayerAfterBetrayal; // Will the AI be able to surrender to player after s/he betrayed them in allied war
         public readonly float DistanceToDefendAllyThreshold; // Defend Allies' systems if they are closer to us, basaed on this threshold lower is closer
+        public readonly float ImperialistWarPlanetsToTakeMult; // multiplier for how many planets to take from available enemy planets if we have better score
 
         public PersonalityModifiers(PersonalityType type)
         {
@@ -44,7 +45,8 @@ namespace Ship_Game
                     AddAngerAlliedWithEnemies3RdParty      = 25;
                     PlayerWarContributionRatioThreshold    = 1f;
                     PlayerWarContributionMaxWarnings       = 2;
-                    DistanceToDefendAllyThreshold = 1f;
+                    ImperialistWarPlanetsToTakeMult = 0.4f;
+                    DistanceToDefendAllyThreshold   = 1f;
                     TurnsAbove95FederationNeeded = 250;
                     TurnsAbove95AllianceTreshold = 100;
                     AllianceValueAlliedWithEnemy = 0.5f;
@@ -75,7 +77,8 @@ namespace Ship_Game
                     AddAngerAlliedWithEnemies3RdParty      = 75;
                     PlayerWarContributionRatioThreshold    = 1f;
                     PlayerWarContributionMaxWarnings       = 1;
-                    DistanceToDefendAllyThreshold = 0.8f;
+                    ImperialistWarPlanetsToTakeMult = 0.6f;
+                    DistanceToDefendAllyThreshold   = 0.8f;
                     TurnsAbove95FederationNeeded = 350;
                     TurnsAbove95AllianceTreshold = 300;
                     AllianceValueAlliedWithEnemy = 0.4f;
@@ -106,7 +109,8 @@ namespace Ship_Game
                     AddAngerAlliedWithEnemies3RdParty      = 75;
                     PlayerWarContributionRatioThreshold    = 1.1f;
                     PlayerWarContributionMaxWarnings       = 1;
-                    DistanceToDefendAllyThreshold = 0.6f;
+                    ImperialistWarPlanetsToTakeMult = 0.8f;
+                    DistanceToDefendAllyThreshold   = 0.6f;
                     TurnsAbove95FederationNeeded = 420;
                     TurnsAbove95AllianceTreshold = 250;
                     AllianceValueAlliedWithEnemy = 0.5f;
@@ -137,7 +141,8 @@ namespace Ship_Game
                     AddAngerAlliedWithEnemies3RdParty      = 100;
                     PlayerWarContributionRatioThreshold    = 1.15f;
                     PlayerWarContributionMaxWarnings       = 1;
-                    DistanceToDefendAllyThreshold = 0.7f;
+                    ImperialistWarPlanetsToTakeMult = 0.5f;
+                    DistanceToDefendAllyThreshold   = 0.7f;
                     TurnsAbove95FederationNeeded = 600;
                     TurnsAbove95AllianceTreshold = 200;
                     AllianceValueAlliedWithEnemy = 0.5f;
@@ -169,7 +174,8 @@ namespace Ship_Game
                     AddAngerAlliedWithEnemies3RdParty      = 50;
                     PlayerWarContributionRatioThreshold    = 1.15f;
                     PlayerWarContributionMaxWarnings       = 2;
-                    DistanceToDefendAllyThreshold = 0.9f;
+                    ImperialistWarPlanetsToTakeMult = 0.7f;
+                    DistanceToDefendAllyThreshold   = 0.9f;
                     TurnsAbove95FederationNeeded = 320;
                     TurnsAbove95AllianceTreshold = 150;
                     AllianceValueAlliedWithEnemy = 0.6f;
@@ -200,7 +206,8 @@ namespace Ship_Game
                     AddAngerAlliedWithEnemies3RdParty      = 100;
                     PlayerWarContributionRatioThreshold    = 1.1f;
                     PlayerWarContributionMaxWarnings       = 1;
-                    DistanceToDefendAllyThreshold = 1.25f;
+                    ImperialistWarPlanetsToTakeMult = 0.5f;
+                    DistanceToDefendAllyThreshold   = 1.25f;
                     TurnsAbove95FederationNeeded = 250;
                     TurnsAbove95AllianceTreshold = 125;
                     AllianceValueAlliedWithEnemy = 0.5f;
@@ -231,7 +238,8 @@ namespace Ship_Game
                     AddAngerAlliedWithEnemies3RdParty      = 25;
                     PlayerWarContributionRatioThreshold    = 1.1f;
                     PlayerWarContributionMaxWarnings       = 2;
-                    DistanceToDefendAllyThreshold = 1.4f;
+                    ImperialistWarPlanetsToTakeMult = 0.4f;
+                    DistanceToDefendAllyThreshold   = 1.4f;
                     TurnsAbove95FederationNeeded = 300;
                     TurnsAbove95AllianceTreshold = 100;
                     AllianceValueAlliedWithEnemy = 0.8f;

--- a/Ship_Game/Empire_War.cs
+++ b/Ship_Game/Empire_War.cs
@@ -21,12 +21,25 @@ namespace Ship_Game
             switch (warType)
             {
                 case WarType.GenocidalWar:
-                case WarType.ImperialistWar: targetPlanets = enemy.GetPlanets().Filter(p => !HasWarMissionTargeting(p)); break;
-                case WarType.BorderConflict: targetPlanets = PotentialPlanetTargetsBorderWar(enemy);                     break;
-                case WarType.DefensiveWar:   targetPlanets = PotentialPlanetTargetsDefensiveWar(enemy);                  break;
+                case WarType.ImperialistWar: targetPlanets = PotentialPlanetTargetsImperialistWar(enemy); break;
+                case WarType.BorderConflict: targetPlanets = PotentialPlanetTargetsBorderWar(enemy);      break;
+                case WarType.DefensiveWar:   targetPlanets = PotentialPlanetTargetsDefensiveWar(enemy);   break;
             }
 
             return targetPlanets?.Length > 0;
+        }
+
+        Planet[] PotentialPlanetTargetsImperialistWar(Empire enemy)
+        {
+            float ratio = (float)TotalScore / enemy.TotalScore;
+            int NumClosestPlaetToTake = 3;
+            float finalRatio = (ratio < 1
+                ? ratio * 0.3f
+                : ratio * PersonalityModifiers.ImperialistWarPlanetsToTakeMult).UpperBound(1);
+
+            NumClosestPlaetToTake = (int)(finalRatio * enemy.GetPlanets().Count).LowerBound(3);
+            var potentialPlanets = enemy.GetPlanets().Filter(p => !HasWarMissionTargeting(p));
+            return potentialPlanets.Sorted(p => p.System.Position.SqDist(WeightedCenter)).Take(NumClosestPlaetToTake).ToArray();
         }
 
         Planet[] PotentialPlanetTargetsBorderWar(Empire enemy)

--- a/Ship_Game/Empires/Components/IncomingThreatDetector.cs
+++ b/Ship_Game/Empires/Components/IncomingThreatDetector.cs
@@ -128,7 +128,7 @@ public class IncomingThreatDetector
 
     static bool IsShipAThreat(Ship s)
     {
-        return s.InPlayerSensorRange && !s.IsInWarp && s.BaseStrength > 0 && !s.IsFreighter;
+        return s.InPlayerSensorRange && !s.IsInWarp && s.BaseStrength > 0 && !s.IsFreighter && !s.IsResearchStation;
     }
 
     bool IsHostilesPresent(Empire owner, SolarSystem s)

--- a/Ship_Game/Gameplay/Relationship.cs
+++ b/Ship_Game/Gameplay/Relationship.cs
@@ -550,9 +550,9 @@ namespace Ship_Game.Gameplay
             else
             {
                 IsHostile = IsEmpireHostileToUs(us, them);
-                bool canAttack = CanWeAttackThem(us, them);
-
-                if (CanTheyAttackUs(them, us))
+                bool canAttack = CanWeAttackThem(us, them, TotalAnger);
+                float TheirAnger = them.GetRelationsOrNull(us).TotalAnger;
+                if (CanTheyAttackUs(them, us, TheirAnger))
                     canAttack = true; // make sure we can also attack them
 
                 if (canAttack) // We are now hostile as well
@@ -615,8 +615,8 @@ namespace Ship_Game.Gameplay
             }
         }
 
-        public bool CanTheyAttackUs(Empire them, Empire us) => CanWeAttackThem(them, us);
-        bool CanWeAttackThem(Empire us, Empire them)
+        public bool CanTheyAttackUs(Empire them, Empire us, float theirAnger) => CanWeAttackThem(them, us, theirAnger);
+        bool CanWeAttackThem(Empire us, Empire them, float ourAnger)
         {
             if (AtWar)
                 return true;
@@ -631,7 +631,7 @@ namespace Ship_Game.Gameplay
             {
                 float trustworthiness = them.isPlayer ? 50 : them.data.DiplomaticPersonality?.Trustworthiness ?? 100;
                 float peacefulness    = 1.0f - them.Research.Strategy.MilitaryRatio;
-                if (TotalAnger > trustworthiness * peacefulness)
+                if (ourAnger > trustworthiness * peacefulness)
                     return true;
             }
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -424,16 +424,15 @@ namespace Ship_Game
             return GravityWellRadius;
         }
 
-        // this is calculating colonyRawValue twice.
         public float ColonyDiplomaticValueTo(Empire empire)
         {
-            float worth = ColonyBaseValue(empire) + ColonyRawValue(empire);
+            float worth = ColonyBaseValue(empire);
             if (empire.NonCybernetic)
                 worth += (FoodHere / 50f) + (ProdHere / 50f);
             else 
                 worth += (ProdHere / 25f);
 
-            return worth.LowerBound(15);
+            return worth.LowerBound(5);
         }
 
         public void SetInGroundCombat(Empire empire, bool notify = false)


### PR DESCRIPTION
Fix: One side can attack other side if they are mad at them and the other side cannot retaliate.
Balance: Updated logic of imperialist and genocidal wars planet target selection.
Refactor: Empire score calculations
Balance: Diplomacy - update trust and anger reduction for colony trade. Allow very angry races to accept good trades.