### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/AI/EmpireAI/EmpireAI.RunEconomicPlanner.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.RunEconomicPlanner.cs
@@ -150,7 +150,7 @@ namespace Ship_Game.AI
 
         float DetermineBuildCapacity(float treasuryGoal, float risk, float percentOfMoney)
         {
-            float buildBudget    = SetBudgetForArea(percentOfMoney, treasuryGoal, risk);
+            float buildBudget = SetBudgetForArea(percentOfMoney, treasuryGoal, risk);
             return buildBudget;
         }
 

--- a/Ship_Game/AI/EmpireAI/EmpireAI.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.cs
@@ -330,11 +330,13 @@ namespace Ship_Game.AI
             {
                 Ship ship = offPool[i];
                 if (ship.AI.BadGuysNear
+                    || ship.IsFreighter
                     || ship.AI.HasPriorityOrder
                     || ship.AI.HasPriorityTarget
                     || !ship.CanBeRefitted
                     || ship.IsResearchStation
-                    || ship.ShipData.IsColonyShip)
+                    || ship.ShipData.IsColonyShip
+                    || ship.IsConstructor)
                 {
                     continue;
                 }

--- a/Ship_Game/AI/EmpireAI/ShipBuilder.cs
+++ b/Ship_Game/AI/EmpireAI/ShipBuilder.cs
@@ -9,7 +9,7 @@ namespace Ship_Game.AI
     public static class ShipBuilder  // Created by Fat Bastard to support ship picking for build
     {
         public const int OrbitalsLimit  = 27; // FB - Maximum of 27 stations or platforms (or shipyards)
-        public const int ShipYardsLimit = 2; // FB - Maximum of 2 shipyards
+        public const int ShipYardsLimit = 3; // FB - Maximum of 3 shipyards
 
         public static IShipDesign PickFromCandidates(
             RoleName role, Empire empire, int maxSize = 0,

--- a/Ship_Game/AI/Research/ShipTechLineFocusing.cs
+++ b/Ship_Game/AI/Research/ShipTechLineFocusing.cs
@@ -239,11 +239,8 @@ namespace Ship_Game.AI.Research
             {
                 if (OwnerEmpire.TryGetTechEntry(shipTech, out TechEntry test))
                 {
-                    // repeater compensator. This needs some deeper logic.
-                    // I current just say if you research one level.
-                    // Dont research any more.
-                    if (test.MaxLevel > 1 && test.Level > 1) continue;
-                    bestShipTechs.Add(test);
+                    if (test.MaxLevel <= 1 || test.Level < test.MaxLevel) 
+                        bestShipTechs.Add(test);
                 }
             }
             return bestShipTechs;

--- a/Ship_Game/AI/ShipAI/ShipAI.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.cs
@@ -874,7 +874,7 @@ namespace Ship_Game.AI
             for (int i = 0; i < enemies.Length; ++i)
             {
                 var enemy = (Ship)enemies[i];
-                if (!enemy.Active || enemy.Dying || enemy.BaseStrength == 0)
+                if (!enemy.Active || enemy.Dying || enemy.BaseStrength == 0 || enemy.IsFreighter)
                     continue;
 
                 projector.PlayerProjectorHasSeenEmpires.SetSeen(enemy.Loyalty, time);

--- a/Ship_Game/AI/ThreatMatrix.cs
+++ b/Ship_Game/AI/ThreatMatrix.cs
@@ -182,6 +182,17 @@ public sealed partial class ThreatMatrix
     }
 
     /// <summary>
+    /// Gets all Rival Specific Faction clusters with a station
+    /// </summary>
+    public ThreatCluster[] GetPirateBases(Empire pirates)
+    {
+        if (pirates.WeArePirates)
+            return RivalClusters.Filter(c => c.HasStarBases && c.Loyalty == pirates);
+
+        return new ThreatCluster[0];
+    }
+
+    /// <summary>
     /// Gets all systems where rival hostile factions exist
     /// </summary>
     public ICollection<SolarSystem> GetAllSystemsWithFactions()

--- a/Ship_Game/Commands/Goals/AssaultPirateBase.cs
+++ b/Ship_Game/Commands/Goals/AssaultPirateBase.cs
@@ -28,6 +28,10 @@ namespace Ship_Game.Commands.Goals
             };
         }
 
+        /// <summary>
+        /// Assault a pirate base. If no base is provided (null), it will use the closest 
+        /// pirate base to empire center.
+        /// </summary>
         public AssaultPirateBase(Empire e, Empire pirateEmpire, Ship targetBase = null) : this(e)
         {
             TargetEmpire = pirateEmpire;
@@ -44,9 +48,7 @@ namespace Ship_Game.Commands.Goals
             if (!Pirates.GetBases(out Array<Ship> bases))
                 return GoalStep.GoalFailed;
 
-            EmpireAI ai = Owner.AI;
-            var filteredBases = bases.Filter(s => !ai.HasAssaultPirateBaseTask(s, out _));
-
+            var filteredBases = bases.Filter(s => !Owner.AI.HasAssaultPirateBaseTask(s, out _));
             if (!GetClosestBaseToCenter(filteredBases, out Ship closestPirateBase))
                 return GoalStep.GoalFailed;
 
@@ -84,7 +86,7 @@ namespace Ship_Game.Commands.Goals
         bool GetClosestBaseToCenter(Ship[] basesList, out Ship closestPirateBase)
         {
             Vector2 empireCenter = Owner.WeightedCenter;
-            closestPirateBase = basesList.FindMin(b => b.Position.Distance(empireCenter));
+            closestPirateBase = basesList.FindMin(b => b.Position.SqDist(empireCenter));
             return closestPirateBase != null;
         }
     }

--- a/Ship_Game/Commands/Goals/BuildOrbital.cs
+++ b/Ship_Game/Commands/Goals/BuildOrbital.cs
@@ -56,7 +56,8 @@ namespace Ship_Game.Commands.Goals  // Created by Fat Bastard
             PlanetBuildingAt = planetBuildingAt;
             IShipDesign constructor = BuildableShip.GetConstructor(Owner);
 
-            PlanetBuildingAt.Construction.Enqueue(ToBuild.IsResearchStation ? QueueItemType.OrbitalUrgent : QueueItemType.Orbital,
+            PlanetBuildingAt.Construction.Enqueue(ToBuild.IsResearchStation || ToBuild.IsShipyard 
+                ? QueueItemType.OrbitalUrgent : QueueItemType.Orbital,
                 ToBuild, constructor, rush: false, this);
         }
 

--- a/Ship_Game/Commands/Goals/EmpireDefense.cs
+++ b/Ship_Game/Commands/Goals/EmpireDefense.cs
@@ -130,12 +130,13 @@ namespace Ship_Game.Commands.Goals
                 possibleValue /= Owner.WeightedCenter.Distance(possiblePos).LowerBound(1);
             }
 
+            possibleValue *= (int)possibleTask.Importance;
             return defenseValue > possibleValue;
         }
 
         bool ShouldConsiderDefendingAlly(SolarSystem system, Empire ally)
         {
-            float  priority = (system.DefenseTaskPriority() * 0.2f).Clamped(0.1f, 1f);  // lower is more important
+            float priority = (system.DefenseTaskPriority() * 0.2f).Clamped(0.1f, 1f);  // lower is more important
             float distanceToThem = system.Position.Distance(ally.WeightedCenter);
             float distanceToUs   = system.Position.Distance(Owner.WeightedCenter) * priority;
             float ratio = distanceToUs / distanceToThem.LowerBound(1);

--- a/Ship_Game/Commands/Goals/MarkForColonization.cs
+++ b/Ship_Game/Commands/Goals/MarkForColonization.cs
@@ -198,7 +198,7 @@ namespace Ship_Game.Commands.Goals
                     PlanetBuildingAt?.Construction.Cancel(this);
                     FinishedShip.DoColonize(TargetPlanet, this);
                     ChangeToStep(WaitForColonizationComplete);
-                    return GoalStep.GoToNextStep;
+                    return GoalStep.TryAgain;
                 }
             }
             else // we have a ship

--- a/Ship_Game/Commands/Goals/ProcessResearchStation.cs
+++ b/Ship_Game/Commands/Goals/ProcessResearchStation.cs
@@ -255,8 +255,7 @@ namespace Ship_Game.Commands.Goals
         void CallForHelpIfNeeded()
         {
             SolarSystem system = TargetPlanet?.System ?? TargetSystem;
-            if (ResearchStation.HealthPercent < 0.95f 
-                && ResearchStation.AI.BadGuysNear
+            if (ResearchStation.AI.BadGuysNear
                 && Owner.KnownEnemyStrengthIn(system) > 0
                 && (system.OwnerList.Count == 0 || system.HasPlanetsOwnedBy(Owner))
                 && !Owner.HasWarTaskTargetingSystem(system))

--- a/Ship_Game/Commands/Goals/ProcessResearchStation.cs
+++ b/Ship_Game/Commands/Goals/ProcessResearchStation.cs
@@ -255,9 +255,9 @@ namespace Ship_Game.Commands.Goals
         void CallForHelpIfNeeded()
         {
             SolarSystem system = TargetPlanet?.System ?? TargetSystem;
-            if (ResearchStation.AI.BadGuysNear
-                && Owner.KnownEnemyStrengthIn(system) > 0
-                && (system.OwnerList.Count == 0 || system.HasPlanetsOwnedBy(Owner))
+            if ((system.OwnerList.Count == 0 || system.HasPlanetsOwnedBy(Owner))
+                && (ResearchStation.HealthPercent < 0.95
+                   || system.ShipList.Any(s => s.IsResearchStation && s.Loyalty.IsAtWarWith(ResearchStation.Loyalty)))
                 && !Owner.HasWarTaskTargetingSystem(system))
             {
                 Owner.AddDefenseSystemGoal(system, Owner.KnownEnemyStrengthIn(system), AI.Tasks.MilitaryTaskImportance.Normal);

--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -4501,6 +4501,13 @@ namespace Ship_Game
         AllowPlayerInterTradeTitle = 4436,
         /// <summary>Allows your idle freighters to transfer</summary>
         AllowPlayerInterTradeTip = 4437,
+        /// <summary>Hot Lava surrounds this tile</summary>
+        LavaPoolTerraformable = 4438,
+        /// <summary>Random</summary>
+        RandomGameMode = 4439,
+        /// <summary>in Random game mode, you may win the</summary>
+        InRandomGameMode = 4440,
+
 
 
 

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -439,6 +439,9 @@ namespace Ship_Game
 
             foreach (Ship s in OwnedShips)
             {
+                if (s.IsResearchStation)
+                    s.QueueTotalRemoval();
+
                 s.LoyaltyChangeFromBoarding(rebels, false);
             }
             EmpireShips.Clear();

--- a/Ship_Game/EmpireDifficultyModifers.cs
+++ b/Ship_Game/EmpireDifficultyModifers.cs
@@ -184,7 +184,7 @@
                     RemnantNumBombers    = 1.25f;
                     BaseColonyGoals      = 5;
                     ColonyGoalMultiplier = 1;
-                    StandByColonyShips   = 3;
+                    StandByColonyShips   = 4;
                     TrustLostStoleColony = 15;
                     FleetStrModifier     = 0.4f;
                     NumSystemsToSniff    = 4;
@@ -229,7 +229,7 @@
                     RemnantNumBombers    = 1.5f;
                     BaseColonyGoals      = 6;
                     ColonyGoalMultiplier = 1;
-                    StandByColonyShips   = 3;
+                    StandByColonyShips   = 5;
                     TrustLostStoleColony = 20;
                     FleetStrModifier     = 0.5f;
                     NumSystemsToSniff    = 5;

--- a/Ship_Game/Empire_Trade.cs
+++ b/Ship_Game/Empire_Trade.cs
@@ -315,7 +315,7 @@ namespace Ship_Game
             for (int i = 0; i < ships.Length; i++)
             {
                 Ship idleFreighter = ships[i];
-                CheckForRefitFreighter(idleFreighter, 20, betterFreighter);
+                CheckForRefitFreighter(idleFreighter, 25, betterFreighter);
             }
         }
 

--- a/Ship_Game/Empire_War.cs
+++ b/Ship_Game/Empire_War.cs
@@ -120,7 +120,7 @@ namespace Ship_Game
         {
             // todo advanced mission types per personality or prepare for war strategy
             MilitaryTask.TaskType taskType = MilitaryTask.TaskType.StrikeForce;
-            MilitaryTaskImportance importance = MilitaryTaskImportance.Normal;
+            MilitaryTaskImportance importance = MilitaryTaskImportance.Important;
             if (IsAlreadyStriking())
             {
                 if (CanBuildBombers
@@ -129,12 +129,12 @@ namespace Ship_Game
                          || targetPlanet.ColonyPotentialValue(enemy) / targetPlanet.ColonyPotentialValue(this) > PersonalityModifiers.DoomFleetThreshold))
                 {
                     taskType = MilitaryTask.TaskType.GlassPlanet;
-                    importance = MilitaryTaskImportance.Important;
+                    importance = MilitaryTaskImportance.Normal;
                 }
                 else
                 {
                     taskType = MilitaryTask.TaskType.AssaultPlanet;
-                    importance = MilitaryTaskImportance.Important;
+                    importance = MilitaryTaskImportance.Normal;
                 }
             }
 

--- a/Ship_Game/Empire_War.cs
+++ b/Ship_Game/Empire_War.cs
@@ -129,12 +129,12 @@ namespace Ship_Game
                          || targetPlanet.ColonyPotentialValue(enemy) / targetPlanet.ColonyPotentialValue(this) > PersonalityModifiers.DoomFleetThreshold))
                 {
                     taskType = MilitaryTask.TaskType.GlassPlanet;
-                    importance = MilitaryTaskImportance.Normal;
+                    importance = MilitaryTaskImportance.Important;
                 }
                 else
                 {
                     taskType = MilitaryTask.TaskType.AssaultPlanet;
-                    importance = MilitaryTaskImportance.Normal;
+                    importance = MilitaryTaskImportance.Important;
                 }
             }
 

--- a/Ship_Game/ExtensionMethods/HelperFunctions.cs
+++ b/Ship_Game/ExtensionMethods/HelperFunctions.cs
@@ -248,17 +248,20 @@ namespace Ship_Game
             return empire.DifficultyModifiers.DataVisibleToPlayer;
         }
 
-        public static bool GetLoneSystem(UniverseState u, out SolarSystem system)
+        public static bool GetLoneSystem(UniverseState u, out SolarSystem system, bool includeReseachable)
         {
-            system = u.Random.ItemFilter(u.Systems, s => s.RingList.Count == 0 && !s.PiratePresence);
+            system = u.Random.ItemFilter(u.Systems, s => s.RingList.Count == 0 
+                                                         && !s.PiratePresence
+                                                         && includeReseachable || !s.IsResearchable);
             return system != null;
         }
 
-        // This also Filters Researchable systems (but not planets)
+        // This also Filters Researchable systems
         public static bool GetUnownedNormalSystems(UniverseState u, out SolarSystem[] systems)
         {
             systems = u.Systems.Filter(s => s.OwnerList.Count == 0
                                          && s.RingList.Count > 0
+                                         && !s.IsResearchable
                                          && !s.PiratePresence
                                          && !s.PlanetList.Any(p => p.IsResearchable)
                                          && !s.ShipList.Any(g => g.IsGuardian));

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
@@ -363,6 +363,7 @@ namespace Ship_Game
             switch (P.Mode)
             {
                 default:
+                case GameMode.Random:        return GameText.RandomGameMode;
                 case GameMode.Sandbox:       return GameText.Sandbox;
                 case GameMode.Elimination:   return GameText.CapitalElimination;
                 case GameMode.Corners:       return GameText.Corners;
@@ -377,6 +378,7 @@ namespace Ship_Game
             switch (P.Mode)
             {
                 default:
+                case GameMode.Random:        return GameText.InRandomGameMode;
                 case GameMode.Sandbox:       return GameText.InTheSandboxGameMode;
                 case GameMode.Elimination:   return GameText.InTheCapitalEliminationGame;
                 case GameMode.Corners:       return GameText.CornersIsARaceMatch;
@@ -637,7 +639,7 @@ namespace Ship_Game
         
         public enum GameMode
         {
-            Sandbox, SmallClusters, BigClusters, Corners, Elimination, Ring
+            Random, Sandbox, SmallClusters, BigClusters, Corners, Elimination, Ring
         }
 
         public enum StarsAbundance

--- a/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
+++ b/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
@@ -277,11 +277,12 @@ namespace Ship_Game.GameScreens.NewGame
             step.Start(Systems.Count);
             switch (Mode)
             {
-                case RaceDesignScreen.GameMode.Corners:       GenerateCornersGameMode(step); break;
-                case RaceDesignScreen.GameMode.BigClusters:   GenerateBigClusters(step);     break;
-                case RaceDesignScreen.GameMode.SmallClusters: GenerateSmallClusters(step);   break;
-                case RaceDesignScreen.GameMode.Ring:          GenerateRingMap(step);         break;
-                default:                                      GenerateRandomMap(step);       break;
+                case RaceDesignScreen.GameMode.Corners:       GenerateCornersGameMode(step);  break;
+                case RaceDesignScreen.GameMode.BigClusters:   GenerateBigClusters(step);      break;
+                case RaceDesignScreen.GameMode.SmallClusters: GenerateSmallClusters(step);    break;
+                case RaceDesignScreen.GameMode.Ring:          GenerateRingMap(step);          break;
+                case RaceDesignScreen.GameMode.Sandbox:       GenerateRandomMap(step, false); break;
+                default:                                      GenerateRandomMap(step, true);  break;
             }
         }
 
@@ -329,12 +330,12 @@ namespace Ship_Game.GameScreens.NewGame
             }
         }
 
-        void SolarSystemSpacing(ProgressCounter step)
+        void SolarSystemSpacing(ProgressCounter step, bool randomStartingPos)
         {
             foreach (SystemPlaceHolder sys in Systems)
             {
                 float spacing = 350000f;
-                if (sys.IsStartingSystem)
+                if (sys.IsStartingSystem && !randomStartingPos)
                     continue; // We created starting systems before
 
                 if (sys.DontStartNearPlayer)
@@ -463,13 +464,17 @@ namespace Ship_Game.GameScreens.NewGame
             return sysPos;
         }
 
-        void GenerateRandomMap(ProgressCounter step)
+        void GenerateRandomMap(ProgressCounter step, bool randomStartingPos)
         {
-            // FB - we are using the sector creation only for starting systems here. the rest will be created randomly
-            (int numHorizontalSectors, int numVerticalSectors) = GetNumSectors((NumOpponents + 1).LowerBound(9));
-            Array<Sector> sectors = GenerateSectors(numHorizontalSectors, numVerticalSectors, 0.1f);
-            GenerateClustersStartingSystems(step, sectors);
-            SolarSystemSpacing(step);
+            if (!randomStartingPos)
+            {
+                // FB - we are using the sector creation only for starting systems here. the rest will be created randomly
+                (int numHorizontalSectors, int numVerticalSectors) = GetNumSectors((NumOpponents + 1).LowerBound(9));
+                Array<Sector> sectors = GenerateSectors(numHorizontalSectors, numVerticalSectors, 0.1f);
+                GenerateClustersStartingSystems(step, sectors);
+            }
+
+            SolarSystemSpacing(step, randomStartingPos);
         }
 
         void GenerateRingMap(ProgressCounter step)

--- a/Ship_Game/Gameplay/Relationship.cs
+++ b/Ship_Game/Gameplay/Relationship.cs
@@ -540,7 +540,8 @@ namespace Ship_Game.Gameplay
             if (us.IsDefeated)
                 return;
 
-            Risk.UpdateRiskAssessment(us);
+            if (!us.IsFaction)
+                Risk.UpdateRiskAssessment(us);
 
             bool noAttackPlayer = GlobalStats.RestrictAIPlayerInteraction && them.isPlayer;
             if (noAttackPlayer)

--- a/Ship_Game/Remnants.cs
+++ b/Ship_Game/Remnants.cs
@@ -308,8 +308,8 @@ namespace Ship_Game
                 case RemnantStory.AncientBalancers:     target = FindStrongestByAveragePopAndStr(empiresList, 1.25f); break;
                 case RemnantStory.AncientExterminators: target = FindWeakestEmpire(empiresList);                      break;
                 case RemnantStory.AncientRaidersRandom: target = Owner.Random.Item(empiresList);                      break;
-                case RemnantStory.AncientPeaceKeepers:  target = FindStrongestEmpireAtWar(empiresList);               break;
-                case RemnantStory.AncientWarMongers:    target = FindStrongestEmpireAtPeace(empiresList);             break;
+                case RemnantStory.AncientPeaceKeepers:  target = FindRandomEmpireAtWar(empiresList);                  break;
+                case RemnantStory.AncientWarMongers:    target = FindRandomEmpireAtPeace(empiresList);                break;
             }
 
             return target != null;
@@ -327,22 +327,22 @@ namespace Ship_Game
             return expectedTarget == currentTarget;
         }
 
-        Empire FindStrongestEmpireAtPeace(Empire[] empiresList)
+        Empire FindRandomEmpireAtPeace(Empire[] empiresList)
         {
             var potentialTargets = empiresList.Filter(e => !e.IsAtWarWithMajorEmpire);
             if (potentialTargets.Length == 0)
-                return Universe.Player;
+                return null;
 
-            return FindStrongestByAveragePopAndStr(potentialTargets);
+            return Owner.Random.Item(potentialTargets); ;
         }
 
-        Empire FindStrongestEmpireAtWar(Empire[] empiresList)
+        Empire FindRandomEmpireAtWar(Empire[] empiresList)
         {
             var potentialTargets = empiresList.Filter(e => e.IsAtWarWithMajorEmpire);
             if (potentialTargets.Length == 0)
-                return null;
+                return Universe.Player;
 
-            return FindStrongestByAveragePopAndStr(potentialTargets);
+            return Owner.Random.Item(potentialTargets); ;
         }
 
         Empire FindStrongestByAveragePopAndStr(Empire[] empiresList, float ratioOverAverageThreshold = 1f)

--- a/Ship_Game/Remnants.cs
+++ b/Ship_Game/Remnants.cs
@@ -634,7 +634,7 @@ namespace Ship_Game
             systemName         = "";
 
             if (!GetRadiatingStars(u, out SolarSystem[] systems)) // Prefer stars which emit radiation
-                if (!GetLoneSystem(u, out system)) // Try a lone system
+                if (!GetLoneSystem(u, out system, includeReseachable: true)) // Try a lone system
                     if (!GetUnownedNormalSystems(u, out systems)) // Fallback to any unowned system
                         return false; // Could not find a spot
 

--- a/Ship_Game/Remnants.cs
+++ b/Ship_Game/Remnants.cs
@@ -87,6 +87,31 @@ namespace Ship_Game
 
         float StepXpTrigger => (ShipRole.GetMaxExpValue() * StoryStep * StoryStep * 0.5f).UpperBound(ActivationXpNeeded);
         float ProductionLimit => 300 * Level * Level * ((int)Universe.P.Difficulty + 1);  // Level 20 - 480K 
+        public float ExpansionRisk => 0; // Might change this based on future story
+        public float BorderRisk(Empire empire)
+        {
+            if (!Activated || Owner.IsDefeated || !GetPortals(out Ship[] portals))
+                return 0;
+
+            int numCloseSystems = portals.Sum(p => p.System.FiveClosestSystems.Sum(s => s.HasPlanetsOwnedBy(empire) ? 1 : 0));
+            return numCloseSystems * 0.05f;
+        }
+
+        public float ThreatRisk(Empire empire)
+        {
+            if (!Activated || Owner.IsDefeated)
+                return 0;
+
+            float risk = Level * 0.025f * ((int)Universe.P.Difficulty + 1);
+            if (Story == RemnantStory.AncientRaidersRandom)
+                return risk;
+
+            if (FindValidTarget(out Empire target) && target == empire)
+                return risk * 2;
+
+            return risk;
+        }
+
 
         void Activate()
         {

--- a/Ship_Game/ShipGroup.cs
+++ b/Ship_Game/ShipGroup.cs
@@ -636,10 +636,10 @@ namespace Ship_Game
                     // from its final target position, see UpdateWarpThrust() for more details on SetWarpPercent
                     speedCapSTL = speedCapSTL != 0f ? Math.Min(speedCapSTL, ship.MaxSTLSpeed) : ship.MaxSTLSpeed;
                     speedCapFTL = speedCapFTL != 0f ? Math.Min(speedCapFTL, ship.MaxFTLSpeed) : ship.MaxFTLSpeed;
-                    if (!gotCapableStragglers && !IsShipInFormation(ship, 30000f))
+                    if (!gotCapableStragglers && !IsShipInFormation(ship, 30_000))
                     {
                         float angleDiff = AveragePos.AngleToTargetWithFacing(ship.Position, ship.RotationDegrees);
-                        if (angleDiff > 100)
+                        if (angleDiff > 150)
                             gotCapableStragglers = true;
                     }
                 }

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -1773,8 +1773,12 @@ namespace Ship_Game.Ships
             }
 
             int offensiveArea = weaponArea + hangarArea;
-            if (offensiveArea == 0 && (IsDefaultTroopShip || IsSupplyShuttle || DesignRole == RoleName.scout))
+            if (offensiveArea == 0
+                && (IsDefaultTroopShip || IsSupplyShuttle || DesignRole == RoleName.scout
+                    || IsSubspaceProjector || IsFreighter))
+            {
                 return 0;
+            }
 
             if (IsPlatformOrStation) 
                 offense /= 2;

--- a/Ship_Game/Ships/ShipMaintenance.cs
+++ b/Ship_Game/Ships/ShipMaintenance.cs
@@ -74,13 +74,14 @@ namespace Ship_Game.Ships
             }
 
             maint += maint * empire.data.Traits.MaintMod + numTroops * TroopMaint;
-            maint *= empire.Universe.P.ShipMaintenanceMultiplier;
 
             // Projectors do not get any more modifiers
             if (ship.IsSubspaceProjector)
                  return maint;
 
-            // Reduced maintenance for shipyards (sitting ducks, no offense) Shipyards are limited to 3.
+            maint *= empire.Universe.P.ShipMaintenanceMultiplier;
+
+            // Reduced maintenance for shipyards (sitting ducks, no offense) Shipyards are limited to 2.
             if (ship.IsShipyard)
                 maint *= 0.4f;
 

--- a/Ship_Game/Ships/Ship_Events.cs
+++ b/Ship_Game/Ships/Ship_Events.cs
@@ -138,7 +138,6 @@ namespace Ship_Game.Ships
 
         void OnResearchStationDeath()
         {
-            Loyalty.AI.SpaceRoadsManager.RemoveRoadIfNeeded(System);
             // must use the goal planet/system, since tether was removed when the ship died and no way to know
             // if it was researching  a planet or a star
             Goal researchGoal = Loyalty.AI.FindGoal(g => g is ProcessResearchStation && g.TargetShip == this);
@@ -155,6 +154,8 @@ namespace Ship_Game.Ships
             {
                 Log.Error($"On Ship die - research station {Name} no goal found!");
             }
+
+            Loyalty.AI.SpaceRoadsManager.RemoveRoadIfNeeded(System);
         }
 
         void AddInhibitionInvestigationIfNeeded()

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
@@ -461,10 +461,10 @@ namespace Ship_Game
                 case 1:  WantedPlatforms = 0; WantedStations = 0; WantedShipyards = 0; break;
                 case 2:  WantedPlatforms = 0; WantedStations = 0; WantedShipyards = 0; break;
                 case 3:  WantedPlatforms = 3; WantedStations = 1; WantedShipyards = 0; break;
-                case 4:  WantedPlatforms = 3; WantedStations = 1; WantedShipyards = 0; break;
-                case 5:  WantedPlatforms = 4; WantedStations = 2; WantedShipyards = 0; break;
-                case 6:  WantedPlatforms = 4; WantedStations = 2; WantedShipyards = 1; break;
-                case 7:  WantedPlatforms = 5; WantedStations = 3; WantedShipyards = 1; break;
+                case 4:  WantedPlatforms = 3; WantedStations = 1; WantedShipyards = 1; break;
+                case 5:  WantedPlatforms = 4; WantedStations = 2; WantedShipyards = 2; break;
+                case 6:  WantedPlatforms = 4; WantedStations = 2; WantedShipyards = 2; break;
+                case 7:  WantedPlatforms = 5; WantedStations = 3; WantedShipyards = 2; break;
                 case 8:  WantedPlatforms = 5; WantedStations = 3; WantedShipyards = 2; break;
                 case 9:  WantedPlatforms = 6; WantedStations = 3; WantedShipyards = 2; break;
                 case 10: WantedPlatforms = 7; WantedStations = 4; WantedShipyards = 2; break;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
@@ -463,16 +463,16 @@ namespace Ship_Game
                 case 3:  WantedPlatforms = 3; WantedStations = 1; WantedShipyards = 0; break;
                 case 4:  WantedPlatforms = 3; WantedStations = 1; WantedShipyards = 1; break;
                 case 5:  WantedPlatforms = 4; WantedStations = 2; WantedShipyards = 2; break;
-                case 6:  WantedPlatforms = 4; WantedStations = 2; WantedShipyards = 2; break;
-                case 7:  WantedPlatforms = 5; WantedStations = 3; WantedShipyards = 2; break;
-                case 8:  WantedPlatforms = 5; WantedStations = 3; WantedShipyards = 2; break;
-                case 9:  WantedPlatforms = 6; WantedStations = 3; WantedShipyards = 2; break;
-                case 10: WantedPlatforms = 7; WantedStations = 4; WantedShipyards = 2; break;
-                case 11: WantedPlatforms = 8; WantedStations = 4; WantedShipyards = 2; break;
-                case 12: WantedPlatforms = 9; WantedStations = 5; WantedShipyards = 2; break;
-                case 13: WantedPlatforms = 9; WantedStations = 5; WantedShipyards = 2; break;
-                case 14: WantedPlatforms = 9; WantedStations = 6; WantedShipyards = 2; break;
-                case 15: WantedPlatforms = 9; WantedStations = 6; WantedShipyards = 2; break;
+                case 6:  WantedPlatforms = 4; WantedStations = 2; WantedShipyards = 3; break;
+                case 7:  WantedPlatforms = 5; WantedStations = 3; WantedShipyards = 3; break;
+                case 8:  WantedPlatforms = 5; WantedStations = 3; WantedShipyards = 3; break;
+                case 9:  WantedPlatforms = 6; WantedStations = 3; WantedShipyards = 3; break;
+                case 10: WantedPlatforms = 7; WantedStations = 4; WantedShipyards = 3; break;
+                case 11: WantedPlatforms = 8; WantedStations = 4; WantedShipyards = 3; break;
+                case 12: WantedPlatforms = 9; WantedStations = 5; WantedShipyards = 3; break;
+                case 13: WantedPlatforms = 9; WantedStations = 5; WantedShipyards = 3; break;
+                case 14: WantedPlatforms = 9; WantedStations = 6; WantedShipyards = 3; break;
+                case 15: WantedPlatforms = 9; WantedStations = 6; WantedShipyards = 3; break;
                 default: WantedPlatforms = 0; WantedStations = 0; WantedShipyards = 0; break;
             }
 

--- a/Ship_Game/Universe/UniverseParams.cs
+++ b/Ship_Game/Universe/UniverseParams.cs
@@ -25,7 +25,7 @@ public class UniverseParams
     
     [StarData] public int NumSystems;
     [StarData] public int NumOpponents;
-    [StarData] public GameMode Mode = GameMode.Sandbox;
+    [StarData] public GameMode Mode = GameMode.Random;
     [StarData(DefaultValue=1f)] public float Pace = 1f;
     [StarData(DefaultValue=1f)] public float StarsModifier = 1f;
 

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -6832,13 +6832,13 @@ Opponents:
  SPA: "Rivales"
 Sandbox:
  Id: 2103
- ENG: "Sandbox"
+ ENG: "Balanced Sandbox"
  RUS: "Песочница"
- SPA: "Espacio cerrado"
+ SPA: "Caja de arena equilibrada"
 Ascension:
  Id: 2104
  ENG: "Ascension"
- RUS: "Вознесение"
+ RUS: "Сбалансированная песочница"
  SPA: "Ascensión"
 GameMode:
  Id: 2105
@@ -6847,9 +6847,9 @@ GameMode:
  SPA: "Modo de juego"
 InTheSandboxGameMode:
  Id: 2106
- ENG: "Sandbox game mode is very similar to Random game mode, but starting positions are balanced so each Empire has some room to expand before encountering other Empires."
- RUS: "В режиме \"Песочница\" вы можете выиграть, завоевав всех ваших противников или объединив всю галактику в альянс."
- SPA: "Режим игры «Песочница» очень похож на режим «Случайная игра», но стартовые позиции сбалансированы, поэтому у каждой Империи есть место для расширения перед встречей с другими Империями."
+ ENG: "Balanced Sandbox game mode is very similar to Random Sandbox game mode, but starting positions are balanced so each Empire has some room to expand before encountering other Empires."
+ RUS: "Игровой режим «Сбалансированная песочница» очень похож на игровой режим «Случайная песочница», но стартовые позиции сбалансированы, поэтому у каждой Империи есть пространство для расширения, прежде чем столкнуться с другими Империями."
+ SPA: "El modo de juego Balanced Sandbox es muy similar al modo de juego Random Sandbox, pero las posiciones iniciales están equilibradas para que cada imperio tenga espacio para expandirse antes de encontrarse con otros imperios."
 InTheAscensionGameMode:
  Id: 2107
  ENG: "In the Ascension game mode, the goal is to be the first race to ascend to Godhood by capturing the Remnant homeworld at the center of the galaxy."
@@ -10426,14 +10426,14 @@ LavaPoolTerraformable:
   ENG: "Hot Lava surrounds this tile, making habitation impossible. This natural pool can be Terraformed when we have the right technology."
 RandomGameMode:
  Id: 4439
- ENG: "Random"
- RUS: "случайный"
- SPA: "Aleatorio"    
+ ENG: "Random Sandbox"
+ RUS: "Случайная песочница"
+ SPA: "Caja de arena aleatoria"    
 InRandomGameMode:
  Id: 4440
- ENG: "In Random game mode, you may win the game by conquering all of your enemies or by uniting the galaxy in alliance. Starting positions are randomized."
- RUS: "В режиме \"Песочница\" вы можете выиграть, завоевав всех ваших противников или объединив всю галактику в альянс. Начальные позиции рандомизированы."
- SPA: "En el modo Espacio cerrado, se gana al conquistar el territorio de todos los enemigos o al unir la galaxia en una única alianza. Las posiciones iniciales son aleatorias."  
+ ENG: "In Random Sandbox game mode, you may win the game by conquering all of your enemies or by uniting the galaxy in alliance. Starting positions are randomized."
+ RUS: "В режиме случайной песочницы вы можете выиграть игру, победив всех своих врагов или объединив галактику в альянс. Начальные позиции рандомизированы."
+ SPA: "En el modo de juego Random Sandbox, puedes ganar el juego conquistando a todos tus enemigos o uniendo la galaxia en una alianza. Las posiciones iniciales son aleatorias."  
 ResearchLabName:
  Id: 4989
  ENG: "Research Lab"

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -6847,9 +6847,9 @@ GameMode:
  SPA: "Modo de juego"
 InTheSandboxGameMode:
  Id: 2106
- ENG: "In the Sandbox game mode, you may win the game by conquering all of your enemies or by uniting the galaxy in alliance. "
+ ENG: "Sandbox game mode is very similar to Random game mode, but starting positions are balanced so each Empire has some room to expand before encountering other Empires."
  RUS: "В режиме \"Песочница\" вы можете выиграть, завоевав всех ваших противников или объединив всю галактику в альянс."
- SPA: "En el modo Espacio cerrado, se gana al conquistar el territorio de todos los enemigos o al unir la galaxia en una única alianza. "
+ SPA: "Режим игры «Песочница» очень похож на режим «Случайная игра», но стартовые позиции сбалансированы, поэтому у каждой Империи есть место для расширения перед встречей с другими Империями."
 InTheAscensionGameMode:
  Id: 2107
  ENG: "In the Ascension game mode, the goal is to be the first race to ascend to Godhood by capturing the Remnant homeworld at the center of the galaxy."
@@ -10424,6 +10424,16 @@ AllowPlayerInterTradeTip:
 LavaPoolTerraformable:
   Id: 4438
   ENG: "Hot Lava surrounds this tile, making habitation impossible. This natural pool can be Terraformed when we have the right technology."
+RandomGameMode:
+ Id: 4439
+ ENG: "Random"
+ RUS: "случайный"
+ SPA: "Aleatorio"    
+InRandomGameMode:
+ Id: 4440
+ ENG: "In Random game mode, you may win the game by conquering all of your enemies or by uniting the galaxy in alliance. Starting positions are randomized."
+ RUS: "В режиме \"Песочница\" вы можете выиграть, завоевав всех ваших противников или объединив всю галактику в альянс. Начальные позиции рандомизированы."
+ SPA: "En el modo Espacio cerrado, se gana al conquistar el territorio de todos los enemigos o al unir la galaxia en una única alianza. Las posiciones iniciales son aleatorias."  
 ResearchLabName:
  Id: 4989
  ENG: "Research Lab"

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -6497,7 +6497,7 @@ BB_Tech_Shipyards_Name:
  SPA: "Astilleros"
 BB_Tech_Shipyards_Desc:
  Id: 2036
- ENG: "Dedicated orbital shipbuilding facilities will allow us to streamline our production process and provide large efficiency bonuses to our efforts. When built at a colony, a station will be placed in geosynchronous orbit (limited to 2 Shipyards per colony, 27 total orbital stytuctures). Stations may also be built in deep space. See the help menu for details."
+ ENG: "Dedicated orbital shipbuilding facilities will allow us to streamline our production process and provide large efficiency bonuses to our efforts. When built at a colony, a station will be placed in geosynchronous orbit (limited to 3 Shipyards per colony, 27 total orbital structures). Stations may also be built in deep space. See the help menu for details."
  RUS: "Орбитальные судостроительные верфи позволят нам поставить производственный процесс на поток и значительно повысить его эффективность. При строительстве в колонии станция будет размещена на геостационарной орбите. Также станции можно строить в глубоком космосе. Подробнее см. в меню справки."
  SPA: "Son instalaciones orbitales dedicadas a la construcción de naves que nos permiten racionalizar nuestros procesos de producción y aportan grandes bonificaciones. Si se construyen en una colonia, se situarán en órbita geosincrónica. Estas estaciones también pueden edificarse en el espacio profundo. Encontrarás más detalles en el menú de ayuda."
 BB_Tech_Shipyards_Bonus:


### PR DESCRIPTION
Feature: Added Random game mode (Sandbox with randomized starting positions)
Feature: AI colonization - shirt circuit and cancel ongoing colony ships in queue if a colony ship from standby goals was grabbed.
Feature: Research Station multiple supply freighters, based on deficit. 

Fix: Optional maintenance multiplier affected projectors although in the tooltip it said it didnt.
Fix: AI ability to research multi level techs above level 2.
Fix: AI Check for standby colony ship per turn. 
Fix: AI expansion - use fleet str multiplier for determining if strong enough to claim remnant defended planets
Fix: SSP sensing civilian ships. 
Fix: Research station do not call for help even if at war.
Fix: Remove research stations when empire is defeated. 
Fix: Dont spawn pirate bases in researchable systems/planets in some cases.
Fix: Dont update risk for factions
Fix: Roads not removed when a research station dies. 
Fix: Trigger refit refitted all freighters at once for the AI cause massive freighter gaps.
Fix: Fleet formation speed are slowed when some ships are in wide angle and far away, but at similar distance

Balance: AI: Increase chances to attack unknown pirate bases based on Stardate.
Balance: AI - defensive task priority balance
Balance: Remnant Warmongers and peacekeepers empire targeting logic
Balance: Remnant empire targeting logic
Balance: Increase Shipyard limit to 3, increase shipyard build priorities
Balance: AI research station call defense fleets logic.
Balance: Shipyard limit cat in AI build defense

Refactor: Find Closest Pirate Base for AI assault
Refactor: AI risk calcs for Build Capacity

