### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/AI/EmpireAI/ShipBuilder.cs
+++ b/Ship_Game/AI/EmpireAI/ShipBuilder.cs
@@ -218,20 +218,20 @@ namespace Ship_Game.AI
 
         static float FreighterValue(IShipDesign s, Empire empire, float fastVsBig)
         {
-            float maxFTL = ShipStats.GetFTLSpeed(s, empire);
-            float maxSTL = ShipStats.GetSTLSpeed(s, empire);
-            float cargo = ShipStats.GetCargoSpace(s.BaseCargoSpace, s);
-            float turnRate = ShipStats.GetTurnRadsPerSec(s);
-            float area = s.SurfaceArea;
+            float maxKFTL  = ShipStats.GetFTLSpeed(s, empire) * 0.001f;
+            float maxDSTL  = ShipStats.GetSTLSpeed(s, empire) * 0.1f;
+            float cargo    = ShipStats.GetCargoSpace(s.BaseCargoSpace, s);
+            float turnRate = ShipStats.GetTurnRadsPerSec(s).ToDegrees();
+            float area     = s.SurfaceArea;
 
-            float warpK           = maxFTL / 1000;
-            float movementWeight  = warpK + maxSTL / 10 + turnRate.ToDegrees() - s.GetCost(empire) / 5;
-            float cargoWeight     = cargo.Clamped(0, 80) - area / 25;
-            float lowCargoPenalty = cargo < area * 0.5f ? cargo / area : 1;
-            float score           = movementWeight * fastVsBig + cargoWeight * (1 - fastVsBig);
+            float fastVsBigWeight = fastVsBig * 10;
+            float costWeight     = s.GetCost(empire) * 0.2f;
+            float movementWeight = (maxKFTL + maxDSTL + turnRate) * fastVsBig;
+            float cargoWeight    = cargo * (10 - fastVsBig);
+            float score          = movementWeight + cargoWeight - costWeight;
 
             // For faster , cheaper ships vs big and maybe slower ships
-            return score * lowCargoPenalty;
+            return score;
         }
 
 
@@ -319,7 +319,7 @@ namespace Ship_Game.AI
             float modifiedStrength;
 
             if (defense > offense && offenseRatio < 0.1f)
-                modifiedStrength = offense * 2;
+                modifiedStrength = offense + offense + defense*0.1f;
             else
                 modifiedStrength = offense + defense;
 

--- a/Ship_Game/AI/EmpireAI/ShipBuilder.cs
+++ b/Ship_Game/AI/EmpireAI/ShipBuilder.cs
@@ -226,8 +226,8 @@ namespace Ship_Game.AI
 
             float fastVsBigWeight = fastVsBig * 10;
             float costWeight     = s.GetCost(empire) * 0.2f;
-            float movementWeight = (maxKFTL + maxDSTL + turnRate) * fastVsBig;
-            float cargoWeight    = cargo * (10 - fastVsBig);
+            float movementWeight = (maxKFTL + maxDSTL + turnRate) * fastVsBigWeight;
+            float cargoWeight    = cargo * (10 - fastVsBigWeight);
             float score          = movementWeight + cargoWeight - costWeight;
 
             // For faster , cheaper ships vs big and maybe slower ships
@@ -261,7 +261,7 @@ namespace Ship_Game.AI
             freighter = freighters.FindMax(ship => FreighterValue(ship, empire, fastVsBig));
 
             if (empire.Universe?.Debug == true)
-                Log.Info(ConsoleColor.Cyan, $"----- Picked {freighter?.Name ?? "null"}");
+                Log.Info(ConsoleColor.Cyan, $"----- Picked {freighter?.Name ?? "null"} (fast vs big: {fastVsBig.String()}/{(1-fastVsBig).String()})");
 
             return freighter;
         }

--- a/Ship_Game/AI/ExpansionAI/ExpansionPlanner.cs
+++ b/Ship_Game/AI/ExpansionAI/ExpansionPlanner.cs
@@ -121,6 +121,13 @@ namespace Ship_Game.AI.ExpansionAI
             if (!CanConsiderExpanding(popRatio, ourPlanetsNum))
                 return;
 
+            if (!Owner.isPlayer)
+            {
+                var goals = Owner.AI.CountGoals(g => g.Type == GoalType.StandbyColonyShip);
+                if (goals < Owner.DifficultyModifiers.StandByColonyShips.UpperBound(ourPlanetsNum-1))
+                    Owner.AI.AddGoal(new StandbyColonyShip(Owner));
+            }
+
             Planet[] currentColonizationGoals = GetColonizationGoalPlanets();
             int desiredGoals = DesiredColonyGoals();
 

--- a/Ship_Game/AI/ExpansionAI/PlanetRanker.cs
+++ b/Ship_Game/AI/ExpansionAI/PlanetRanker.cs
@@ -45,7 +45,7 @@ namespace Ship_Game.AI.ExpansionAI
             {
                 DistanceMod = (planet.Position.Distance(empireCenter) / longestDistance * 10).Clamped(1, 10);
                 EnemyStrMod = ((empire.KnownEnemyStrengthIn(planet.System) / (empire.OffensiveStrength+10)) * 10).Clamped(1, 10);
-                CanColonize = !moralityBlock && (rawValue > 30 || empire.IsCybernetic && planet.MineralRichness > 1.5f);
+                CanColonize = !moralityBlock && (rawValue > 20 || empire.IsCybernetic && planet.MineralRichness > 1.5f);
                 Value = rawValue / DistanceMod / EnemyStrMod;
             }
         }

--- a/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
@@ -722,7 +722,10 @@ namespace Ship_Game.AI
                 Owner.ChangeOrdnance(-ordnanceDelivered);
                 EscortTarget.AI.TerminateResupplyIfDone(SupplyType.Rearm, terminateIfEnemiesNear: true);
                 DequeueCurrentOrder();
-                ChangeAIState(AIState.AwaitingOrders);
+                if (Owner.Ordinance < 1)
+                    OrderReturnToHangar();
+                else
+                    ChangeAIState(AIState.AwaitingOrders);
             }
         }
 

--- a/Ship_Game/AI/ShipAI/ShipAI.Goods.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Goods.cs
@@ -139,7 +139,7 @@ namespace Ship_Game.AI
             Owner.Loyalty.UpdateAverageFreightFTL(Owner.MaxFTLSpeed);
             Owner.Loyalty.UpdateAverageFreightCargoCap(Owner.CargoSpaceMax);
             // If we did not unload all cargo, its better to build faster smaller cheaper freighters
-            FreighterPriority freighterPriority = fullBeforeUnload && Owner.CargoSpaceUsed.AlmostZero()
+            FreighterPriority freighterPriority = fullBeforeUnload && Owner.CargoSpaceUsed < 1
                                                   ? FreighterPriority.UnloadedAllCargo
                                                   : FreighterPriority.ExcessCargoLeft;
                                                     

--- a/Ship_Game/AI/ShipAI/ShipAI_Trade.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI_Trade.cs
@@ -85,7 +85,7 @@ namespace Ship_Game.AI
             Owner.Loyalty.UpdateAverageFreightFTL(Owner.MaxFTLSpeed);
             Owner.Loyalty.UpdateAverageFreightCargoCap(Owner.CargoSpaceMax);
             // If we did not unload all cargo, its better to build faster smaller cheaper freighters
-            FreighterPriority freighterPriority = fullBeforeUnload && Owner.CargoSpaceUsed.AlmostZero()
+            FreighterPriority freighterPriority = fullBeforeUnload && Owner.CargoSpaceUsed < 1
                                                   ? FreighterPriority.UnloadedAllCargo
                                                   : FreighterPriority.ExcessCargoLeft;
 

--- a/Ship_Game/Commands/Goals/MarkForColonization.cs
+++ b/Ship_Game/Commands/Goals/MarkForColonization.cs
@@ -111,7 +111,6 @@ namespace Ship_Game.Commands.Goals
                     (spaceStrength * strMultiplier).LowerBound(20), TargetEmpire, (int)strMultiplier);
 
                 empireAi.AddPendingTask(Task);
-                empireAi.AddGoal(new StandbyColonyShip(Owner));
             }
             else if (!Owner.AnyActiveFleetsTargetingSystem(TargetPlanet.System))
             {

--- a/Ship_Game/Commands/Goals/RemnantPortal.cs
+++ b/Ship_Game/Commands/Goals/RemnantPortal.cs
@@ -102,7 +102,7 @@ namespace Ship_Game.Commands.Goals
 
         void ScrambleDefense()
         {
-            if (Portal.HealthPercent < 0.95f && !Owner.AI.Goals.Any(g => g.IsRemnantDefendingPortal(Portal)))
+            if (Portal.InCombat && Portal.HealthPercent < 0.95f && !Owner.AI.Goals.Any(g => g.IsRemnantDefendingPortal(Portal)))
                 Owner.AI.AddGoalAndEvaluate(new RemnantDefendPortal(Owner, Portal));
         }
 

--- a/Ship_Game/Commands/Goals/StandbyColonyShip.cs
+++ b/Ship_Game/Commands/Goals/StandbyColonyShip.cs
@@ -16,19 +16,10 @@ namespace Ship_Game.Commands.Goals
         {
             Steps = new Func<GoalStep>[]
             {
-                CheckIfStandbyShipNeeded,
                 BuildColonyShip,
                 EnsureBuildingColonyShip,
                 KeepOnStandBy
             };
-        }
-
-        GoalStep CheckIfStandbyShipNeeded()
-        {
-            var goals = Owner.AI.CountGoals(g => g.Type == GoalType.StandbyColonyShip);
-            return goals > Owner.DifficultyModifiers.StandByColonyShips.UpperBound(Owner.GetPlanets().Count) 
-                ? GoalStep.GoalFailed  // reached standby colony ship limit
-                : GoalStep.GoToNextStep;
         }
 
         GoalStep BuildColonyShip()

--- a/Ship_Game/EmpireDifficultyModifers.cs
+++ b/Ship_Game/EmpireDifficultyModifers.cs
@@ -261,7 +261,7 @@
                 ShipBuildStrMax    = 1f;
                 ColonyRankModifier = 0;
                 TaskForceStrength  = 1f;
-                ExpansionCheckInterval = 4;
+                ExpansionCheckInterval = 2;
 
                 if (empire.Universe.P.FixedPlayerCreditCharge && difficulty > GameDifficulty.Normal)
                     CreditsMultiplier = 0.2f;

--- a/Ship_Game/EmpireDifficultyModifers.cs
+++ b/Ship_Game/EmpireDifficultyModifers.cs
@@ -128,7 +128,7 @@
                     EnemyTroopStrength   = 1.6f;
                     MineralDecayDivider  = 60;
                     PiratePayModifier    = 1f;
-                    ExpansionMultiplier  = 0.7f; // 30% lower, makes the AI expand a bit more easily, but not too much
+                    ExpansionMultiplier  = 0.5f;
                     ExpansionCheckInterval = 5; // every 5 turns
                     MinStartingColonies  = 5;
                     ExpandSearchTurns    = 30;
@@ -172,7 +172,7 @@
                     EnemyTroopStrength   = 1.8f;
                     MineralDecayDivider  = 40;
                     PiratePayModifier    = 1.5f;
-                    ExpansionMultiplier  = 0.4f; // 60% lower threshold, basically makes every Empire a super Expansionist
+                    ExpansionMultiplier  = 0.25f; 
                     ExpansionCheckInterval = 3; // every 3 turns
                     MinStartingColonies  = 6;
                     ExpandSearchTurns    = 20;

--- a/Ship_Game/GamePlayGlobals.cs
+++ b/Ship_Game/GamePlayGlobals.cs
@@ -29,7 +29,7 @@ public class GamePlayGlobals
     [StarData] public float ResearchStationProductionPerResearch = 2f; // Production consumed per 1 Research point
 
     // required empire pop ratio before expansion is considered
-    [StarData] public float RequiredExpansionPopRatio = 0.4f;
+    [StarData] public float RequiredExpansionPopRatio = 0.2f;
     [StarData] public float ShipyardBonus;
     [StarData] public float CustomMineralDecay = 1;
     [StarData] public float VolcanicActivity = 1;

--- a/Ship_Game/GameScreens/ColonyScreen/QueueItem.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/QueueItem.cs
@@ -141,8 +141,8 @@ namespace Ship_Game
                 case QueueItemType.ColonyShipClaim: priority = 0;                                                                               break;
                 case QueueItemType.Building:        priority = planet.PrioritizeColonyBuilding(Building);                                       break;
                 case QueueItemType.Troop:           priority = 0.2f + owner.AI.DefensiveCoordinator.TroopsToTroopsWantedRatio * 5;              break;
-                case QueueItemType.Scout:           priority = owner.GetPlanets().Count * 0.05f;                                                break;
-                case QueueItemType.ColonyShip:      priority = (owner.GetPlanets().Count * (owner.IsExpansionists ? 0.01f : 0.03f));            break;
+                case QueueItemType.Scout:           priority = owner.GetPlanets().Count * 0.02f;                                                break;
+                case QueueItemType.ColonyShip:      priority = (owner.GetPlanets().Count * (owner.IsExpansionists ? 0.005f : 0.01f));           break;
                 case QueueItemType.Orbital:         priority = 1 + (owner.TotalOrbitalMaintenance / owner.AI.DefenseBudget.LowerBound(1) * 10); break;
                 case QueueItemType.RoadNode:        priority = 0.5f + owner.AI.SpaceRoadsManager.NumOnlineSpaceRoads * 0.1f;                    break;
                 case QueueItemType.Freighter: 

--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignIssues.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignIssues.cs
@@ -483,16 +483,16 @@ namespace Ship_Game.GameScreens.ShipDesign
                 AddDesignIssue(DesignIssueType.LowBurstPowerTime, severity);
         }
 
-        public void CheckOrdnanceVsEnergyWeapons(int numWeapons, int numOrdnanceWeapons, float ordnanceUsed, float ordnanceRecovered)
+        public void CheckOrdnanceVsEnergyWeapons(float weaponsArea, float kineticWeaponsArea, float ordnanceUsed, float ordnanceRecovered)
         {
-            if (Stationary || numWeapons == 0 || numOrdnanceWeapons == 0)
+            if (Stationary || weaponsArea == 0 || kineticWeaponsArea == 0)
                 return;
 
-            if (numOrdnanceWeapons < numWeapons && ordnanceUsed > ordnanceRecovered)
+            if (kineticWeaponsArea < weaponsArea && ordnanceUsed > ordnanceRecovered)
                 AddDesignIssue(DesignIssueType.NoOrdnanceResupplyPlayerOrder, WarningLevel.Informative);
 
-            float ordnanceToEnergyRatio = (float)numOrdnanceWeapons / numWeapons;
-            if (ordnanceToEnergyRatio.LessOrEqual(ShipResupply.KineticToEnergyRatio))
+            float ordnanceToEnergyRatio = kineticWeaponsArea / weaponsArea;
+            if (ordnanceToEnergyRatio.LessOrEqual(ShipResupply.KineticRatioThreshold))
                 AddDesignIssue(DesignIssueType.NoOrdnanceResupplyCombat, WarningLevel.Informative);
         }
 

--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignIssuesPanel.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignIssuesPanel.cs
@@ -100,7 +100,7 @@ namespace Ship_Game.GameScreens.ShipDesign
                 Issues.CheckWeaponPowerTime(ds.HasEnergyWeapons, ds.PowerConsumed > 0, ds.EnergyDuration);
                 Issues.CheckCombatEfficiency(ds.PowerConsumed, ds.EnergyDuration, ds.PowerRecharge, ds.NumWeapons, ds.NumOrdWeapons);
                 Issues.CheckBurstPowerTime(ds.BeamPeakPowerNeeded > 0, ds.BurstEnergyDuration, ds.BeamAverageDuration);
-                Issues.CheckOrdnanceVsEnergyWeapons(ds.NumWeapons, ds.NumOrdWeapons, ds.AvgOrdnanceUsed, S.OrdAddedPerSecond);
+                Issues.CheckOrdnanceVsEnergyWeapons(ds.WeaponsArea, ds.KineticWeaponsArea, ds.AvgOrdnanceUsed, S.OrdAddedPerSecond);
                 Issues.CheckTroopsVsBays(S.TroopCapacity, ds.NumTroopBays);
                 Issues.CheckTroops(S.TroopCapacity, S.SurfaceArea);
                 Issues.CheckAccuracy(ds.WeaponAccuracies);

--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignStats.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignStats.cs
@@ -17,6 +17,8 @@ public class ShipDesignStats
     public int NumWeaponSlots;
     public int NumWeapons;
     public int NumOrdWeapons;
+    public float WeaponsArea;
+    public float KineticWeaponsArea;
     public int NumTroopBays;
 
     public float WeaponPowerNeeded;
@@ -73,6 +75,8 @@ public class ShipDesignStats
         NumWeaponSlots = S.Weapons.Sum(w => w.Module.Area);
         NumWeapons    = weapons.Count(w => !w.TruePD);
         NumOrdWeapons = weapons.Count(w => !w.TruePD && w.OrdinanceRequiredToFire > 0);
+        WeaponsArea   = weapons.Sum(w => !w.TruePD ? w.Module.Area : 0f);
+        KineticWeaponsArea = weapons.Sum(w => !w.TruePD && w.OrdinanceRequiredToFire > 0 ? w.Module.Area : 0);
         NumTroopBays  = modules.Count(m => m.IsTroopBay);
 
         WeaponPowerNeeded = weapons.Sum(w => w.PowerFireUsagePerSecond);

--- a/Ship_Game/Remnants.cs
+++ b/Ship_Game/Remnants.cs
@@ -646,6 +646,13 @@ namespace Ship_Game
             return SpawnShip(RemnantShipType.Portal, pos, out portal);
         }
 
+        public float GetHostileStrInPortalSystem(Ship portal)
+        {
+            return portal.System != null 
+                ? Owner.Threats.GetHostileStrengthAt(portal.System.Position, portal.System.Radius)
+                : Owner.Threats.GetHostileStrengthAt(portal.Position, portal.SensorRange);
+        }
+
         public bool CreateShip(Ship portal, bool needBomber, int numShips, out Ship ship)
         {
             ship = null;

--- a/Ship_Game/Ships/ShipModule.cs
+++ b/Ship_Game/Ships/ShipModule.cs
@@ -1112,20 +1112,20 @@ namespace Ship_Game.Ships
             if (HangarTimer <= 0f && (fighter == null || !fighter.Active))
             {
                 SetHangarShip(Ship.CreateShipFromHangar(Parent.Universe, this, carrier.Loyalty, carrier.Position + LocalCenter, carrier));
-
-                if (HangarShip == null)
+                if (HangarShip != null)
                 {
-                    Log.Warning($"Could not create ship from hangar, UID = {HangarShipUID}");
-                    return;
+                    HangarShip.DoEscort(Parent);
+                    HangarShip.Velocity = carrier.Velocity + Random.Direction2D() * HangarShip.STLSpeedLimit;
+                    HangarShip.Mothership = carrier;
+                    HangarTimer = HangarTimerConstant;
+                    CalculateModuleOffenseDefense(Parent.SurfaceArea, forceRecalculate: true);
+                    carrier.ChangeOrdnance(-HangarShip.ShipOrdLaunchCost);
+                    carrier.OnShipLaunched(HangarShip);
                 }
-
-                HangarShip.DoEscort(Parent);
-                HangarShip.Velocity = carrier.Velocity + Random.Direction2D() * HangarShip.STLSpeedLimit;
-                HangarShip.Mothership = carrier;
-                HangarTimer = HangarTimerConstant;
-                CalculateModuleOffenseDefense(Parent.SurfaceArea, forceRecalculate: true);
-                carrier.ChangeOrdnance(-HangarShip.ShipOrdLaunchCost);
-                carrier.OnShipLaunched(HangarShip);
+                else
+                {
+                    HangarTimer = 1; // try again in 1 secondd
+                }
             }
         }
 

--- a/Ship_Game/Ships/Ship_Initialize.cs
+++ b/Ship_Game/Ships/Ship_Initialize.cs
@@ -333,10 +333,15 @@ namespace Ship_Game.Ships
                 Ship template = GetShipTemplate(shipName);
                 if (parent.Ordinance >= template?.ShipOrdLaunchCost)
                     ship = CreateShipAtPoint(us, template, owner, p);
+                else
+                    return null;
             }
 
             if (ship == null)
+            {
+                Log.Warning($"Could not create ship from hangar, UID = {hangar.HangarShipUID}");
                 return null;
+            }
 
             ship.Mothership = parent;
             ship.Velocity   = parent.Velocity;

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -7997,8 +7997,8 @@ NoAmmoResupplyInCombat:
  RUS: "Без пополнения боезапаса в бою"
 DueToHighRatioOf:
  Id: 2551
- ENG: "Due to high ratio of Energy to Ordnance requiring weapons, the ship will not go to resupply if it's ammo reserves are low during combat."
- RUS: "Из-за высокого соотношения энергии и боеприпасов, требующих для оружия, корабль не пойдет на пополнение запасов, если во время боя у него мало боеприпасов, он будет вести огонь с энергет.вооружения."
+ ENG: "Due to high ratio of Energy to Ordnance requiring weapon areas, the ship will not go to resupply if it's ammo reserves are low during combat."
+ RUS: "Из-за высокого отношения энергии к артиллерийскому оружию, требующему площади вооружения, корабль не пойдет на пополнение запасов, если во время боя у него мало боеприпасов."
 GenerallyTheShipWillStay:
  Id: 2552
  ENG: "Generally, the ship will stay in combat with slightly reduced combat effectiveness, but it will be able to fight. It is up to you if you want to reduce the number of Energy weapons."


### PR DESCRIPTION
Fix: Supply ships with no ordnance left still try to supply other ships
Fix: Remove hangar ship warning when carrier does not have enough ordnance to launch a fighter
Fix: Low offense ships having same values even though some are more advanced.
AI: Move standby colony ship goal to AI expansion 
AI: Increase priority of scouts and colony ships
Refactor: Better calculation of ship resupply when ship has a blend of energy and kinetic weapons.
Refactor: Freighter picker logic. 
Refactor: Small changes in Remnant Portal code
Balance: AI expansion. 

