### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/AI/ShipAI/ShipAI.Goals.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Goals.cs
@@ -458,7 +458,7 @@ namespace Ship_Game.AI
                 StardateAdded = exportPlanet.Universe.StarDate;
                 TargetStation = targetStation;
 
-                ExportFrom.AddToOutgoingFreighterList(freighter);
+                ExportFrom.AddToOutgoingFreighterList(freighter, goodsType);
             }
 
             public TradePlan(Planet exportPlanet, Planet importPlanet, Goods goodsType, Ship freighter, float blockadeTimer)
@@ -470,7 +470,7 @@ namespace Ship_Game.AI
                 Freighter     = freighter;
                 StardateAdded = exportPlanet.Universe.StarDate;
 
-                ExportFrom.AddToOutgoingFreighterList(freighter);
+                ExportFrom.AddToOutgoingFreighterList(freighter, goodsType);
                 ImportTo.AddToIncomingFreighterList(freighter);
             }
 

--- a/Ship_Game/GameScreens/LoadGame/LoadGame.cs
+++ b/Ship_Game/GameScreens/LoadGame/LoadGame.cs
@@ -45,7 +45,7 @@ namespace Ship_Game.GameScreens.LoadGame
         public UniverseScreen Load(bool noErrorDialogs = false, bool startSimThread = true)
         {
             StartSimThread = startSimThread;
-            Log.LogEventStats(Log.GameEvent.LoadGame);
+            // Log.LogEventStats(Log.GameEvent.LoadGame); - disabled to save some error limit
             try
             {
                 Log.Write(ConsoleColor.Blue, $"LoadGame {SaveFile.Name}");

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
@@ -408,9 +408,9 @@ namespace Ship_Game
 
         void OnPacingClicked(UIButton b)
         {
-            P.Pace += OptionIncrement*0.25f;
-            if (P.Pace > 4f) P.Pace = 1f;
-            if (P.Pace < 1f) P.Pace = 4f;
+            P.Pace += OptionIncrement*0.5f;
+            if (P.Pace > 10f) P.Pace = 1f;
+            if (P.Pace < 1f) P.Pace = 10f;
         }
         
         void OnDifficultyClicked(UIButton b)

--- a/Ship_Game/Technology.cs
+++ b/Ship_Game/Technology.cs
@@ -141,16 +141,16 @@ namespace Ship_Game
             UniverseState us = universeState ?? throw new NullReferenceException(nameof(universeState));
 
             if (!GlobalStats.Defaults.ChangeResearchCostBasedOnSize)
-                return us.ProductionPace * Cost;
+                return us.P.Pace * Cost;
 
             float settingResearchMultiplier = us.SettingsResearchModifier;
             if (settingResearchMultiplier < 1f)
-                return us.ProductionPace * (Cost * settingResearchMultiplier.LowerBound(0.5f)).RoundTo10();
+                return us.P.Pace * (Cost * settingResearchMultiplier.LowerBound(0.5f)).RoundTo10();
 
             float costRatio = GetCostRatio(settingResearchMultiplier);
             float multiplierToUse = 1 + settingResearchMultiplier * costRatio;
 
-            return us.ProductionPace * (Cost * multiplierToUse.Clamped(1, 25)).RoundDownTo10();
+            return us.P.Pace * (Cost * multiplierToUse.Clamped(1, 25)).RoundDownTo10();
         }
         
         float GetCostRatio(float settingResearchMultiplier)

--- a/Ship_Game/Universe/SolarBodies/ColonyResource.cs
+++ b/Ship_Game/Universe/SolarBodies/ColonyResource.cs
@@ -9,6 +9,7 @@ namespace Ship_Game.Universe.SolarBodies
     public abstract class ColonyResource
     {
         [StarData] protected readonly Planet Planet;
+        [StarData] float AveragePercent;
         public bool Initialized { get; private set; }
 
         float PercentValue;
@@ -83,6 +84,23 @@ namespace Ship_Game.Universe.SolarBodies
         public float ColonistIncome(float yieldPerColonist)
         {
             return Percent * yieldPerColonist * Planet.PopulationBillion;
+        }
+
+        public void CalculateAveragePercentage()
+        {
+            AveragePercent = HelperFunctions.ExponentialMovingAverage(AveragePercent, Percent);
+        }
+
+        public void ResetAveragePercentage()
+        {
+            AveragePercent = 0;
+        }
+
+        public float GetAveragePercent()
+        {
+            if (AveragePercent < 0.05) return 0;
+            else if (AveragePercent > 0.95) return 1;
+            else return AveragePercent;
         }
 
         // Nominal workers needed to neither gain nor lose storage

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Colonize.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Colonize.cs
@@ -11,6 +11,7 @@ namespace Ship_Game
         {
             Empire oldOwner = Owner;
             Owner = newOwner;
+            Food.ResetAveragePercentage();
 
             if (oldOwner != null)
             {

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
@@ -89,7 +89,7 @@ public partial class Planet
         // Modify the number of turns that can use all production.
         turnsWithInfra *= priority.Clamped(0, 1);
         // Percentage of the pop allocated to production
-        float workPercentage = IsCybernetic ? 1 : 1 - Food.Percent;
+        float workPercentage = IsCybernetic ? 1 : 1 - Food.GetAveragePercent();
 
         // Getting the queue copied and inserting the new items into it to check time to finish
         // This is needed since the planet has dynamic production allocation based on queue items
@@ -102,7 +102,7 @@ public partial class Planet
         {
             QueueItem qi = modifiedQueue[i];
             // How much production will be created for this item (since some will be diverted to research)
-            float productionOutputForItem = workPercentage * EvaluateProductionQueue(qi) * PopulationBillion;
+            float productionOutputForItem = Prod.FlatBonus + workPercentage * EvaluateProductionQueue(qi) * PopulationBillion;
             // How much net production will be applied to the queue item after checking planet's trade state
             float netProdPerTurn = LimitedProductionExpenditure(turnsWithInfra <= 0 ? productionOutputForItem 
                 : productionOutputForItem + InfraStructure);

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
@@ -103,6 +103,16 @@ namespace Ship_Game
             NumFreightersPickingUpProd = NumOutgoingFreightersPickUp(outgoingFreighters, Goods.Production);
         }
 
+        void IncreaseOutgoingFreighters(Goods goods)
+        {
+            switch (goods) 
+            {
+                case Goods.Food:       OutgoingFoodFreighters++;      break;
+                case Goods.Production: OutgoingProdFreighters++;      break;
+                case Goods.Colonists:  OutGoingColonistsFreighters++; break;
+            }
+        }
+
         int GetFoodExportSlots()
         {
             if (TradeBlocked || !ExportFood)
@@ -263,8 +273,9 @@ namespace Ship_Game
                 IncomingFreighters.AddUniqueRef(ship);
         }
 
-        public void AddToOutgoingFreighterList(Ship ship)
+        public void AddToOutgoingFreighterList(Ship ship, Goods goods)
         {
+            IncreaseOutgoingFreighters(goods);
             lock (OutgoingFreighters)
                 OutgoingFreighters.AddUniqueRef(ship);
         }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_WorkDistribution.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_WorkDistribution.cs
@@ -90,6 +90,7 @@ namespace Ship_Game
         void AssignOtherWorldsWorkers(float percentFood, float percentProd, float wantedFoodIncome, float wantedProdIncome)
         {
             Food.Percent        = FarmToPercentage(percentFood, wantedFoodIncome);
+            Food.CalculateAveragePercentage();
             float remainingWork = 1 - Food.Percent;
             Prod.Percent        = WorkToPercentage(percentProd, wantedProdIncome).UpperBound(remainingWork);
             if (NonCybernetic)
@@ -163,6 +164,7 @@ namespace Ship_Game
                 farmers = 0.1f; // avoid crazy small percentage of labor
 
             Food.Percent = farmers * labor;
+            Food.CalculateAveragePercentage();
         }
 
         void AssignCoreWorldProduction(float labor)

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.UpdateGame.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.UpdateGame.cs
@@ -324,54 +324,6 @@ namespace Ship_Game
             return updated;
         }
 
-        // TODO: This needs to be reimplemented
-        void HandleArmageddon()
-        {
-            // todo figure what to do with this
-            /*
-            if (GlobalStats.RemnantArmageddon)
-            {
-                ArmageddonCountdown(timeStep);
-            }
-                ArmageddonTimer -= timeStep.FixedTime;
-                if (ArmageddonTimer < 0f)
-                {
-                    ArmageddonTimer = 300f;
-                    ++ArmageddonCounter;
-                    if (ArmageddonCounter > 5)
-                        ArmageddonCounter = 5;
-                    for (int i = 0; i < ArmageddonCounter; ++i)
-                    {
-                        Ship exterminator = Ship.CreateShipAtPoint("Remnant Exterminator", EmpireManager.Remnants,
-                                player.WeightedCenter + new Vector2(RandomMath.RandomBetween(-500000f, 500000f),
-                                    RandomMath.RandomBetween(-500000f, 500000f)));
-                        exterminator.AI.DefaultAIState = AIState.Exterminate;
-                    }
-                }
-            }
-            ArmageddonCountdown(timeStep);
-            */
-        }
-        
-        /*
-        void ArmageddonCountdown(FixedSimTime timeStep)
-        {
-            ArmageddonTimer -= timeStep.FixedTime;
-            if (ArmageddonTimer < 0f)
-            {
-                ArmageddonTimer = 300f;
-                ++ArmageddonCounter;
-                if (ArmageddonCounter > 5)
-                    ArmageddonCounter = 5;
-                for (int i = 0; i < ArmageddonCounter; ++i)
-                {
-                    var exterminator = Ship.CreateShipAtPoint("Remnant Exterminator", EmpireManager.Remnants,
-                                                              player.WeightedCenter + RandomMath.Vector2D(500_000f));
-                    exterminator.AI.DefaultAIState = AIState.Exterminate;
-                }
-            }
-        }*/
-
         void HandleGameSpeedChange(InputState input)
         {
             if (input.SpeedReset)
@@ -380,7 +332,7 @@ namespace Ship_Game
             {
                 bool unlimited = Debug || Debugger.IsAttached;
                 float speedMin = unlimited ? 0.0625f : 0.25f;
-                float speedMax = unlimited ? 128f    : 6f;
+                float speedMax = unlimited ? 128f    : 10f;
                 UState.GameSpeed = GetGameSpeedAdjust(input.SpeedUp).Clamped(speedMin, speedMax);
             }
         }


### PR DESCRIPTION
Feature: Allow game speed up to x10 in non debug. 
Feature: Allow pace o be max x10 slower. 
Fix: Use Pace in tech cost instead of Production pace
Fix: FlatProduction was ignored when calculating queue completion. 
Fix: Trade slot limit was ignored when several freighters could be assigned at the same turn, since freighter lists are updated once per turn now. This is relevant only for outgoing slots, since incoming trade is assigned at a rate of 1 slot per turn per goods.
Fix: Add EMA to colony resource percentage to flatten food percent calcs when calculating queue completion.
Refactor: Remove dead code.
Refactor: Disable load game sentry logs