### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/AI/EmpireAI/EmpireAI.RunEconomicPlanner.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.RunEconomicPlanner.cs
@@ -122,12 +122,14 @@ namespace Ship_Game.AI
                 SSP                += budgetBalance;
             }
 
-            DefenseBudget   = ExponentialMovingAverage(DefenseBudget, DetermineDefenseBudget(treasuryGoal, defense, ThreatLevel));
-            SSPBudget       = ExponentialMovingAverage(SSPBudget, DetermineSSPBudget(treasuryGoal, SSP));
-            BuildCapacity   = ExponentialMovingAverage(BuildCapacity, DetermineBuildCapacity(treasuryGoal, ThreatLevel, build));
-            SpyBudget       = ExponentialMovingAverage(SpyBudget, DetermineSpyBudget(treasuryGoal, spy));
-            ColonyBudget    = ExponentialMovingAverage(ColonyBudget, DetermineColonyBudget(treasuryGoal, colony));
-            TerraformBudget = ExponentialMovingAverage(TerraformBudget, DetermineColonyBudget(treasuryGoal, terraform));
+            float moneyStrategy = treasuryGoal.LowerBound(money);
+
+            DefenseBudget   = ExponentialMovingAverage(DefenseBudget, DetermineDefenseBudget(moneyStrategy, defense, ThreatLevel));
+            SSPBudget       = ExponentialMovingAverage(SSPBudget, DetermineSSPBudget(moneyStrategy, SSP));
+            BuildCapacity   = ExponentialMovingAverage(BuildCapacity, DetermineBuildCapacity(moneyStrategy, ThreatLevel, build));
+            SpyBudget       = ExponentialMovingAverage(SpyBudget, DetermineSpyBudget(moneyStrategy, spy));
+            ColonyBudget    = ExponentialMovingAverage(ColonyBudget, DetermineColonyBudget(moneyStrategy, colony));
+            TerraformBudget = ExponentialMovingAverage(TerraformBudget, DetermineColonyBudget(moneyStrategy, terraform));
 
             PlanetBudgetDebugInfo();
             float allianceBudget = 0;

--- a/Ship_Game/AI/EmpireAI/EmpireRiskAssessment.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireRiskAssessment.cs
@@ -57,7 +57,7 @@ namespace Ship_Game.AI
             if (Them.WeArePirates)
                 return Them.Pirates.Level * 0.1f;
 
-            if (Them.WeArePirates)
+            if (Them.WeAreRemnants)
                 return Them.Remnants.ExpansionRisk;
 
             float expansion = us.GetExpansionRatio() * 0.25f;

--- a/Ship_Game/AI/ShipAI/ShipAI.Goals.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Goals.cs
@@ -238,6 +238,15 @@ namespace Ship_Game.AI
             AddShipGoal(Plan.Colonize, planet.Position, Vectors.Up, planet, g, AIState.Colonize);
         }
 
+        public void OrderMoveAndStandByColonize(Planet planet, Goal g)
+        {
+            float distanceToWait = Owner.Loyalty.GetProjectorRadius() * 1.2f;
+            Vector2 dir = planet.Position.DirectionToTarget(Owner.Position);
+            Vector2 pos = planet.Position + dir * distanceToWait;
+            OrderMoveToNoStop(pos, -dir, AIState.Colonize, MoveOrder.AddWayPoint, goal: g);
+            AddShipGoal(Plan.StandByColonize, AIState.Colonize);
+        }
+
         public void OrderMoveAndRebase(Planet p)
         {
             Vector2 direction = Owner.Position.DirectionToTarget(p.Position);
@@ -528,7 +537,8 @@ namespace Ship_Game.AI
             DropOffGoodsForStation = 37,
             ResearchStationResearching = 38, // for shipUIinfo display only
             ResearchStationIdle = 39, // for shipUIinfo display only
-            ResearchStationNoSupply = 40 // for shipUIinfo display only
+            ResearchStationNoSupply = 40, // for shipUIinfo display only
+            StandByColonize = 41
         }
     }
 }

--- a/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
@@ -561,11 +561,12 @@ namespace Ship_Game.AI
             IgnoreCombat = true;
             ClearWayPoints();
 
+            /* // FB - traying again without it after code changes
             if (!Owner.Loyalty.isPlayer)
             {
                 // bugfix: Avoid lingering fleets for the AI
                 Owner.Fleet?.RemoveShip(Owner, returnToEmpireAI: false, clearOrders: clearOrders);
-            }
+            }*/
 
             Target = null;
             SetOrbitTarget(toOrbit);

--- a/Ship_Game/AI/ShipAI/ShipAI.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.cs
@@ -4,7 +4,6 @@ using Ship_Game.Ships;
 using Ship_Game.Utils;
 using System;
 using System.Diagnostics.Contracts;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using SDUtils;
 using Ship_Game.Data.Serialization;
@@ -239,6 +238,12 @@ namespace Ship_Game.AI
         public bool IsExploring => State == AIState.Explore
                                 || ExplorationTarget != null
                                 || OrderQueue.Any(g => g.Plan == Plan.Explore);
+
+
+        void DoStandByColonize(FixedSimTime timeStep)
+        {
+            ReverseThrustUntilStopped(timeStep);
+        }
 
         void DoColonize(ShipGoal shipGoal)
         {
@@ -501,6 +506,8 @@ namespace Ship_Game.AI
 
         void EvaluateShipGoal(FixedSimTime timeStep, ShipGoal goal)
         {
+            if (Owner.Name == "LALA")
+                Log.Info("d");
             switch (goal.Plan)
             {
                 case Plan.AwaitOrders:              DoAwaitOrders(timeStep, goal);            break;
@@ -517,6 +524,7 @@ namespace Ship_Game.AI
                 case Plan.RotateInlineWithVelocity: RotateInLineWithVelocity(timeStep);       break;
                 case Plan.Orbit:                    Orbit.Orbit(goal.TargetPlanet, timeStep); break;
                 case Plan.Colonize:                 DoColonize(goal);                         break;
+                case Plan.StandByColonize:          DoStandByColonize(timeStep);              break;
                 case Plan.Explore:                  DoExplore(timeStep);                      break;
                 case Plan.Rebase:                   DoRebase(timeStep, goal);                 break;
                 case Plan.DefendSystem:             DoSystemDefense(timeStep);                break;

--- a/Ship_Game/AI/ShipAI/ShipAI.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.cs
@@ -452,8 +452,22 @@ namespace Ship_Game.AI
                 Owner.AI.IgnoreCombat = false;
                 if (Owner.Fleet != null)
                     OrderMoveTo(Owner.Fleet.GetFinalPos(Owner), Owner.Fleet.FinalDirection, State);
+                else if (ShouldNotReturnToLastPos())
+                    ClearOrders();
 
                 Owner.Supply.ResetIncomingOrdnance(supplyType);
+
+                bool ShouldNotReturnToLastPos()
+                {
+                    if (OrderQueue.TryPeekFirst(out ShipGoal nextGoal) && nextGoal.MovePosition != Vector2.Zero)
+                    {
+                        Vector2 movePos = nextGoal.MovePosition;
+                        return Owner.Universe.Influence.GetInfluenceStatus(Owner.Loyalty, MovePosition) == Universe.InfluenceStatus.Enemy
+                                || Owner.Loyalty.AI.ThreatMatrix.GetHostileStrengthAt(movePos, Owner.SensorRange * 2) > Owner.GetStrength();
+                    }
+
+                    return false;
+                }
             }
         }
 

--- a/Ship_Game/AI/ShipAI/ShipAI.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.cs
@@ -506,8 +506,6 @@ namespace Ship_Game.AI
 
         void EvaluateShipGoal(FixedSimTime timeStep, ShipGoal goal)
         {
-            if (Owner.Name == "LALA")
-                Log.Info("d");
             switch (goal.Plan)
             {
                 case Plan.AwaitOrders:              DoAwaitOrders(timeStep, goal);            break;

--- a/Ship_Game/Commands/Goals/ProcessResearchStation.cs
+++ b/Ship_Game/Commands/Goals/ProcessResearchStation.cs
@@ -280,7 +280,7 @@ namespace Ship_Game.Commands.Goals
             if (InSupplyChain)
             {
                 SupplyDificit = (SupplyDificit + value).LowerBound(0);
-                NumSupplyGoals = ((int)Math.Ceiling(SupplyDificit / Owner.AverageFreighterCargoCap)).Clamped(1,10);
+                NumSupplyGoals = ((int)Math.Ceiling(SupplyDificit / Owner.AverageFreighterCargoCap)).Clamped(1, 5);
             }
         }
 

--- a/Ship_Game/Commands/Goals/StandbyColonyShip.cs
+++ b/Ship_Game/Commands/Goals/StandbyColonyShip.cs
@@ -31,7 +31,7 @@ namespace Ship_Game.Commands.Goals
                 return GoalStep.TryAgain;
 
             PlanetBuildingAt = planet;
-            planet.Construction.Enqueue(colonyShip, QueueItemType.ColonyShip, this);
+            planet.Construction.Enqueue(colonyShip, QueueItemType.ColonyShipClaim, this);
             return GoalStep.GoToNextStep;
         }
 

--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -4512,6 +4512,9 @@ namespace Ship_Game
 
 
 
+
+        /// <summary>Ship Maintenance Modifier</summary>
+        ShipMaintenanceModifier = 4988,
         /// <summary>on surface</summary>
         OnSurface = 4993,
         /// <summary>in space</summary>

--- a/Ship_Game/Data/RacialTrait.cs
+++ b/Ship_Game/Data/RacialTrait.cs
@@ -104,6 +104,7 @@ namespace Ship_Game
         [StarData] public int Miners;
         [StarData] public float ProductionMod;
         [StarData] public float MaintMod; // ex: -0.25
+        [StarData] public float ShipMaintMultiplier = 1; // ex: 0.75
         [StarData] public float InBordersSpeedBonus = 0.5f;
         [StarData] public float TaxMod; // bonus tax modifier
         [StarData] public float ShipCostMod;

--- a/Ship_Game/Debug/Page/EmpireInfoDebug.cs
+++ b/Ship_Game/Debug/Page/EmpireInfoDebug.cs
@@ -123,17 +123,16 @@ public class EmpireInfoDebug : DebugPage
         {
             string plural = rel.Them.data.Traits.Plural;
             Text.Color = rel.Them.EmpireColor;
-            if (rel.Treaty_NAPact)
-                Text.String(15f, "NA Pact with " + plural);
-
-            if (rel.Treaty_Trade)
-                Text.String(15f, "Trade Pact with " + plural);
-
-            if (rel.Treaty_OpenBorders)
-                Text.String(15f, "Open Borders with " + plural);
-
             if (rel.AtWar)
                 Text.String(15f, $"War with {plural} ({rel.ActiveWar?.WarType})");
+            else if (rel.Treaty_Alliance)
+                Text.String(15f, "Alliance with " + plural);
+            else if (rel.Treaty_OpenBorders)
+                Text.String(15f, "Open Borders with " + plural);
+            else if (rel.Treaty_Trade)
+                Text.String(15f, "Trade Pact with " + plural);
+            else if (rel.Treaty_NAPact)
+                Text.String(15f, "NA Pact with " + plural);
         }
 
         if (Screen.SelectedSystem != null)

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -2318,6 +2318,17 @@ namespace Ship_Game
                 AI.AddGoal(new BuildScout(this));
         }
 
+        public bool TryFindClosestScoutTo(Vector2 pos, out Ship scout)
+        {
+            scout = null;
+            var ships = OwnedShips;
+            var potentialScouts = OwnedShips.Filter(s => s.IsGoodScout());
+            if (potentialScouts.Length > 0)
+                scout = potentialScouts.FindMin(s => s.Position.SqDist(pos));
+
+            return scout != null;
+        }
+
         private void ApplyFertilityChange(float amount)
         {
             if (amount.AlmostEqual(0)) return;

--- a/Ship_Game/Empire_Relationship.cs
+++ b/Ship_Game/Empire_Relationship.cs
@@ -762,7 +762,7 @@ namespace Ship_Game
                       $"\n{Localizer.Token(GameText.DueToLosingWarUS)}";
 
             // AI A merged with AI B due to a losing war with AI C
-            return $"{Name} {Localizer.Token(GameText.HasMergedWith)} {absorber}" +
+            return $"{Name} {Localizer.Token(GameText.HasMergedWith)} {absorber.Name}" +
                       $"\n{Localizer.Token(GameText.DueToLosingWarThem)} {enemy.Name}";
         }
     }

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -2355,12 +2355,14 @@ namespace Ship_Game.Fleets
                 }
             }
             // We are far from formation
-            else if (distToWP < distSquadPosToWP)
+            else if (distToWP < distSquadPosToWP) // anglediff will be below 90
             {
-                if (distToSquadPos > 100_000 && angleDiff > 45)
+                if (distToSquadPos > 100_000 && angleDiff > 25)
                 {
+                    float limit = (angleDiff+10) * 0.01f;
                     // We are ahead, but at a wide angle that allows us to continue full speed
-                    (speedSTL, speedFTL) = (ship.MaxSTLSpeed, ship.MaxFTLSpeed);
+                    speedSTL = Math.Max(ship.MaxSTLSpeed * limit, STLSpeedLimit * 0.25f);
+                    speedFTL = Math.Max(ship.MaxFTLSpeed * limit, FTLSpeedLimit * 0.25f);
                 }
                 else
                 {

--- a/Ship_Game/GameScreens/ColonyScreen/QueueItem.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/QueueItem.cs
@@ -187,7 +187,7 @@ namespace Ship_Game
     public enum QueueItemType
     {
         ColonyShip,
-        ColonyShipClaim,
+        ColonyShipClaim, // change to ColonyShipPriority when spinning a savegame version
         Freighter,
         Scout,
         Troop,

--- a/Ship_Game/GameScreens/MainDiplomacyScreen/MainDiplomacyScreen.cs
+++ b/Ship_Game/GameScreens/MainDiplomacyScreen/MainDiplomacyScreen.cs
@@ -583,8 +583,15 @@ namespace Ship_Game
                     DrawStat(Localizer.Token(GameText.ShipMassModifier), SelectedEmpire.data.MassModifier - 1f, ref textCursor, true);
                 if (SelectedEmpire.data.Traits.TaxMod != 0)
                     DrawStat(Localizer.Token(GameText.TaxIncomeModifier), SelectedEmpire.data.Traits.TaxMod, ref textCursor, false);
-                if (SelectedEmpire.data.Traits.MaintMod != 0)
-                    DrawStat(Localizer.Token(GameText.MaintenanceModifier), SelectedEmpire.data.Traits.MaintMod, ref textCursor, true);
+                if (SelectedEmpire.data.Traits.MaintMod != 0 || SelectedEmpire.data.Traits.ShipMaintMultiplier < 1)
+                {
+                    if (SelectedEmpire.data.Traits.MaintMod != 0 )
+                        DrawStat(Localizer.Token(GameText.MaintenanceModifier), SelectedEmpire.data.Traits.MaintMod, ref textCursor, true);
+
+                    float shipMaintTotal = ((1 + SelectedEmpire.data.Traits.MaintMod) * SelectedEmpire.data.Traits.ShipMaintMultiplier) - 1;
+                    DrawStat(Localizer.Token(GameText.ShipMaintenanceModifier), shipMaintTotal, ref textCursor, true);
+                }
+
                 DrawStat(Localizer.Token(GameText.InbordersFtlBonus), SelectedEmpire.data.Traits.InBordersSpeedBonus, ref textCursor, false);
                 if (Universe.UState.P.FTLModifier != 1f)
                 {

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
@@ -639,7 +639,7 @@ namespace Ship_Game
         
         public enum GameMode
         {
-            Random, Sandbox, SmallClusters, BigClusters, Corners, Elimination, Ring
+            Sandbox, Random, SmallClusters, BigClusters, Corners, Elimination, Ring
         }
 
         public enum StarsAbundance

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
@@ -278,18 +278,32 @@ namespace Ship_Game
         public static (int NumStars, float StarNumModifier)
             GetNumStars(StarsAbundance abundance, GalSize galaxySize, int numOpponents)
         {
-            float starNumModifier = ((int)abundance + 1) * 0.25f;
+            float starNumModifier;
+            switch (abundance)
+            {
+                case StarsAbundance.VeryRare:    starNumModifier = 0.3f;  break;
+                case StarsAbundance.Rare:        starNumModifier = 0.5f;  break;
+                case StarsAbundance.Uncommon:    starNumModifier = 0.8f;  break;
+                default:
+                case StarsAbundance.Normal:      starNumModifier = 1f;    break;
+                case StarsAbundance.Abundant:    starNumModifier = 1.1f;  break;
+                case StarsAbundance.Crowded:     starNumModifier = 1.25f; break;
+                case StarsAbundance.Packed:      starNumModifier = 1.5f;  break;
+                case StarsAbundance.SuperPacked: starNumModifier = 1.8f;  break;
+            }
+
+
             int numSystemsFromSize;
             switch (galaxySize)
             {
                 default:
-                case GalSize.Tiny: numSystemsFromSize = 16; break;
-                case GalSize.Small: numSystemsFromSize = 36; break;
-                case GalSize.Medium: numSystemsFromSize = 60; break;
-                case GalSize.Large: numSystemsFromSize = 80; break;
-                case GalSize.Huge: numSystemsFromSize = 96; break;
-                case GalSize.Epic: numSystemsFromSize = 112; break;
-                case GalSize.TrulyEpic: numSystemsFromSize = 124; break;
+                case GalSize.Tiny:      numSystemsFromSize = 16;  break;
+                case GalSize.Small:     numSystemsFromSize = 36;  break;
+                case GalSize.Medium:    numSystemsFromSize = 60;  break;
+                case GalSize.Large:     numSystemsFromSize = 80;  break;
+                case GalSize.Huge:      numSystemsFromSize = 100; break;
+                case GalSize.Epic:      numSystemsFromSize = 120; break;
+                case GalSize.TrulyEpic: numSystemsFromSize = 150; break;
             }
 
             int numStars = (int)(numSystemsFromSize * starNumModifier)
@@ -639,7 +653,7 @@ namespace Ship_Game
         
         public enum GameMode
         {
-            Sandbox, Random, SmallClusters, BigClusters, Corners, Elimination, Ring
+            Sandbox, Random, Ring, SmallClusters, BigClusters, Elimination, Corners
         }
 
         public enum StarsAbundance

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
@@ -230,6 +230,8 @@ namespace Ship_Game
                     || tEnt.HomeworldSizeMod < 0f && (traits.HomeworldSizeMod < 0f || traits.HistoryTraitSmallHomeWorld)
                     || tEnt.HomeworldFertMod < 0f && (traits.HomeworldFertMod < 0f || traits.HistoryTraitPollutedHomeWorld) && tEnt.HomeworldRichMod == 0f
                     || tEnt.HomeworldFertMod < 0f && (traits.HomeworldRichMod > 0f || traits.HistoryTraitIndustrializedHomeWorld) && tEnt.HomeworldRichMod != 0f
+                    || tEnt.HomeworldRichMod > 0 && (traits.HomeworldRichMod > 0f)
+                    || tEnt.HomeworldFertMod > 0 && (traits.HomeworldFertMod > 0f)
                     || (traits.Militaristic > 0 || traits.HistoryTraitMilitaristic) && tEnt.Militaristic > 0 
                     || (traits.PassengerModifier > 1 || traits.HistoryTraitManifestDestiny) && tEnt.PassengerModifier > 1
                     || (traits.PassengerBonus > 0 || traits.HistoryTraitManifestDestiny) && tEnt.PassengerBonus > 0

--- a/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
+++ b/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
@@ -289,15 +289,16 @@ namespace Ship_Game.GameScreens.NewGame
         void GenerateSystems(ProgressCounter step)
         {
             step.Start(Systems.Count);
+            float researchableMultiplier = (100f / Systems.Count).UpperBound(1);
             foreach (SystemPlaceHolder placeHolder in Systems)
             {
                 Empire e = placeHolder.Owner;
                 var sys = new SolarSystem(UState, placeHolder.Position);
 
                 if (placeHolder.Data != null)
-                    sys.GenerateFromData(UState, Random, placeHolder.Data, e);
+                    sys.GenerateFromData(UState, Random, placeHolder.Data, e, researchableMultiplier);
                 else
-                    sys.GenerateRandomSystem(UState, Random, placeHolder.SystemName, e);
+                    sys.GenerateRandomSystem(UState, Random, placeHolder.SystemName, e, researchableMultiplier);
 
                 if (e != null && e.GetOwnedSystems().Count == 0)
                 {

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -1745,6 +1745,9 @@ namespace Ship_Game.Ships
 
         public float CalculateShipStrength()
         {
+            if (IsMeteor)
+                return 0;
+
             float offense   = 0;
             float defense   = 0;
             int weaponArea  = 0;

--- a/Ship_Game/Ships/ShipMaintenance.cs
+++ b/Ship_Game/Ships/ShipMaintenance.cs
@@ -73,8 +73,7 @@ namespace Ship_Game.Ships
                     maint *= 0.5f;
             }
 
-            maint += maint * empire.data.Traits.MaintMod + numTroops * TroopMaint;
-
+            maint = maint * (1 + empire.data.Traits.MaintMod) * empire.data.Traits.ShipMaintMultiplier + numTroops * TroopMaint;
             // Projectors do not get any more modifiers
             if (ship.IsSubspaceProjector)
                  return maint;

--- a/Ship_Game/TechEntry.cs
+++ b/Ship_Game/TechEntry.cs
@@ -995,6 +995,7 @@ namespace Ship_Game
                 case "Tax Bonus": data.Traits.TaxMod += unlockedBonus.Bonus; break;
                 case "Repair Bonus": data.Traits.RepairMod += unlockedBonus.Bonus; break;
                 case "Maintenance Bonus": data.Traits.MaintMod -= unlockedBonus.Bonus; break;
+                case "Ship Maintenance Bonus": data.Traits.ShipMaintMultiplier -= unlockedBonus.Bonus; break;
                 case "Power Flow Bonus": data.PowerFlowMod += unlockedBonus.Bonus; break;
                 case "Shield Power Bonus": data.ShieldPowerMod += unlockedBonus.Bonus; break;
                 case "Ship Experience Bonus": data.ExperienceMod += unlockedBonus.Bonus; break;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -276,7 +276,7 @@ namespace Ship_Game
         }
 
         public Planet(int id, RandomBase random, SolarSystem system, float randomAngle, float ringRadius, string name,
-                      float sysMaxRingRadius, Empire owner, SolarSystemData.Ring data) : this(id)
+                      float sysMaxRingRadius, Empire owner, SolarSystemData.Ring data, float researchableMultiplier = 1) : this(id)
         {
             SetSystem(system);
             OrbitalAngle = randomAngle;
@@ -308,7 +308,7 @@ namespace Ship_Game
                 if (type.Category == PlanetCategory.GasGiant)
                     scale += 1f;
 
-                if (random.RollDice(percent: type.Habitable ? -1 : type.ResearchableChance))
+                if (!type.Habitable && random.RollDice(type.ResearchableChance * researchableMultiplier))
                 {
                     SetResearchable(true, Universe);
                     //Log.Info($"{Name} can be researched");

--- a/Ship_Game/Universe/SolarBodies/SolarSystemBody.cs
+++ b/Ship_Game/Universe/SolarBodies/SolarSystemBody.cs
@@ -546,6 +546,7 @@ namespace Ship_Game
                 newOwner.data.Traits.ConsumptionModifier  = GetTraitMin(newOwner.data.Traits.ConsumptionModifier, ownerTraits.ConsumptionModifier);
                 newOwner.data.Traits.PopGrowthMax         = GetTraitMin(newOwner.data.Traits.PopGrowthMax, ownerTraits.PopGrowthMax);
                 newOwner.data.Traits.MaintMod             = GetTraitMin(newOwner.data.Traits.MaintMod, ownerTraits.MaintMod);
+                newOwner.data.Traits.ShipMaintMultiplier  = GetTraitMin(newOwner.data.Traits.ShipMaintMultiplier, ownerTraits.ShipMaintMultiplier);
                 newOwner.data.Traits.DiplomacyMod         = GetTraitMax(newOwner.data.Traits.DiplomacyMod, ownerTraits.DiplomacyMod);
                 newOwner.data.Traits.DodgeMod             = GetTraitMax(newOwner.data.Traits.DodgeMod, ownerTraits.DodgeMod);
                 newOwner.data.Traits.EnergyDamageMod      = GetTraitMax(newOwner.data.Traits.EnergyDamageMod, ownerTraits.EnergyDamageMod);

--- a/Ship_Game/Universe/SolarSystem.cs
+++ b/Ship_Game/Universe/SolarSystem.cs
@@ -393,7 +393,7 @@ namespace Ship_Game
             return null;
         }
 
-        public void GenerateRandomSystem(UniverseState us, RandomBase random, string name, Empire owner)
+        public void GenerateRandomSystem(UniverseState us, RandomBase random, string name, Empire owner, float researchableMultiplier = 1)
         {
             // Changed by RedFox: 3% chance to get a tri-sun "star_binary"
             Sun = random.RollDice(percent:3)
@@ -430,7 +430,7 @@ namespace Ship_Game
                 float randomAngle = random.Float(0f, 360f);
                 string planetName = markovNameGenerator?.NextName ?? Name + " " + RomanNumerals.ToRoman(ringNum);
                 var p = new Planet(us.CreateId(), random, this, randomAngle, ringRadius, planetName,
-                                   sysMaxRingRadius, owner, null);
+                                   sysMaxRingRadius, owner, null, researchableMultiplier / us.ResearchablePlanetDivisor);
                 PlanetList.Add(p);
                 var ring = new Ring
                 {
@@ -474,13 +474,13 @@ namespace Ship_Game
                 Sun = SunType.RandomBarrenSun(random);
                 researchableChance = Sun.ResearchableChance;
             }
-            else if (PlanetList.Count == 0 + us.P.ExtraPlanets)
+            else if (PlanetList.Count == us.P.ExtraPlanets)
             {
                 // Allow some Lone Stars to be Researchable
                 researchableChance += 50;
             }
 
-            if (random.RollDice(percent: researchableChance))
+            if (random.RollDice(percent: researchableChance * researchableMultiplier / us.ResearchablePlanetDivisor))
             {
                 SetResearchable(true, Universe);
                 // Log.Info($"{Name} can be researched");
@@ -489,7 +489,8 @@ namespace Ship_Game
             FinalizeGeneratedSystem();
         }
 
-        public void GenerateFromData(UniverseState us, RandomBase random, SolarSystemData data, Empire owner)
+        public void GenerateFromData(UniverseState us, RandomBase random, SolarSystemData data, 
+            Empire owner, float researchableMultiplier = 1)
         {
             Name = data.Name;
             Sun = SunType.FindSun(data.SunPath);
@@ -522,7 +523,7 @@ namespace Ship_Game
 
                 float randomAngle = random.Float(0f, 360f);
                 var p = new Planet(us.CreateId(), random, this, randomAngle, orbitalDist, ringData.Planet,
-                                   sysMaxRingRadius, owner, ringData);
+                                   sysMaxRingRadius, owner, ringData, researchableMultiplier / us.ResearchablePlanetDivisor);
                 PlanetList.Add(p);
                 RingList.Add(new Ring
                 {

--- a/Ship_Game/Universe/UniverseParams.cs
+++ b/Ship_Game/Universe/UniverseParams.cs
@@ -25,7 +25,7 @@ public class UniverseParams
     
     [StarData] public int NumSystems;
     [StarData] public int NumOpponents;
-    [StarData] public GameMode Mode = GameMode.Random;
+    [StarData] public GameMode Mode = GameMode.Sandbox;
     [StarData(DefaultValue=1f)] public float Pace = 1f;
     [StarData(DefaultValue=1f)] public float StarsModifier = 1f;
 

--- a/Ship_Game/Universe/UniverseState.cs
+++ b/Ship_Game/Universe/UniverseState.cs
@@ -141,6 +141,7 @@ namespace Ship_Game.Universe
 
         public ShieldManager Shields => Screen.Shields;
 
+        public float ResearchablePlanetDivisor => (P.ExtraPlanets * 0.8f).LowerBound(1);
         public float DefaultProjectorRadius;
 
         public readonly RandomBase Random = new ThreadSafeRandom();

--- a/Ship_Game/Universe/UniverseState.cs
+++ b/Ship_Game/Universe/UniverseState.cs
@@ -594,11 +594,20 @@ namespace Ship_Game.Universe
                 return 1f;
 
             int idealNumPlayers   = (int)P.GalaxySize + 3;
-            float galSizeModifier = P.GalaxySize <= GalSize.Medium 
-                ? ((int)P.GalaxySize / 2f).LowerBound(0.25f) // 0.25, 0.5 or 1
-                : 1 + ((int)P.GalaxySize - (int)GalSize.Medium) * 0.25f; // 1.25, 1.5, 1.75, 2
+            float galSizeModifier;
+            switch (P.GalaxySize)
+            {
+                case GalSize.Tiny:      galSizeModifier = 0.5f;  break;
+                case GalSize.Small:     galSizeModifier = 0.75f; break;
+                default:
+                case GalSize.Medium:    galSizeModifier = 1f;    break;
+                case GalSize.Large:     galSizeModifier = 1.15f; break;
+                case GalSize.Huge:      galSizeModifier = 1.35f; break;
+                case GalSize.Epic:      galSizeModifier = 1.6f;  break;
+                case GalSize.TrulyEpic: galSizeModifier = 1.9f;  break;
+            }
 
-            float extraPlanetsMod = 1 + P.ExtraPlanets * 0.25f;
+            float extraPlanetsMod = 1 + P.ExtraPlanets*0.25f;
             int numMajorEmpires = EmpireList.Count(e => !e.IsFaction);
             float playerRatio     = (float)idealNumPlayers / numMajorEmpires;
             float settingsRatio   = galSizeModifier * extraPlanetsMod * playerRatio * P.StarsModifier;

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -6832,9 +6832,9 @@ Opponents:
  SPA: "Rivales"
 Sandbox:
  Id: 2103
- ENG: "Balanced Sandbox"
+ ENG: "Sandbox"
  RUS: "Песочница"
- SPA: "Caja de arena equilibrada"
+ SPA: "Salvadera"
 Ascension:
  Id: 2104
  ENG: "Ascension"
@@ -6847,9 +6847,9 @@ GameMode:
  SPA: "Modo de juego"
 InTheSandboxGameMode:
  Id: 2106
- ENG: "Balanced Sandbox game mode is very similar to Random Sandbox game mode, but starting positions are balanced so each Empire has some room to expand before encountering other Empires."
- RUS: "Игровой режим «Сбалансированная песочница» очень похож на игровой режим «Случайная песочница», но стартовые позиции сбалансированы, поэтому у каждой Империи есть пространство для расширения, прежде чем столкнуться с другими Империями."
- SPA: "El modo de juego Balanced Sandbox es muy similar al modo de juego Random Sandbox, pero las posiciones iniciales están equilibradas para que cada imperio tenga espacio para expandirse antes de encontrarse con otros imperios."
+ ENG: "In Sandbox game mode you may win the game by conquering all of your enemies or by uniting the galaxy in alliance. Starting positions are balanced so each Empire has some room to expand before encountering other Empires."
+ RUS: "В режиме игры «Песочница» вы можете выиграть игру, победив всех своих врагов или объединив галактику в альянс. Стартовые позиции сбалансированы, поэтому у каждой Империи есть пространство для расширения перед столкновением с другими Империями."
+ SPA: "En el modo de juego Sandbox, puedes ganar el juego conquistando a todos tus enemigos o uniendo la galaxia en una alianza. Las posiciones iniciales están equilibradas para que cada Imperio tenga algo de espacio para expandirse antes de encontrarse con otros Imperios."
 InTheAscensionGameMode:
  Id: 2107
  ENG: "In the Ascension game mode, the goal is to be the first race to ascend to Godhood by capturing the Remnant homeworld at the center of the galaxy."
@@ -8888,9 +8888,9 @@ ShipMassModifier:
  SPA: "Modificador de la masa de las naves"
 MaintenanceModifier:
  Id: 4037
- ENG: "Maintenance Modifier"
- RUS: "Модификатор обслуживания"
- SPA: "Modificador del mantenimiento"
+ ENG: "Buildings Maintenance Modifier"
+ RUS: "Модификатор технического обслуживания зданий"
+ SPA: "Modificador de mantenimiento de edificios"
 InsystemFtlSpeed:
  Id: 4038
  ENG: "In-system FTL speed"
@@ -10426,14 +10426,19 @@ LavaPoolTerraformable:
   ENG: "Hot Lava surrounds this tile, making habitation impossible. This natural pool can be Terraformed when we have the right technology."
 RandomGameMode:
  Id: 4439
- ENG: "Random Sandbox"
- RUS: "Случайная песочница"
- SPA: "Caja de arena aleatoria"    
+ ENG: "Random"
+ RUS: "Случайный"
+ SPA: "Aleatorio"    
 InRandomGameMode:
  Id: 4440
- ENG: "In Random Sandbox game mode, you may win the game by conquering all of your enemies or by uniting the galaxy in alliance. Starting positions are randomized."
- RUS: "В режиме случайной песочницы вы можете выиграть игру, победив всех своих врагов или объединив галактику в альянс. Начальные позиции рандомизированы."
- SPA: "En el modo de juego Random Sandbox, puedes ganar el juego conquistando a todos tus enemigos o uniendo la galaxia en una alianza. Las posiciones iniciales son aleatorias."  
+ ENG: "Random game mode is very similar to Sandbox Game Mode but starting positions are randomized. Some empires might start very close to eachother and some may have a lot of space to expand."
+ RUS: "Случайный режим игры очень похож на режим песочницы, но стартовые позиции случайны. Некоторые империи могут начинаться очень близко друг к другу, а у некоторых может быть много места для расширения."
+ SPA: "El modo de juego aleatorio es muy similar al modo de juego Sandbox, pero las posiciones iniciales son aleatorias. Algunos imperios pueden comenzar muy cerca uno del otro y otros pueden tener mucho espacio para expandirse."  
+ShipMaintenanceMultiplier:
+ Id: 4988
+ ENG: "Ship Maintenance Multiplier"
+ RUS: "Модификатор технического обслуживания корабля"
+ SPA: "Modificador de mantenimiento de barcos" 
 ResearchLabName:
  Id: 4989
  ENG: "Research Lab"


### PR DESCRIPTION
Feature: Separate ship maint bonus from maint mod - avoid OP maint mod changes with technologies. Show correct data in diplomacy screen
Feature: AI - use colony ships along with claim fleets and also check scouts to investigate the target.
UI: Sandbox game as default game mode.
Fix: Error in Absorb message empire name. 
Fix: AI build capacity was low when treasury goal was lower than actual money.
Fix: ships return to hostile positions if resupplied and not part of fleet.
Fix: Some issues with trait selection. 
Fix: AI ships return to hostile areas and die after resupply.
Fix: Set Meteor str to always be 0.
Balance: Regulate Researchable solar bodies based on map size and extra planets.
Balance: star system number formula
Balance: Ship movement improvement
Balance: Limit research supply goals to 5.
Debug: Empire debug - show best relations or war.
