### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/AI/ExpansionAI/ExpansionPlanner.cs
+++ b/Ship_Game/AI/ExpansionAI/ExpansionPlanner.cs
@@ -285,7 +285,7 @@ namespace Ship_Game.AI.ExpansionAI
             targetSystem = Owner.Random.ItemFilter(
                 ship.Universe.Systems,
                 sys => ship.System != sys && sys.IsFullyExploredBy(Owner)
-                    && Owner.KnownEnemyStrengthIn(sys) > 10 && sys.ShipList.Any(s => s.IsGuardian));
+                    && Owner.KnownEnemyStrengthIn(sys) > 10 && sys.ShipList.Any(s => s.IsGuardian || s.Loyalty.WeArePirates));
 
             return targetSystem != null;
         }

--- a/Ship_Game/AI/ExpansionAI/ExpansionPlanner.cs
+++ b/Ship_Game/AI/ExpansionAI/ExpansionPlanner.cs
@@ -28,6 +28,11 @@ namespace Ship_Game.AI.ExpansionAI
             ResetExpandSearchTimer();
         }
 
+        public void InitExpansionIntervalTimer(int id)
+        {
+            ExpansionIntervalTimer = Owner.DifficultyModifiers.ExpansionCheckInterval - id + 1;
+        }
+
         public Planet[] GetColonizationGoalPlanets()
         {
             return Owner.AI.SelectFromGoals((MarkForColonization c) => c.TargetPlanet);

--- a/Ship_Game/AI/ExpansionAI/ExpansionPlanner.cs
+++ b/Ship_Game/AI/ExpansionAI/ExpansionPlanner.cs
@@ -323,19 +323,14 @@ namespace Ship_Game.AI.ExpansionAI
                 MarkedForExploration.Remove(system);
         }
 
-        public void SetExpandSearchTimer(int value)
-        {
-            ExpandSearchTimer = value;
-        }
-
         public void SetMaxSystemsToCheckedDiv(int value)
         {
             MaxSystemsToCheckedDiv = value;
         }
 
-        public void ResetExpandSearchTimer()
+        void ResetExpandSearchTimer()
         {
-            SetExpandSearchTimer(Owner.DifficultyModifiers.ExpandSearchTurns);
+            ExpandSearchTimer = Owner.DifficultyModifiers.ExpandSearchTurns;
         }
     }
 }

--- a/Ship_Game/AI/ExpansionAI/ResearchStationPlanner.cs
+++ b/Ship_Game/AI/ExpansionAI/ResearchStationPlanner.cs
@@ -25,14 +25,15 @@ namespace Ship_Game.AI.ExpansionAI
         /// <summary>
         /// This will check relevant researchable planets/stars and set goals to deploy
         /// research stations, based on diplomacy situation and personality
+        /// ignoreDistance is used for testing
         /// </summary>
         /// 
-        public void RunResearchStationPlanner()
+        public void RunResearchStationPlanner(bool ignoreDistance = false)
         {
             if (!ShouldRunResearchMananger())
                 return;
 
-            ExplorableGameObject[] potentialExplorables = GetPotentialResearchableSolarBodies();
+            ExplorableGameObject[] potentialExplorables = GetPotentialResearchableSolarBodies(ignoreDistance);
             foreach (ExplorableGameObject researchable in potentialExplorables) 
             {
                 ProcessReserchable(researchable, Influense(researchable.Position));
@@ -91,15 +92,15 @@ namespace Ship_Game.AI.ExpansionAI
             return true;
         }
 
-        ExplorableGameObject[] GetPotentialResearchableSolarBodies()
+        ExplorableGameObject[] GetPotentialResearchableSolarBodies(bool ignoreDistance)
         {
             Array<ExplorableGameObject> solarBodies = new();
-            foreach (ExplorableGameObject solarBody in  Universe.ResearchableSolarBodies.Keys)
+            foreach (ExplorableGameObject solarBody in Universe.ResearchableSolarBodies.Keys)
             {
                 SolarSystem system = solarBody.System ?? solarBody as SolarSystem;
                 if (solarBody.IsExploredBy(Owner) 
                     && !solarBody.IsResearchStationDeployedBy(Owner) // this bit is for performance - faster than HasGoal
-                    && system.FiveClosestSystems.Any(s => s.HasPlanetsOwnedBy(Owner))
+                    && ignoreDistance || system.HasPlanetsOwnedBy(Owner) || system.FiveClosestSystems.Any(s => s.HasPlanetsOwnedBy(Owner))
                     && !Owner.AI.HasGoal(g => g.IsResearchStationGoal(solarBody))
                     && (Owner.Universe.Remnants == null 
                         || !Owner.Universe.Remnants.AI.HasGoal(g => g is RemnantPortal && g.TargetShip.System == solarBody)))

--- a/Ship_Game/AI/ExpansionAI/ResearchStationPlanner.cs
+++ b/Ship_Game/AI/ExpansionAI/ResearchStationPlanner.cs
@@ -96,8 +96,10 @@ namespace Ship_Game.AI.ExpansionAI
             Array<ExplorableGameObject> solarBodies = new();
             foreach (ExplorableGameObject solarBody in  Universe.ResearchableSolarBodies.Keys)
             {
-                if (solarBody.IsExploredBy(Owner)
+                SolarSystem system = solarBody.System ?? solarBody as SolarSystem;
+                if (solarBody.IsExploredBy(Owner) 
                     && !solarBody.IsResearchStationDeployedBy(Owner) // this bit is for performance - faster than HasGoal
+                    && system.FiveClosestSystems.Any(s => s.HasPlanetsOwnedBy(Owner))
                     && !Owner.AI.HasGoal(g => g.IsResearchStationGoal(solarBody))
                     && (Owner.Universe.Remnants == null 
                         || !Owner.Universe.Remnants.AI.HasGoal(g => g is RemnantPortal && g.TargetShip.System == solarBody)))

--- a/Ship_Game/AI/ShipAI/ShipAI.Goods.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Goods.cs
@@ -179,7 +179,7 @@ namespace Ship_Game.AI
             if (targetStation.System != null)
             {
                 Owner.Loyalty.AI.SpaceRoadsManager.AddSpaceRoadHeat(exportPlanet.System, 
-                    targetStation.System, Owner.CargoSpaceMax * 0.1f);
+                    targetStation.System, Owner.CargoSpaceMax * 1f);
             }
             Plan plan = Plan.PickupGoodsForStation;
             SetTradePlan(plan, exportPlanet, targetStation, goods);

--- a/Ship_Game/AI/ShipAI/ShipAI.Goods.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Goods.cs
@@ -176,6 +176,11 @@ namespace Ship_Game.AI
 
         public void SetupFreighterPlan(Planet exportPlanet, Ship targetStation, Goods goods)
         {
+            if (targetStation.System != null)
+            {
+                Owner.Loyalty.AI.SpaceRoadsManager.AddSpaceRoadHeat(exportPlanet.System, 
+                    targetStation.System, Owner.CargoSpaceMax * 0.1f);
+            }
             Plan plan = Plan.PickupGoodsForStation;
             SetTradePlan(plan, exportPlanet, targetStation, goods);
         }

--- a/Ship_Game/Commands/Goals/RemnantEngageEmpire.cs
+++ b/Ship_Game/Commands/Goals/RemnantEngageEmpire.cs
@@ -179,7 +179,7 @@ namespace Ship_Game.Commands.Goals
 
         GoalStep WaitForCompletion()
         {
-            if (Fleet.Ships.Count == 0)
+            if (Fleet == null || Fleet.Ships.Count == 0)
                 return GoalStep.GoalFailed; // fleet is dead
 
             if (!IsPortalValidOrRerouted())

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -490,6 +490,8 @@ namespace Ship_Game
         public bool CanTerraformPlanetTiles => IsBuildingUnlocked(Building.TerraformerId) && data.Traits.TerraformingLevel >= 2;
         public bool CanFullTerraformPlanets => IsBuildingUnlocked(Building.TerraformerId) && data.Traits.TerraformingLevel >= 3;
 
+        public float AverageSystemsSqdistFromCenter => OwnedSolarSystems.Average(s => s.Position.SqDist(WeightedCenter));
+
         public bool IsModuleUnlocked(string moduleUID) => UnlockedModulesDict.TryGetValue(moduleUID, out bool found) && found;
 
         public Map<string, TechEntry>.ValueCollection TechEntries => TechnologyDict.Values;
@@ -2101,6 +2103,10 @@ namespace Ship_Game
             {
                 Ship ship = ships[i];
                 ship.LoyaltyChangeByGift(this, addNotification: false);
+                if (ship.IsConstructor)
+                    ship.AI.OrderScrapShip();
+                if (ship.IsResearchStation)
+                    ship.AI.OrderScuttleShip();
             }
 
             AssimilateTech(target);

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -565,11 +565,12 @@ namespace Ship_Game
             OwnedPlanets.Remove(planet);
             Universe.OnPlanetOwnerRemoved(this, planet);
 
-            if (OwnedPlanets.All(p => p.System != planet.System)) // system no more in owned planets?
+            if (!planet.System.HasPlanetsOwnedBy(this)) // system no more in owned planets?
                 OwnedSolarSystems.Remove(planet.System);
 
             CalcWeightedCenter(calcNow: true);
             UpdateRallyPoints(); // update rally points every time OwnedPlanets changes
+            AI.SpaceRoadsManager.RemoveRoadIfNeeded(planet.System);
         }
 
         public void ClearAllPlanets()

--- a/Ship_Game/Gameplay/SpaceRoad.cs
+++ b/Ship_Game/Gameplay/SpaceRoad.cs
@@ -68,6 +68,7 @@ namespace Ship_Game.Gameplay
         public bool IsHot => Heat >= NumProjectors*2;
         public bool IsCold => Heat <= -(NumProjectors+2);
         public float Maintenance => Status == SpaceRoadStatus.Down ? 0 : OperationalMaintenance;
+        public bool HasSystem(SolarSystem s) => System1 == s || System2== s;
 
         [StarDataConstructor]
         public SpaceRoad()

--- a/Ship_Game/Remnants.cs
+++ b/Ship_Game/Remnants.cs
@@ -514,9 +514,9 @@ namespace Ship_Game
                 ? Level.UpperBound(10)  // Increase distance spread of checks by level
                 : (MaxLevel - Level).Clamped(2, 10); // Decrease spread to focus on quality targets
 
-            if (Level <= 5) // Level 5 or below will go for closest planets to the portal
+            if (Level < 10) // Level 9 or below will go for closest planets to the portal
                 nextPlanet = GetTargetPlanetByDistance(potentialPlanets, currentPlanet.Position, numPlanetsToTake);
-            else // Remnants higher than level 5 will go after high level planets
+            else // Remnants higher than level 9 will go after high level planets
                 nextPlanet = GetTargetPlanetByPop(potentialPlanets, numPlanetsToTake);
 
             return nextPlanet != null;
@@ -549,9 +549,8 @@ namespace Ship_Game
 
         public float RequiredAttackFleetStr(Empire targetEmpire)
         {
-            float empireMultiplier = targetEmpire.isPlayer ? 1f : 0.4f;
             float strMultiplier = 1 + (int)Owner.Universe.P.Difficulty*0.5f; // 1, 1.5, 2, 2.5
-            float str = targetEmpire.OffensiveStrength * strMultiplier * empireMultiplier;
+            float str = targetEmpire.OffensiveStrength * strMultiplier;
             float effectiveLevel = Level * strMultiplier;
             return str.Clamped(min: Level * Level * 1000 * strMultiplier,
                                max: str * effectiveLevel / MaxLevel);

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -1772,13 +1772,17 @@ namespace Ship_Game.Ships
                 }
             }
 
+            int offensiveArea = weaponArea + hangarArea;
+            if (offensiveArea == 0 && (IsDefaultTroopShip || IsSupplyShuttle || DesignRole == RoleName.scout))
+                return 0;
+
             if (IsPlatformOrStation) 
                 offense /= 2;
 
             if (!Carrier.HasFighterBays && !hasWeapons) 
                 offense = 0f;
 
-            return ShipBuilder.GetModifiedStrength(SurfaceArea, weaponArea + hangarArea, offense, defense);
+            return ShipBuilder.GetModifiedStrength(SurfaceArea, offensiveArea, offense, defense);
         }
 
         // UI statistics, show average repair per second

--- a/Ship_Game/Ships/Ship_Events.cs
+++ b/Ship_Game/Ships/Ship_Events.cs
@@ -138,6 +138,7 @@ namespace Ship_Game.Ships
 
         void OnResearchStationDeath()
         {
+            Loyalty.AI.SpaceRoadsManager.RemoveRoadIfNeeded(System);
             // must use the goal planet/system, since tether was removed when the ship died and no way to know
             // if it was researching  a planet or a star
             Goal researchGoal = Loyalty.AI.FindGoal(g => g is ProcessResearchStation && g.TargetShip == this);

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -520,11 +520,11 @@ namespace Ship_Game
         public void ApplyBombEnvEffects(float popKilled, float fertilityDamage, Empire attacker) // added by Fat Bastard
         {
             if (fertilityDamage.AlmostZero())
-                fertilityDamage = popKilled / 4; // Old bomb support
+                fertilityDamage = popKilled * 0.25f; // Old bomb support
 
             fertilityDamage *= attacker.data.BombEnvironmentDamageMultiplier;
-            float netPopKill = PopulationRatio > 0.1f ? popKilled * PopulationRatio.LowerBound(0.2f)  // Harder to kill sparse pop
-                                                      : popKilled; // Unless very small pop left
+            float netPopKill = PopulationRatio > 0.25f ? popKilled * PopulationRatio.LowerBound(0.5f) // Harder to kill sparse pop
+                                                       : popKilled; // Unless very small pop left
 
             Population -= 1000f * netPopKill;
             AddBaseFertility(-fertilityDamage); // environment suffers temp damage

--- a/Ship_Game/Universe/UniverseState_Empires.cs
+++ b/Ship_Game/Universe/UniverseState_Empires.cs
@@ -121,6 +121,10 @@ public partial class UniverseState
                 throw new InvalidOperationException($"Duplicate Player empire! previous={Player}  new={e}");
             Player = e;
         }
+        else
+        {
+            e.AI?.ExpansionAI.InitExpansionIntervalTimer(e.Id);
+        }
 
         switch (e.data.Traits.Name)
         {

--- a/UnitTests/ExoticSystems/ResearchStations.cs
+++ b/UnitTests/ExoticSystems/ResearchStations.cs
@@ -16,6 +16,8 @@ namespace UnitTests.ExoticSystems
         readonly Planet NewPlanet;
         readonly Planet EnemyHome;
 
+        void RunResearchStationPlanner() => Player.AI.ResearchStationsAI.RunResearchStationPlanner(ignoreDistance: true);
+
         public ResearchStations()
         {
             CreateUniverseAndPlayerEmpire();
@@ -40,17 +42,17 @@ namespace UnitTests.ExoticSystems
             AssertEqual(true, Player.CanBuildPlatforms);
             AssertEqual(true, Player.CanBuildResearchStations);
 
-            Player.AI.ResearchStationsAI.RunResearchStationPlanner();
+            RunResearchStationPlanner();
             // Not explored yet
             AssertEqual(false, Player.AI.HasGoal(g => g.IsResearchStationGoal(NewPlanet)));
 
             NewPlanet.SetExploredBy(Player);
-            Player.AI.ResearchStationsAI.RunResearchStationPlanner();
+            RunResearchStationPlanner();
             // No automation activated
             AssertEqual(false, Player.AI.HasGoal(g => g.IsResearchStationGoal(NewPlanet)));
 
             Player.AutoBuildResearchStations = true;
-            Player.AI.ResearchStationsAI.RunResearchStationPlanner();
+            RunResearchStationPlanner();
             AssertEqual(true, Player.AI.HasGoal(g => g.IsResearchStationGoal(NewPlanet)));
             AssertEqual(true, Player.AI.HasGoal(g => g.IsBuildingOrbitalFor(NewPlanet)));
 
@@ -59,13 +61,13 @@ namespace UnitTests.ExoticSystems
             AssertEqual(false, system.IsExploredBy(Player));
 
             // system not explored yet
-            Player.AI.ResearchStationsAI.RunResearchStationPlanner();
+            RunResearchStationPlanner();
             AssertEqual(false, Player.AI.HasGoal(g => g.IsResearchStationGoal(system)));
 
             system.SetExploredBy(Player);
-            Player.AI.ResearchStationsAI.RunResearchStationPlanner();
-            Player.AI.ResearchStationsAI.RunResearchStationPlanner();
-            Player.AI.ResearchStationsAI.RunResearchStationPlanner();
+            RunResearchStationPlanner();
+            RunResearchStationPlanner();
+            RunResearchStationPlanner();
             AssertEqual(true, Player.AI.HasGoal(g => g.IsResearchStationGoal(system)));
             AssertEqual(true, Player.AI.HasGoal(g => g.IsBuildingOrbitalFor(system)));
         }


### PR DESCRIPTION
Feature: Add space station systems to road manager 
AI: Sniff around systems with known pirate activity as well 
AI: Avoid Research Station Deployment if position is too far, based on empire weighted center.
Balance:  Remnant AI.
Balance: Bomb pop killed calcs
Balance: Research station planner to run every 1 year.
Fix: Dont create road or add heat/cool when not auto managing space roads
Fix: Research Station unittest
Fix: Crash in RemnantEngageEmpire goal
Fix: Remove research stations after merge to prevent non goal research stations.
Fix: Set default supply, troop and scout ships str to 0
Refactor: Load balance expansion planner so every turn 1 or 2 empires will run it.
@gkapulis 