### PR TITLE
Refactor/racial traits

### DIFF
--- a/SDUtils/CollectionExt.cs
+++ b/SDUtils/CollectionExt.cs
@@ -179,6 +179,9 @@ namespace SDUtils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Array<T> ToArrayList<T>(this IEnumerable<T> source) => new Array<T>(source);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Array<T> ToArrayList<T>(this T[] source) => new Array<T>(source);
+
         public static T[] ToArr<T>(this ICollection<T> source)
         {
             int count = source.Count;

--- a/Ship_Game/Data/RacialTrait.cs
+++ b/Ship_Game/Data/RacialTrait.cs
@@ -3,6 +3,9 @@ using System.Xml.Serialization;
 using Microsoft.Xna.Framework.Graphics;
 using SDGraphics;
 using Ship_Game.Data.Serialization;
+using Ship_Game.Data;
+using System;
+using SDUtils;
 
 namespace Ship_Game
 {
@@ -23,7 +26,7 @@ namespace Ship_Game
         [StarData] public string ShipType = "";
         [StarData] public string Singular;
         [StarData] public string Plural;
-        [StarData] public bool Pack;
+
         [StarData] public string Adj1;
         [StarData] public string Adj2;
         [StarData] public string HomeSystemName;
@@ -74,8 +77,9 @@ namespace Ship_Game
 
 
         // RacialTraits.xml
-        [StarData] public int TraitName;
-        [XmlIgnore] public LocalizedText LocalizedName => new(TraitName);
+        [StarData] public int TraitIndex;
+        [StarData] public string TraitName;
+        [XmlIgnore] public LocalizedText LocalizedName => new(TraitIndex);
         [StarData] public string Category;
         [StarData] public int Cost;
         [StarData] public int Description;
@@ -101,7 +105,6 @@ namespace Ship_Game
         [StarData] public float EnergyDamageMod;
         [StarData] public float ResearchMod;
         [StarData] public float Mercantile;
-        [StarData] public int Miners;
         [StarData] public float ProductionMod;
         [StarData] public float MaintMod; // ex: -0.25
         [StarData] public float ShipMaintMultiplier = 1; // ex: 0.75
@@ -109,14 +112,12 @@ namespace Ship_Game
         [StarData] public float TaxMod; // bonus tax modifier
         [StarData] public float ShipCostMod;
         [StarData] public float ModHpModifier;
-        [StarData] public int SmallSize;
-        [StarData] public float PassengerModifier = 1f;
         [StarData] public float PassengerBonus;
-        [StarData] public bool Assimilators;
         [StarData] public float GroundCombatModifier;
         [StarData] public float RepairMod;
         [StarData] public int Cybernetic;
         [StarData] public float SpyModifier;
+        [StarData] public int Pack;
 
         // for flavor text: is this species aquatic?
         [StarData] public int Aquatic;
@@ -126,11 +127,16 @@ namespace Ship_Game
         [StarData] public bool SmartMissiles; // unlocked by tech
         [StarData] public int TerraformingLevel;  // unlocked by tech, FB from 0 to 3
         [StarData] public float EnemyPlanetInhibitionPercentCounter;  // unlocked by tech, FB - from 0 to 0.75
+        [StarData] public bool Assimilators;
+        [StarData] public float PassengerModifier = 1f;
+
+        [StarData] public Array<string> TraitOptions;
 
         // MISC wrappers
 
         public float HomeworldSizeMultiplier => 1f + HomeworldSizeMod;
         public float MaintMultiplier => 1f + MaintMod; // Ex: 1.25
+
 
         public RacialTrait GetClone()
         {
@@ -175,118 +181,42 @@ namespace Ship_Game
             var traits = ResourceManager.RaceTraits;
             if (traits.TraitList == null)
                 return;
-            foreach (RacialTrait trait in traits.TraitList)
+
+            foreach (RacialTraitOption trait in traits.TraitList)
             {
-                if (PhysicalTraitAlluring && trait.DiplomacyMod > 0
-                    || PhysicalTraitRepulsive && trait.DiplomacyMod < 0)
-                {
-                    DiplomacyMod = trait.DiplomacyMod;
-                }
-                if (PhysicalTraitEagleEyed && trait.EnergyDamageMod > 0
-                    || PhysicalTraitBlind && trait.EnergyDamageMod < 0)
-                {
-                    EnergyDamageMod = trait.EnergyDamageMod;
-                }
-                if (PhysicalTraitEfficientMetabolism && trait.ConsumptionModifier < 0
-                    || PhysicalTraitGluttonous && trait.ConsumptionModifier > 0)
-                {
-                    ConsumptionModifier = trait.ConsumptionModifier;
-                }
-                if (PhysicalTraitFertile && trait.PopGrowthMin > 0)
-                {
-                    PopGrowthMin = trait.PopGrowthMin;
-                }
-                else if (PhysicalTraitLessFertile && trait.PopGrowthMax > 0)
-                {
-                    PopGrowthMax = trait.PopGrowthMax;
-                }
-                if (PhysicalTraitSmart && trait.ResearchMod > 0 || PhysicalTraitDumb && trait.ResearchMod < 0)
-                {
-                    ResearchMod = trait.ResearchMod;
-                }
-                if (PhysicalTraitReflexes && trait.DodgeMod > 0 || PhysicalTraitPonderous && trait.DodgeMod < 0)
-                {
-                    DodgeMod = trait.DodgeMod;
-                }
-                if ((PhysicalTraitSavage && trait.GroundCombatModifier > 0) || (PhysicalTraitTimid && trait.GroundCombatModifier < 0))
-                {
-                    GroundCombatModifier = trait.GroundCombatModifier;
-                }
-                if ((SociologicalTraitEfficient && trait.MaintMod < 0) || (SociologicalTraitWasteful && trait.MaintMod > 0))
-                {
-                    MaintMod = trait.MaintMod;
-                }
-                if ((SociologicalTraitIndustrious && trait.ProductionMod > 0) || (SociologicalTraitLazy && trait.ProductionMod < 0))
-                {
-                    ProductionMod = trait.ProductionMod;
-                }
-                if ((SociologicalTraitMeticulous && trait.TaxMod > 0) || (SociologicalTraitCorrupt && trait.TaxMod < 0))
-                {
-                    TaxMod = trait.TaxMod;
-                }
-                if ((SociologicalTraitSkilledEngineers && trait.ModHpModifier > 0) || (SociologicalTraitHaphazardEngineers && trait.ModHpModifier < 0))
-                {
-                    ModHpModifier = trait.ModHpModifier;
-                }
-                if (SociologicalTraitMercantile && trait.Mercantile > 0)
-                {
-                    Mercantile = trait.Mercantile;
-                }
-                if ((HistoryTraitDuplicitous && trait.SpyMultiplier > 0) || (HistoryTraitHonest && trait.SpyMultiplier < 0))
-                {
-                    SpyMultiplier = trait.SpyMultiplier;
-                }
-                if ((HistoryTraitHugeHomeWorld && trait.HomeworldSizeMod > 0) || (HistoryTraitSmallHomeWorld && trait.HomeworldSizeMod < 0))
-                {
-                    HomeworldSizeMod = trait.HomeworldSizeMod;
-                }
-                if (HistoryTraitAstronomers && trait.BonusExplored > 0)
-                {
-                    BonusExplored = trait.BonusExplored;
-                }
-                if (HistoryTraitCybernetic)                
-                    Cybernetic = 1;
-                if (trait.RepairMod > 0)          
-                    RepairMod = trait.RepairMod;
-                if (HistoryTraitManifestDestiny && trait.PassengerBonus > 0)
-                {
-                    PassengerBonus = trait.PassengerBonus;
-                }
-                if (HistoryTraitManifestDestiny && trait.PassengerModifier > 1)
-                {
-                    PassengerModifier = trait.PassengerModifier;
-                }
-                if (HistoryTraitNavalTraditions && trait.ShipCostMod < 0)
-                {
-                    ShipCostMod = trait.ShipCostMod;
-                }
-                if (HistoryTraitSpiritual && trait.Spiritual > 0)
-                {
-                    Spiritual = trait.Spiritual;
-                }
-                if (HistoryTraitPollutedHomeWorld && trait.HomeworldFertMod < 0 && trait.HomeworldRichMod == 0)
-                {
-                    HomeworldFertMod -= trait.HomeworldFertMod;
-                }
-                if (HistoryTraitIndustrializedHomeWorld && trait.HomeworldFertMod < 0 && trait.HomeworldRichMod > 0)
-                {
-                    HomeworldFertMod -= trait.HomeworldFertMod;
-                    HomeworldRichMod = trait.HomeworldRichMod;
-                }
+                DiplomacyMod += trait.DiplomacyMod;
+                EnergyDamageMod += trait.EnergyDamageMod;
+                ConsumptionModifier += trait.ConsumptionModifier;
+                PopGrowthMin += trait.PopGrowthMin;
+                PopGrowthMax += trait.PopGrowthMax;
+                ResearchMod += trait.ResearchMod;
+                DodgeMod += trait.DodgeMod;
+                GroundCombatModifier += trait.GroundCombatModifier;
+                MaintMod += trait.MaintMod;
+                ProductionMod += trait.ProductionMod;
+                TaxMod += trait.TaxMod;
+                ModHpModifier += trait.ModHpModifier;
+                Mercantile += trait.Mercantile;
+                SpyMultiplier += trait.SpyMultiplier;
+                HomeworldSizeMod += trait.HomeworldSizeMod;
+                BonusExplored += trait.BonusExplored;
+                Cybernetic += trait.Cybernetic;
+                RepairMod += trait.RepairMod;
+                PassengerBonus += trait.PassengerBonus;
+                ShipCostMod += trait.ShipCostMod;
+                Spiritual += trait.Spiritual;
+                HomeworldFertMod = trait.HomeworldFertMod;
+                HomeworldFertMod += trait.HomeworldFertMod;
+                HomeworldRichMod += trait.HomeworldRichMod;
+                Militaristic += trait.Militaristic;
+                Pack += trait.Pack;
+                Prototype += trait.Prototype;
             }
-            if (HistoryTraitMilitaristic)
-                Militaristic = 1;
-
-            if (HistoryTraitPackMentality)
-                Pack = true;
-
-            if (HistoryTraitPrototypeFlagship)
-                Prototype = 1;
         }
 
         public void ApplyTraitToShip(Ship ship)
         {
-            if (Pack) ship.UpdatePackDamageModifier();
+            if (Pack > 0) ship.UpdatePackDamageModifier();
         }
     }
 }

--- a/Ship_Game/Data/RacialTrait.cs
+++ b/Ship_Game/Data/RacialTrait.cs
@@ -80,6 +80,8 @@ namespace Ship_Game
         [StarData] public int Pack;
         [StarData] public int Aquatic;
         [StarData] public float ExploreDistanceMultiplier = 1;
+        [StarData] public float CreditsPerKilledSlot;
+        [StarData] public float PenaltyPerKilledSlot;
 
         // FB - Environment
         [StarData] public PlanetCategory PreferredEnv = PlanetCategory.Terran;
@@ -185,6 +187,9 @@ namespace Ship_Game
                 Militaristic += trait.Militaristic;
                 Pack += trait.Pack;
                 Aquatic += trait.Aquatic;
+                CreditsPerKilledSlot += trait.CreditsPerKilledSlot;
+                PenaltyPerKilledSlot += trait.PenaltyPerKilledSlot;
+
                 ExploreDistanceMultiplier *= trait.ExploreDistanceMultiplier;
                 Prototype += trait.Prototype;
                 EnvTerran *= trait.EnvTerranMultiplier;
@@ -196,6 +201,7 @@ namespace Ship_Game
                 EnvIce *= trait.EnvIceMultiplier;
                 EnvBarren *= trait.EnvBarrenMultiplier;
                 EnvVolcanic *= trait.EnvVolcanicMultiplier;
+
                 if (trait.PreferredEnv != PlanetCategory.Terran)
                     PreferredEnv = trait.PreferredEnv;
             }

--- a/Ship_Game/Data/RacialTrait.cs
+++ b/Ship_Game/Data/RacialTrait.cs
@@ -81,7 +81,7 @@ namespace Ship_Game
         [StarData] public int Aquatic;
 
         // FB - Environment
-        [StarData] public PlanetCategory PreferredEnv;
+        [StarData] public PlanetCategory PreferredEnv = PlanetCategory.Terran;
         [StarData] public float EnvTerran = 1;
         [StarData] public float EnvOceanic = 1;
         [StarData] public float EnvSteppe = 1;
@@ -154,6 +154,9 @@ namespace Ship_Game
 
             foreach (RacialTraitOption trait in traits.TraitList)
             {
+                if (!TraitOptions.Contains(trait.TraitName))
+                    continue;
+                    
                 DiplomacyMod += trait.DiplomacyMod;
                 EnergyDamageMod += trait.EnergyDamageMod;
                 ConsumptionModifier += trait.ConsumptionModifier;

--- a/Ship_Game/Data/RacialTrait.cs
+++ b/Ship_Game/Data/RacialTrait.cs
@@ -62,7 +62,7 @@ namespace Ship_Game
         [StarData] public float HomeworldFertMod;
         [StarData] public float HomeworldRichMod;
         [StarData] public float DodgeMod;
-        [StarData] public float EnergyDamageMod;
+        [StarData] public float TargetingModifier;
         [StarData] public float ResearchMod;
         [StarData] public float Mercantile;
         [StarData] public float ProductionMod;
@@ -79,6 +79,7 @@ namespace Ship_Game
         [StarData] public float SpyModifier;
         [StarData] public int Pack;
         [StarData] public int Aquatic;
+        [StarData] public float ExploreDistanceMultiplier = 1;
 
         // FB - Environment
         [StarData] public PlanetCategory PreferredEnv = PlanetCategory.Terran;
@@ -158,7 +159,7 @@ namespace Ship_Game
                     continue;
                     
                 DiplomacyMod += trait.DiplomacyMod;
-                EnergyDamageMod += trait.EnergyDamageMod;
+                TargetingModifier += trait.EnergyDamageMod;
                 ConsumptionModifier += trait.ConsumptionModifier;
                 PopGrowthMin += trait.PopGrowthMin;
                 PopGrowthMax += trait.PopGrowthMax;
@@ -184,16 +185,17 @@ namespace Ship_Game
                 Militaristic += trait.Militaristic;
                 Pack += trait.Pack;
                 Aquatic += trait.Aquatic;
+                ExploreDistanceMultiplier *= trait.ExploreDistanceMultiplier;
                 Prototype += trait.Prototype;
-                EnvTerran *= trait.EnvTerranMultiplier > 0 ? trait.EnvTerranMultiplier : 1;
-                EnvOceanic *= trait.EnvOceanicMultiplier > 0 ? trait.EnvOceanicMultiplier : 1;
-                EnvSteppe *= trait.EnvSteppeMultiplier > 0 ? trait.EnvSteppeMultiplier : 1;
-                EnvTundra *= trait.EnvTundraMultiplier > 0 ? trait.EnvTundraMultiplier : 1;
-                EnvSwamp *= trait.EnvSwampMultiplier > 0 ? trait.EnvSwampMultiplier : 1;
-                EnvDesert *= trait.EnvDesertMultiplier > 0 ? trait.EnvDesertMultiplier: 1;
-                EnvIce *= trait.EnvIceMultiplier > 0 ? trait.EnvIceMultiplier : 1;
-                EnvBarren *= trait.EnvBarrenMultiplier > 0 ? trait.EnvBarrenMultiplier : 1;
-                EnvVolcanic *= trait.EnvVolcanicMultiplier > 0 ? trait.EnvVolcanicMultiplier : 1;
+                EnvTerran *= trait.EnvTerranMultiplier;
+                EnvOceanic *= trait.EnvOceanicMultiplier;
+                EnvSteppe *= trait.EnvSteppeMultiplier;
+                EnvTundra *= trait.EnvTundraMultiplier;
+                EnvSwamp *= trait.EnvSwampMultiplier;
+                EnvDesert *= trait.EnvDesertMultiplier;
+                EnvIce *= trait.EnvIceMultiplier;
+                EnvBarren *= trait.EnvBarrenMultiplier;
+                EnvVolcanic *= trait.EnvVolcanicMultiplier;
                 if (trait.PreferredEnv != PlanetCategory.Terran)
                     PreferredEnv = trait.PreferredEnv;
             }

--- a/Ship_Game/Data/RacialTrait.cs
+++ b/Ship_Game/Data/RacialTrait.cs
@@ -36,47 +36,7 @@ namespace Ship_Game
         [StarData] public float G;
         [StarData] public float B;
         
-        // Default Trait flags, set in Races/MyRace.xml
-        [StarData] public bool PhysicalTraitAlluring;
-        [StarData] public bool PhysicalTraitRepulsive;
-        [StarData] public bool PhysicalTraitEagleEyed;
-        [StarData] public bool PhysicalTraitBlind;
-        [StarData] public bool PhysicalTraitEfficientMetabolism;
-        [StarData] public bool PhysicalTraitGluttonous;
-        [StarData] public bool PhysicalTraitFertile;
-        [StarData] public bool PhysicalTraitLessFertile;
-        [StarData] public bool PhysicalTraitSmart;
-        [StarData] public bool PhysicalTraitDumb;
-        [StarData] public bool PhysicalTraitReflexes;
-        [StarData] public bool PhysicalTraitPonderous;
-        [StarData] public bool PhysicalTraitSavage;
-        [StarData] public bool PhysicalTraitTimid;
-        [StarData] public bool SociologicalTraitEfficient;
-        [StarData] public bool SociologicalTraitWasteful;
-        [StarData] public bool SociologicalTraitIndustrious;
-        [StarData] public bool SociologicalTraitLazy;
-        [StarData] public bool SociologicalTraitMercantile;
-        [StarData] public bool SociologicalTraitMeticulous;
-        [StarData] public bool SociologicalTraitCorrupt;
-        [StarData] public bool SociologicalTraitSkilledEngineers;
-        [StarData] public bool SociologicalTraitHaphazardEngineers;
-        [StarData] public bool HistoryTraitAstronomers;
-        [StarData] public bool HistoryTraitCybernetic;
-        [StarData] public bool HistoryTraitManifestDestiny;
-        [StarData] public bool HistoryTraitMilitaristic;
-        [StarData] public bool HistoryTraitNavalTraditions;
-        [StarData] public bool HistoryTraitPackMentality;
-        [StarData] public bool HistoryTraitPrototypeFlagship;
-        [StarData] public bool HistoryTraitSpiritual;
-        [StarData] public bool HistoryTraitPollutedHomeWorld;
-        [StarData] public bool HistoryTraitIndustrializedHomeWorld;
-        [StarData] public bool HistoryTraitDuplicitous;
-        [StarData] public bool HistoryTraitHonest;
-        [StarData] public bool HistoryTraitHugeHomeWorld;
-        [StarData] public bool HistoryTraitSmallHomeWorld;
-
-
-        // RacialTraits.xml
+            // RacialTraits.xml
         [StarData] public int TraitIndex;
         [StarData] public string TraitName;
         [XmlIgnore] public LocalizedText LocalizedName => new(TraitIndex);

--- a/Ship_Game/Data/RacialTrait.cs
+++ b/Ship_Game/Data/RacialTrait.cs
@@ -78,9 +78,19 @@ namespace Ship_Game
         [StarData] public int Cybernetic;
         [StarData] public float SpyModifier;
         [StarData] public int Pack;
-
-        // for flavor text: is this species aquatic?
         [StarData] public int Aquatic;
+
+        // FB - Environment
+        [StarData] public PlanetCategory PreferredEnv;
+        [StarData] public float EnvTerran = 1;
+        [StarData] public float EnvOceanic = 1;
+        [StarData] public float EnvSteppe = 1;
+        [StarData] public float EnvTundra = 1;
+        [StarData] public float EnvSwamp = 1;
+        [StarData] public float EnvDesert = 1;
+        [StarData] public float EnvIce = 1;
+        [StarData] public float EnvBarren = 1;
+        [StarData] public float EnvVolcanic = 1;
 
         [StarData] public float ResearchTaxMultiplier = 1; // set by difficulty
         [StarData] public bool TaxGoods; // unlocked by tech
@@ -170,7 +180,19 @@ namespace Ship_Game
                 HomeworldRichMod += trait.HomeworldRichMod;
                 Militaristic += trait.Militaristic;
                 Pack += trait.Pack;
+                Aquatic += trait.Aquatic;
                 Prototype += trait.Prototype;
+                EnvTerran *= trait.EnvTerranMultiplier > 0 ? trait.EnvTerranMultiplier : 1;
+                EnvOceanic *= trait.EnvOceanicMultiplier > 0 ? trait.EnvOceanicMultiplier : 1;
+                EnvSteppe *= trait.EnvSteppeMultiplier > 0 ? trait.EnvSteppeMultiplier : 1;
+                EnvTundra *= trait.EnvTundraMultiplier > 0 ? trait.EnvTundraMultiplier : 1;
+                EnvSwamp *= trait.EnvSwampMultiplier > 0 ? trait.EnvSwampMultiplier : 1;
+                EnvDesert *= trait.EnvDesertMultiplier > 0 ? trait.EnvDesertMultiplier: 1;
+                EnvIce *= trait.EnvIceMultiplier > 0 ? trait.EnvIceMultiplier : 1;
+                EnvBarren *= trait.EnvBarrenMultiplier > 0 ? trait.EnvBarrenMultiplier : 1;
+                EnvVolcanic *= trait.EnvVolcanicMultiplier > 0 ? trait.EnvVolcanicMultiplier : 1;
+                if (trait.PreferredEnv != PlanetCategory.Terran)
+                    PreferredEnv = trait.PreferredEnv;
             }
         }
 

--- a/Ship_Game/Data/RacialTrait.cs
+++ b/Ship_Game/Data/RacialTrait.cs
@@ -159,7 +159,7 @@ namespace Ship_Game
                     continue;
                     
                 DiplomacyMod += trait.DiplomacyMod;
-                TargetingModifier += trait.EnergyDamageMod;
+                TargetingModifier += trait.TargetingModifier;
                 ConsumptionModifier += trait.ConsumptionModifier;
                 PopGrowthMin += trait.PopGrowthMin;
                 PopGrowthMax += trait.PopGrowthMax;

--- a/Ship_Game/Data/RacialTraitOption.cs
+++ b/Ship_Game/Data/RacialTraitOption.cs
@@ -56,6 +56,8 @@ namespace Ship_Game.Data
         public int Pack;
         public int Aquatic;
         public float ExploreDistanceMultiplier = 1;
+        public float CreditsPerKilledSlot;
+        public float PenaltyPerKilledSlot;
 
         // FB - Environment
         public PlanetCategory PreferredEnv = PlanetCategory.Terran;

--- a/Ship_Game/Data/RacialTraitOption.cs
+++ b/Ship_Game/Data/RacialTraitOption.cs
@@ -57,7 +57,7 @@ namespace Ship_Game.Data
         public int Aquatic;
 
         // FB - Environment
-        public PlanetCategory PreferredEnv;
+        public PlanetCategory PreferredEnv = PlanetCategory.Terran;
         public float EnvTerranMultiplier;
         public float EnvOceanicMultiplier;
         public float EnvSteppeMultiplier;

--- a/Ship_Game/Data/RacialTraitOption.cs
+++ b/Ship_Game/Data/RacialTraitOption.cs
@@ -1,0 +1,57 @@
+﻿using Ship_Game.Data.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace Ship_Game.Data
+{
+    public sealed class RacialTraitOption
+    {
+        // RacialTraits.xml
+        public int TraitIndex;
+        public string TraitName;
+        public string Category;
+        public int Cost;
+        public int Description;
+        public int Excludes;
+
+        [XmlIgnore] public LocalizedText LocalizedName => new(TraitIndex);
+
+        // individual trait effects defined in RacialTraits.xml
+        public float SpyMultiplier;
+        public float ConsumptionModifier;
+        public float ReproductionMod;
+        public float PopGrowthMax;
+        public float PopGrowthMin;
+        public float DiplomacyMod; // Initial Trust only
+        public int Blind;
+        public int BonusExplored;
+        public int Militaristic;
+        public float HomeworldSizeMod;
+        public int Prewarp;
+        public int Prototype;
+        public float Spiritual;
+        public float HomeworldFertMod;
+        public float HomeworldRichMod;
+        public float DodgeMod;
+        public float EnergyDamageMod;
+        public float ResearchMod;
+        public float Mercantile;
+        public float ProductionMod;
+        public float MaintMod; // ex: -0.25
+        public float ShipMaintMultiplier; // ex: 0.75
+        public float InBordersSpeedBonus;
+        public float TaxMod; // bonus tax modifier
+        public float ShipCostMod;
+        public float ModHpModifier;
+        public float PassengerBonus;
+        public float GroundCombatModifier;
+        public float RepairMod;
+        public int Cybernetic;
+        public float SpyModifier;
+        public int Pack;
+    }
+}

--- a/Ship_Game/Data/RacialTraitOption.cs
+++ b/Ship_Game/Data/RacialTraitOption.cs
@@ -1,4 +1,4 @@
-﻿using Ship_Game.Data.Serialization;
+﻿using SDUtils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,7 +16,7 @@ namespace Ship_Game.Data
         public string Category;
         public int Cost;
         public int Description;
-        public int Excludes;
+        public Array<string> Excludes;
 
         [XmlIgnore] public LocalizedText LocalizedName => new(TraitIndex);
 

--- a/Ship_Game/Data/RacialTraitOption.cs
+++ b/Ship_Game/Data/RacialTraitOption.cs
@@ -38,7 +38,7 @@ namespace Ship_Game.Data
         public float HomeworldFertMod;
         public float HomeworldRichMod;
         public float DodgeMod;
-        public float EnergyDamageMod;
+        public float TargetingModifier;
         public float ResearchMod;
         public float Mercantile;
         public float ProductionMod;
@@ -55,17 +55,18 @@ namespace Ship_Game.Data
         public float SpyModifier;
         public int Pack;
         public int Aquatic;
+        public float ExploreDistanceMultiplier = 1;
 
         // FB - Environment
         public PlanetCategory PreferredEnv = PlanetCategory.Terran;
-        public float EnvTerranMultiplier;
-        public float EnvOceanicMultiplier;
-        public float EnvSteppeMultiplier;
-        public float EnvTundraMultiplier;
-        public float EnvSwampMultiplier;
-        public float EnvDesertMultiplier;
-        public float EnvIceMultiplier;
-        public float EnvBarrenMultiplier;
-        public float EnvVolcanicMultiplier;
+        public float EnvTerranMultiplier = 1;
+        public float EnvOceanicMultiplier = 1;
+        public float EnvSteppeMultiplier = 1;
+        public float EnvTundraMultiplier = 1;
+        public float EnvSwampMultiplier = 1;
+        public float EnvDesertMultiplier = 1;
+        public float EnvIceMultiplier = 1;
+        public float EnvBarrenMultiplier = 1;
+        public float EnvVolcanicMultiplier = 1;
     }
 }

--- a/Ship_Game/Data/RacialTraitOption.cs
+++ b/Ship_Game/Data/RacialTraitOption.cs
@@ -1,4 +1,5 @@
 ﻿using SDUtils;
+using Ship_Game.Data.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -53,5 +54,18 @@ namespace Ship_Game.Data
         public int Cybernetic;
         public float SpyModifier;
         public int Pack;
+        public int Aquatic;
+
+        // FB - Environment
+        public PlanetCategory PreferredEnv;
+        public float EnvTerranMultiplier;
+        public float EnvOceanicMultiplier;
+        public float EnvSteppeMultiplier;
+        public float EnvTundraMultiplier;
+        public float EnvSwampMultiplier;
+        public float EnvDesertMultiplier;
+        public float EnvIceMultiplier;
+        public float EnvBarrenMultiplier;
+        public float EnvVolcanicMultiplier;
     }
 }

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -181,6 +181,8 @@ namespace Ship_Game
         public bool WeArePirates  => Pirates != null; // Use this to figure out if this empire is pirate faction
         public bool WeAreRemnants => Remnants != null; // Use this to figure out if this empire is pirate faction
 
+        public bool HavePackMentality => data.Traits.Pack > 0;
+
         public float MaximumIncome       => PotentialIncome + TotalTradeMoneyAddedThisTurn + ExcessGoodsMoneyAddedThisTurn + data.FlatMoneyBonus; // + AverageTradeIncome + data.FlatMoneyBonus;
         public float MaximumStableIncome => PotentialIncome + AverageTradeIncome + data.FlatMoneyBonus;
         // Income this turn before deducting ship maintenance

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -2239,6 +2239,7 @@ namespace Ship_Game
 
         public void TheyKilledOurShip(Empire they, Ship killedShip)
         {
+            AddMoney(data.Traits.PenaltyPerKilledSlot * killedShip.SurfaceArea * -1);
             if (KillsForRemnantStory(they, killedShip))
                 return;
 
@@ -2248,6 +2249,7 @@ namespace Ship_Game
 
         public void WeKilledTheirShip(Empire they, Ship killedShip)
         {
+            AddMoney(data.Traits.CreditsPerKilledSlot * killedShip.SurfaceArea);
             if (!GetRelations(they, out Relationship rel))
                 return;
             rel.KilledAShip(killedShip);

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -373,14 +373,14 @@ namespace Ship_Game
         /// Returns the Player's Preferred Environment Modifier.
         /// </summary>
         public float PlayerPreferredEnvModifier
-            => RacialEnvModifer(Universe.Player.data.PreferredEnv, Universe.Player);
+            => RacialEnvModifer(Universe.Player.data.PreferredEnvPlanet, Universe.Player);
 
 
         /// <summary>
         /// Returns the preferred Environment Modifier of a given empire.This is null Safe.
         /// </summary>
         public static float PreferredEnvModifier(Empire empire)
-            => empire == null ? 1 : RacialEnvModifer(empire.data.PreferredEnv, empire);
+            => empire == null ? 1 : RacialEnvModifer(empire.data.PreferredEnvPlanet, empire);
 
 
         /// <summary>
@@ -394,15 +394,15 @@ namespace Ship_Game
 
             switch (category)
             {
-                case PlanetCategory.Terran:   modifer = empire.data.EnvTerran;   break;
-                case PlanetCategory.Oceanic:  modifer = empire.data.EnvOceanic;  break;
-                case PlanetCategory.Steppe:   modifer = empire.data.EnvSteppe;   break;
-                case PlanetCategory.Tundra:   modifer = empire.data.EnvTundra;   break;
-                case PlanetCategory.Swamp:    modifer = empire.data.EnvSwamp;    break;
-                case PlanetCategory.Desert:   modifer = empire.data.EnvDesert;   break;
-                case PlanetCategory.Ice:      modifer = empire.data.EnvIce;      break;
-                case PlanetCategory.Barren:   modifer = empire.data.EnvBarren;   break;
-                case PlanetCategory.Volcanic: modifer = empire.data.EnvVolcanic; break;
+                case PlanetCategory.Terran:   modifer = empire.data.Traits.EnvTerran;   break;
+                case PlanetCategory.Oceanic:  modifer = empire.data.Traits.EnvOceanic;  break;
+                case PlanetCategory.Steppe:   modifer = empire.data.Traits.EnvSteppe;   break;
+                case PlanetCategory.Tundra:   modifer = empire.data.Traits.EnvTundra;   break;
+                case PlanetCategory.Swamp:    modifer = empire.data.Traits.EnvSwamp;    break;
+                case PlanetCategory.Desert:   modifer = empire.data.Traits.EnvDesert;   break;
+                case PlanetCategory.Ice:      modifer = empire.data.Traits.EnvIce;      break;
+                case PlanetCategory.Barren:   modifer = empire.data.Traits.EnvBarren;   break;
+                case PlanetCategory.Volcanic: modifer = empire.data.Traits.EnvVolcanic; break;
             }
 
             return modifer;
@@ -2067,14 +2067,14 @@ namespace Ship_Game
 
         void AbsorbAllEnvPreferences(Empire target)
         {
-            data.EnvTerran  = GetBonus(target.data.EnvTerran, data.EnvTerran);
-            data.EnvOceanic = GetBonus(target.data.EnvOceanic, data.EnvOceanic);
-            data.EnvSteppe  = GetBonus(target.data.EnvSteppe, data.EnvSteppe);
-            data.EnvTundra  = GetBonus(target.data.EnvTundra, data.EnvTundra);
-            data.EnvSwamp   = GetBonus(target.data.EnvSwamp, data.EnvSwamp);    
-            data.EnvDesert  = GetBonus(target.data.EnvDesert, data.EnvDesert);
-            data.EnvIce     = GetBonus(target.data.EnvIce, data.EnvIce);
-            data.EnvBarren  = GetBonus(target.data.EnvBarren, data.EnvBarren);
+            data.Traits.EnvTerran  = GetBonus(target.data.Traits.EnvTerran,  data.Traits.EnvTerran);
+            data.Traits.EnvOceanic = GetBonus(target.data.Traits.EnvOceanic, data.Traits.EnvOceanic);
+            data.Traits.EnvSteppe  = GetBonus(target.data.Traits.EnvSteppe,  data.Traits.EnvSteppe);
+            data.Traits.EnvTundra  = GetBonus(target.data.Traits.EnvTundra,  data.Traits.EnvTundra);
+            data.Traits.EnvSwamp   = GetBonus(target.data.Traits.EnvSwamp,   data.Traits.EnvSwamp);    
+            data.Traits.EnvDesert  = GetBonus(target.data.Traits.EnvDesert,  data.Traits.EnvDesert);
+            data.Traits.EnvIce     = GetBonus(target.data.Traits.EnvIce,     data.Traits.EnvIce);
+            data.Traits.EnvBarren  = GetBonus(target.data.Traits.EnvBarren,  data.Traits.EnvBarren);
 
             float GetBonus(float theirBonus, float ourBonus)
             {

--- a/Ship_Game/EmpireData.cs
+++ b/Ship_Game/EmpireData.cs
@@ -148,8 +148,8 @@ namespace Ship_Game
             set => TaxRateValue = value.NaNChecked(0.25f, "EmpireData.TaxRate");
         }
 
-        [StarData] public Array<string> ExcludedDTraits = new();
-        [StarData] public Array<string> ExcludedETraits = new();
+        [StarData] public Array<string> PersonalityTraitsWeights = new();
+        [StarData] public Array<string> EconomicTraitsWeights = new();
         [StarData] public Array<Agent> AgentList = new();
         [StarData] public string AbsorbedBy;
         [StarData] public string StartingShip;

--- a/Ship_Game/EmpireData.cs
+++ b/Ship_Game/EmpireData.cs
@@ -253,17 +253,7 @@ namespace Ship_Game
         [StarData] public byte ThrustColor1G;
         [StarData] public byte ThrustColor1B;
 
-        // FB - Environment
-        [StarData] public float EnvTerran;
-        [StarData] public float EnvOceanic;
-        [StarData] public float EnvSteppe;
-        [StarData] public float EnvTundra;
-        [StarData] public float EnvSwamp;
-        [StarData] public float EnvDesert;
-        [StarData] public float EnvIce;
-        [StarData] public float EnvBarren;
-        [StarData] public float EnvVolcanic;
-        [StarData] public PlanetCategory PreferredEnv;
+
 
         // FB - Minimum Troop Level
         [StarData] public int MinimumTroopLevel;
@@ -357,15 +347,15 @@ namespace Ship_Game
         [XmlIgnore]
         public bool IsFactionOrMinorRace => Faction > 0 || MinorRace;
 
-        [XmlIgnore]  public float EnvPerfTerran  => EnvTerran;
-        [XmlIgnore]  public float EnvPerfOceanic => EnvOceanic;
-        [XmlIgnore]  public float EnvPerfSteppe  => EnvSteppe;
-        [XmlIgnore]  public float EnvPerfTundra  => EnvTundra;
-        [XmlIgnore]  public float EnvPerfSwamp   => EnvSwamp;
-        [XmlIgnore]  public float EnvPerfDesert  => EnvDesert;
-        [XmlIgnore]  public float EnvPerfIce     => EnvIce;
-        [XmlIgnore]  public float EnvPerfBarren  => EnvBarren;
-        [XmlIgnore]  public PlanetCategory PreferredEnvPlanet => PreferredEnv;
+        [XmlIgnore]  public float EnvPerfTerran  => Traits.EnvTerran;
+        [XmlIgnore]  public float EnvPerfOceanic => Traits.EnvOceanic;
+        [XmlIgnore]  public float EnvPerfSteppe  => Traits.EnvSteppe;
+        [XmlIgnore]  public float EnvPerfTundra  => Traits.EnvTundra;
+        [XmlIgnore]  public float EnvPerfSwamp   => Traits.EnvSwamp;
+        [XmlIgnore]  public float EnvPerfDesert  => Traits.EnvDesert;
+        [XmlIgnore]  public float EnvPerfIce     => Traits.EnvIce;
+        [XmlIgnore]  public float EnvPerfBarren  => Traits.EnvBarren;
+        [XmlIgnore]  public PlanetCategory PreferredEnvPlanet => Traits.PreferredEnv;
 
         [XmlIgnore]  public string ShipType  => Traits.ShipType;
         [XmlIgnore]  public string VideoPath => Traits.VideoPath;

--- a/Ship_Game/EmpireData.cs
+++ b/Ship_Game/EmpireData.cs
@@ -119,16 +119,6 @@ namespace Ship_Game
         string Adj1 { get; }
         string Adj2 { get; }
 
-        float EnvPerfTerran { get; }
-        float EnvPerfOceanic { get; }
-        float EnvPerfSteppe { get; }
-        float EnvPerfTundra { get; }
-        float EnvPerfSwamp { get; }
-        float EnvPerfDesert { get; }
-        float EnvPerfIce { get; }
-        float EnvPerfBarren { get; }
-        PlanetCategory PreferredEnvPlanet { get; }
-
         string WarpStart { get; }
         string WarpEnd { get; }
     }

--- a/Ship_Game/GamePlayGlobals.cs
+++ b/Ship_Game/GamePlayGlobals.cs
@@ -70,7 +70,6 @@ public class GamePlayGlobals
     [StarData] public bool UseDestroyers;
     [StarData] public bool UsePlanetaryProjection;
     [StarData] public bool ReconDropDown;
-    [StarData] public bool DisplayEnvPreferenceInRaceDesign;
     // Research costs will be increased based on map size to balance the increased capacity of larger maps
     [StarData] public bool ChangeResearchCostBasedOnSize;
     // Use short term researchable techs with no best ship

--- a/Ship_Game/GamePlayGlobals.cs
+++ b/Ship_Game/GamePlayGlobals.cs
@@ -17,8 +17,9 @@ public class GamePlayGlobals
     [StarData] public int MaxOpponents = 7;
     [StarData] public int DefaultNumOpponents = 5; // Default AIs to start on default settings
     [StarData] public int TurnTimer = 5; // default time in seconds for a single turn
+    [StarData] public int TraitPoints = 8; // How many points each race has to spend on racial traits
 
-    
+
     // GamePlay modifiers
     // How easy ships are to destroy. Ships which have active internal slots below this ratio, will Die()
     [StarData] public float ShipDestroyThreshold = 0.5f;

--- a/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
@@ -882,7 +882,7 @@ namespace Ship_Game
                 NumMaxTerraformers     = P.TerraformerLimit;
                 NeedLevel1Terraform    = P.HasTerrainToTerraform;
                 NeedLevel2Terraform    = P.HasTilesToTerraform;
-                NeedLevel3Terraform    = P.Category != P.Owner.data.PreferredEnv || P.BaseMaxFertility.Less(P.TerraformedMaxFertility);
+                NeedLevel3Terraform    = P.Category != P.Owner.data.PreferredEnvPlanet || P.BaseMaxFertility.Less(P.TerraformedMaxFertility);
                 NumTerrain             = P.CountBuildings(b => b.CanBeTerraformed);
                 NumTerraformableTiles  = P.TilesList.Count(t => t.CanTerraform);
                 TerraformLevel         = P.ContainsEventTerraformers ? 3 : P.Owner.data.Traits.TerraformingLevel;

--- a/Ship_Game/GameScreens/LoadSaveItems/LoadRaceScreen.cs
+++ b/Ship_Game/GameScreens/LoadSaveItems/LoadRaceScreen.cs
@@ -36,7 +36,7 @@ public sealed class LoadRaceScreen : GenericLoadSaveScreen
             try
             {
                 RaceSave data = SaveRaceScreen.Load(file);
-                if (data.Name.IsEmpty())
+                if (data.Name.IsEmpty() || data.Version < SavedGame.SaveGameVersion)
                     continue;
 
                 string info = "Race Name: " + data.Traits.Name;

--- a/Ship_Game/GameScreens/MainDiplomacyScreen/MainDiplomacyScreen.cs
+++ b/Ship_Game/GameScreens/MainDiplomacyScreen/MainDiplomacyScreen.cs
@@ -614,8 +614,8 @@ namespace Ship_Game
                     DrawBadStat(Localizer.Token(GameText.SpyEffectivenessModifier), "-"+SelectedEmpire.data.SpyModifier.ToString("#"), ref textCursor);
                 if (SelectedEmpire.data.Traits.Spiritual != 0)
                     DrawStat(Localizer.Token(GameText.ArtifactBonusModifier), SelectedEmpire.data.Traits.Spiritual, ref textCursor, false);
-                if (SelectedEmpire.data.Traits.EnergyDamageMod != 0)
-                    DrawStat(Localizer.Token(GameText.CannonAccuracyModifier), SelectedEmpire.data.Traits.EnergyDamageMod, ref textCursor, false);
+                if (SelectedEmpire.data.Traits.TargetingModifier != 0)
+                    DrawStat(Localizer.Token(GameText.CannonAccuracyModifier), SelectedEmpire.data.Traits.TargetingModifier, ref textCursor, false);
                 if (SelectedEmpire.data.Traits.DodgeMod > 0)
                     DrawStat(Localizer.Token(GameText.DodgeModifier), SelectedEmpire.data.Traits.DodgeMod , ref textCursor, false);
                 if (SelectedEmpire.data.OrdnanceEffectivenessBonus != 0)

--- a/Ship_Game/GameScreens/NewGame/EnvPreferencesPanel.cs
+++ b/Ship_Game/GameScreens/NewGame/EnvPreferencesPanel.cs
@@ -15,7 +15,7 @@ namespace Ship_Game.GameScreens.NewGame
         readonly UILabel BestType;
         UIPanel PlanetIcon;
 
-        public PlanetCategory PreferredEnv;
+        public PlanetCategory PreferredEnv = PlanetCategory.Terran;
         public float EnvTerran = 1;
         public float EnvOceanic = 1;
         public float EnvSteppe = 1;
@@ -28,7 +28,7 @@ namespace Ship_Game.GameScreens.NewGame
 
         IEmpireData Data;
 
-        public EnvPreferencesPanel(RaceDesignScreen parent, in Rectangle rect) : base(rect)
+        public EnvPreferencesPanel(RaceDesignScreen parent, RacialTrait raceSummary, in Rectangle rect) : base(rect)
         {
             Screen = parent;
             Data = Screen.SelectedData;
@@ -78,14 +78,14 @@ namespace Ship_Game.GameScreens.NewGame
             AddEnvSplitter(column2, "{Ice}: ",    () => EnvIce);
             AddEnvSplitter(column2, "{Desert}: ", () => EnvDesert);
             AddEnvSplitter(column2, "{Barren}: ", () => EnvBarren);
-
-            UpdatePlanetIcon();
+            UpdatePreferences(raceSummary);
         }
 
-        public void UpdateArchetype(IEmpireData data)
+        public void UpdateArchetype(IEmpireData data, RacialTrait raceSummary)
         {
             Data = data;
             UpdatePlanetIcon();
+            UpdatePreferences(raceSummary);
         }
 
         public void UpdatePreferences(RacialTrait raceSummary)
@@ -100,6 +100,7 @@ namespace Ship_Game.GameScreens.NewGame
             EnvIce = raceSummary.EnvIce;
             EnvBarren = raceSummary.EnvBarren;
             EnvVolcanic = raceSummary.EnvVolcanic;
+            UpdatePlanetIcon();
         }
 
         void UpdatePlanetIcon()

--- a/Ship_Game/GameScreens/NewGame/EnvPreferencesPanel.cs
+++ b/Ship_Game/GameScreens/NewGame/EnvPreferencesPanel.cs
@@ -15,6 +15,17 @@ namespace Ship_Game.GameScreens.NewGame
         readonly UILabel BestType;
         UIPanel PlanetIcon;
 
+        public PlanetCategory PreferredEnv;
+        public float EnvTerran = 1;
+        public float EnvOceanic = 1;
+        public float EnvSteppe = 1;
+        public float EnvTundra = 1;
+        public float EnvSwamp = 1;
+        public float EnvDesert = 1;
+        public float EnvIce = 1;
+        public float EnvBarren = 1;
+        public float EnvVolcanic = 1;
+
         IEmpireData Data;
 
         public EnvPreferencesPanel(RaceDesignScreen parent, in Rectangle rect) : base(rect)
@@ -37,8 +48,8 @@ namespace Ship_Game.GameScreens.NewGame
 
             UIList column1 = Add(new UIList(ListLayoutStyle.ResizeList));
             UIList column2 = Add(new UIList(ListLayoutStyle.ResizeList));
-            column1.SetLocalPos(15, 45);
-            column2.SetLocalPos(15 + (lo ? 60 : 140), 45);
+            column1.SetLocalPos(15, 35);
+            column2.SetLocalPos(15 + (lo ? 60 : 140), 35);
             column1.Padding = column2.Padding = new Vector2(4, 4);
 
             UILabel AddEnvSplitter(UIList list, string title, Func<float> getValue)
@@ -57,42 +68,57 @@ namespace Ship_Game.GameScreens.NewGame
                 return val;
             }
 
-            AddEnvSplitter(column1, "{Terran}: ", () => Data.EnvPerfTerran);
-            AddEnvSplitter(column1, "{Steppe}: ", () => Data.EnvPerfSteppe);
-            AddEnvSplitter(column1, "{Oceanic}: ",() => Data.EnvPerfOceanic);
-            AddEnvSplitter(column1, "{Swamp}: ",  () => Data.EnvPerfSwamp);
+            AddEnvSplitter(column1, "{Terran}: ", () => EnvTerran);
+            AddEnvSplitter(column1, "{Steppe}: ", () => EnvSteppe);
+            AddEnvSplitter(column1, "{Oceanic}: ",() => EnvOceanic);
+            AddEnvSplitter(column1, "{Swamp}: ",  () => EnvSwamp);
+            AddEnvSplitter(column1, "{Volcanic}: ", () => EnvVolcanic);
 
-            AddEnvSplitter(column2, "{Tundra}: ", () => Data.EnvPerfTundra);
-            AddEnvSplitter(column2, "{Ice}: ",    () => Data.EnvPerfIce);
-            AddEnvSplitter(column2, "{Desert}: ", () => Data.EnvPerfDesert);
-            AddEnvSplitter(column2, "{Barren}: ", () => Data.EnvPerfBarren);
+            AddEnvSplitter(column2, "{Tundra}: ", () => EnvTundra);
+            AddEnvSplitter(column2, "{Ice}: ",    () => EnvIce);
+            AddEnvSplitter(column2, "{Desert}: ", () => EnvDesert);
+            AddEnvSplitter(column2, "{Barren}: ", () => EnvBarren);
 
-            UpdatePlanetIcon(Data);
+            UpdatePlanetIcon();
         }
 
         public void UpdateArchetype(IEmpireData data)
         {
             Data = data;
-            UpdatePlanetIcon(data);
+            UpdatePlanetIcon();
         }
 
-        void UpdatePlanetIcon(IEmpireData data)
+        public void UpdatePreferences(RacialTrait raceSummary)
+        {
+            PreferredEnv = raceSummary.PreferredEnv;
+            EnvTerran = raceSummary.EnvTerran;
+            EnvOceanic = raceSummary.EnvOceanic;
+            EnvSteppe = raceSummary.EnvSteppe;
+            EnvTundra = raceSummary.EnvTundra;
+            EnvSwamp = raceSummary.EnvSwamp;
+            EnvDesert = raceSummary.EnvDesert;
+            EnvIce = raceSummary.EnvIce;
+            EnvBarren = raceSummary.EnvBarren;
+            EnvVolcanic = raceSummary.EnvVolcanic;
+        }
+
+        void UpdatePlanetIcon()
         {
             PlanetIcon?.RemoveFromParent(true);
 
             int size = Screen.LowRes ? 80 : 100;
             PlanetIcon = Add(new UIPanel(BestType.LocalPos.Add(0, 20), new Vector2(size),
-                                         GetPlanetIcon(data))
+                                         GetPlanetIcon())
             {
                 Name = "EnvPref.PlanetIcon",
-                Tooltip = Planet.TextCategory(data.PreferredEnvPlanet)
+                Tooltip = Planet.TextCategory(PreferredEnv)
             });
         }
 
-        static SubTexture GetPlanetIcon(IEmpireData data)
+        SubTexture GetPlanetIcon()
         {
             string path;
-            switch (data.PreferredEnvPlanet)
+            switch (PreferredEnv)
             {
                 default:
                 case PlanetCategory.Terran:  path = "Planets/25"; break;

--- a/Ship_Game/GameScreens/NewGame/EnvPreferencesPanel.cs
+++ b/Ship_Game/GameScreens/NewGame/EnvPreferencesPanel.cs
@@ -101,6 +101,21 @@ namespace Ship_Game.GameScreens.NewGame
             EnvBarren = raceSummary.EnvBarren;
             EnvVolcanic = raceSummary.EnvVolcanic;
             UpdatePlanetIcon();
+            UpdateVisibility();
+        }
+
+        void UpdateVisibility()
+        {
+            Visible = PreferredEnv != PlanetCategory.Terran
+                || EnvTerran != 1
+                || EnvOceanic != 1
+                || EnvSteppe != 1
+                || EnvTundra != 1
+                || EnvSwamp != 1
+                || EnvDesert != 1
+                || EnvIce != 1
+                || EnvBarren != 1
+                || EnvVolcanic != 1;
         }
 
         void UpdatePlanetIcon()

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
@@ -216,10 +216,10 @@ namespace Ship_Game
             DoRaceDescription();
             SetRacialTraits(SelectedData.Traits);
 
-            var envRect = new Rectangle(5, (int)TitleBar.Bottom + 5, (int)ChooseRaceList.Width, 150);
-            EnvMenu = Add(new EnvPreferencesPanel(this, envRect));
-            EnvMenu.Visible = true; // GlobalStats.Defaults.DisplayEnvPreferenceInRaceDesign;
 
+            var envRect = new Rectangle(5, (int)TitleBar.Bottom + 5, (int)ChooseRaceList.Width, 150);
+            EnvMenu = Add(new EnvPreferencesPanel(this, RaceSummary, envRect));
+            EnvMenu.Visible = true; // GlobalStats.Defaults.DisplayEnvPreferenceInRaceDesign;
             ChooseRaceList.ButtonMedium("Load Race", OnLoadRaceClicked)
                 .SetLocalPos(ChooseRaceList.Width / 2 - 142, ChooseRaceList.Height + 10);
             ChooseRaceList.ButtonMedium("Save Race", OnSaveRaceClicked)
@@ -518,7 +518,9 @@ namespace Ship_Game
 
             //if (GlobalStats.Defaults.DisplayEnvPreferenceInRaceDesign)
             {
-                EnvMenu.UpdateArchetype(SelectedData);
+                UpdateTraits();
+                DoRaceDescription();
+                EnvMenu.UpdateArchetype(SelectedData, RaceSummary);
             }
         }
 

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
@@ -40,7 +40,7 @@ namespace Ship_Game
         UILabel ExtraPlanetsLabel;
         UILabel PerformanceWarning;
         int FlagIndex;
-        public int TotalPointsUsed { get; private set; } = 8;
+        public int TotalPointsUsed { get; private set; }
 
         public IEmpireData SelectedData { get; private set; }
 
@@ -122,7 +122,7 @@ namespace Ship_Game
             if (traitsList.H > 580)
                 traitsList.H = 580;
 
-            LocalizedText[] traitNames = { GameText.Physical, GameText.Sociological, GameText.HistoryAndTradition };
+            LocalizedText[] traitNames = { GameText.Physical, GameText.Sociological, GameText.HistoryAndTradition, "Environment" };
             Traits = Add(new SubmenuScrollList<TraitsListItem>(traitsList.Bevel(-20), traitNames));
             Traits.OnTabChange = OnTraitsTabChanged;
             Traits.SetBackground(new Menu1(traitsList));
@@ -216,9 +216,9 @@ namespace Ship_Game
             DoRaceDescription();
             SetRacialTraits(SelectedData.Traits);
 
-            var envRect = new Rectangle(5, (int)TitleBar.Bottom + 5, (int)ChooseRaceList.Width + 5, 150);
+            var envRect = new Rectangle(5, (int)TitleBar.Bottom + 5, (int)ChooseRaceList.Width, 150);
             EnvMenu = Add(new EnvPreferencesPanel(this, envRect));
-            EnvMenu.Visible = GlobalStats.Defaults.DisplayEnvPreferenceInRaceDesign;
+            EnvMenu.Visible = true; // GlobalStats.Defaults.DisplayEnvPreferenceInRaceDesign;
 
             ChooseRaceList.ButtonMedium("Load Race", OnLoadRaceClicked)
                 .SetLocalPos(ChooseRaceList.Width / 2 - 142, ChooseRaceList.Height + 10);
@@ -321,8 +321,9 @@ namespace Ship_Game
             {
                 default:
                 case 0: category = "Physical"; break;
-                case 1: category = "Industry"; break;
-                case 2: category = "Special";  break;
+                case 1: category = "Sociological"; break;
+                case 2: category = "HistoryAndTradition";  break;
+                case 3: category = "Environment"; break;
             }
 
             TraitsListItem[] traits = AllTraits.FilterSelect(t => t.Trait.Category == category,
@@ -344,7 +345,7 @@ namespace Ship_Game
         {
             foreach (TraitEntry trait in AllTraits)
                 trait.Selected = false;
-            TotalPointsUsed = 8;
+            TotalPointsUsed = P.RacialTraitPoints;
         }
 
         void OnLoadRaceClicked(UIButton b)
@@ -507,6 +508,7 @@ namespace Ship_Game
 
             UpdateTraits();
             DoRaceDescription();
+            EnvMenu.UpdatePreferences(RaceSummary);
         }
 
         void OnRaceArchetypeItemClicked(RaceArchetypeListItem item)
@@ -514,7 +516,7 @@ namespace Ship_Game
             SelectedData = item.EmpireData;
             SetRacialTraits(SelectedData.Traits);
 
-            if (GlobalStats.Defaults.DisplayEnvPreferenceInRaceDesign)
+            //if (GlobalStats.Defaults.DisplayEnvPreferenceInRaceDesign)
             {
                 EnvMenu.UpdateArchetype(SelectedData);
             }

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
@@ -219,7 +219,6 @@ namespace Ship_Game
 
             var envRect = new Rectangle(5, (int)TitleBar.Bottom + 5, (int)ChooseRaceList.Width, 150);
             EnvMenu = Add(new EnvPreferencesPanel(this, RaceSummary, envRect));
-            EnvMenu.Visible = true; // GlobalStats.Defaults.DisplayEnvPreferenceInRaceDesign;
             ChooseRaceList.ButtonMedium("Load Race", OnLoadRaceClicked)
                 .SetLocalPos(ChooseRaceList.Width / 2 - 142, ChooseRaceList.Height + 10);
             ChooseRaceList.ButtonMedium("Save Race", OnSaveRaceClicked)
@@ -515,13 +514,9 @@ namespace Ship_Game
         {
             SelectedData = item.EmpireData;
             SetRacialTraits(SelectedData.Traits);
-
-            //if (GlobalStats.Defaults.DisplayEnvPreferenceInRaceDesign)
-            {
-                UpdateTraits();
-                DoRaceDescription();
-                EnvMenu.UpdateArchetype(SelectedData, RaceSummary);
-            }
+            UpdateTraits();
+            DoRaceDescription();
+            EnvMenu.UpdateArchetype(SelectedData, RaceSummary);
         }
 
         void OnEngageClicked(UIButton b)

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
@@ -76,6 +76,7 @@ namespace Ship_Game
             t.Name      = RaceName;
             t.ShipType  = SelectedData.ShipType;
             t.VideoPath = SelectedData.VideoPath;
+            t.TraitOptions = AllTraits.FilterSelect(trait => trait.Selected, trait => trait.Trait.TraitName).ToArrayList();
             return t;
         }
         
@@ -484,7 +485,7 @@ namespace Ship_Game
                 TotalPointsUsed += t.Trait.Cost;
                 GameAudio.BlipClick();
             }
-            else if (TotalPointsUsed - t.Trait.Cost < 0 || t.Selected)
+            else if (TotalPointsUsed - t.Trait.Cost < 0 || t.Selected || t.Excluded)
             {
                 GameAudio.NegativeClick();
             }
@@ -642,7 +643,7 @@ namespace Ship_Game
                     if (t.Selected)
                     {
                         batch.DrawString(Font, $"({t.Trait.Cost}) {t.Trait.LocalizedName.Text}", cursor,
-                                               (t.Trait.Cost > 0 ? new Color(59, 137, 59) : Color.Crimson));
+                                               (t.Trait.Cost > 0 ? Color.ForestGreen: Color.Red));
                         cursor.Y += (Font.LineSpacing + 2);
                         line++;
                     }

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
@@ -483,9 +483,6 @@ namespace Ship_Game
                 t.Selected = !t.Selected;
                 TotalPointsUsed += t.Trait.Cost;
                 GameAudio.BlipClick();
-                foreach (TraitEntry ex in AllTraits)
-                    if (t.Trait.Excludes == ex.Trait.TraitIndex)
-                        ex.Excluded = false;
             }
             else if (TotalPointsUsed - t.Trait.Cost < 0 || t.Selected)
             {
@@ -496,7 +493,7 @@ namespace Ship_Game
                 bool ok = true;
                 foreach (TraitEntry ex in AllTraits)
                 {
-                    if (t.Trait.Excludes == ex.Trait.TraitIndex && ex.Selected)
+                    if (t.Trait.Excludes.Contains(ex.Trait.TraitName) && ex.Selected)
                         ok = false;
                 }
                 if (ok)
@@ -504,13 +501,10 @@ namespace Ship_Game
                     t.Selected = true;
                     TotalPointsUsed -= t.Trait.Cost;
                     GameAudio.BlipClick();
-                    foreach (TraitEntry ex in AllTraits)
-                    {
-                        if (t.Trait.Excludes == ex.Trait.TraitIndex)
-                            ex.Excluded = true;
-                    }
                 }
             }
+
+            UpdateTraits();
             DoRaceDescription();
         }
 

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
@@ -244,7 +244,7 @@ namespace Ship_Game
                 RacialTraitOption trait = t.Trait;
                 RaceSummary.ConsumptionModifier    += trait.ConsumptionModifier;
                 RaceSummary.DiplomacyMod           += trait.DiplomacyMod;
-                RaceSummary.TargetingModifier        += trait.EnergyDamageMod;
+                RaceSummary.TargetingModifier      += trait.TargetingModifier;
                 RaceSummary.MaintMod               += trait.MaintMod;
                 RaceSummary.ReproductionMod        += trait.ReproductionMod;
                 RaceSummary.PopGrowthMax           += trait.PopGrowthMax;

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
@@ -196,7 +196,7 @@ namespace Ship_Game
             Plural = traits.Plural;
             HomeSysName = traits.HomeSystemName;
             HomeWorldName = traits.HomeworldName;
-            TotalPointsUsed = 8;
+            TotalPointsUsed = P.RacialTraitPoints;
 
             foreach (TraitEntry traitEntry in AllTraits)
             {
@@ -217,7 +217,7 @@ namespace Ship_Game
             foreach (TraitEntry traitEntry in AllTraits)
                 traitEntry.Excluded = false;
 
-            TotalPointsUsed = 8;
+            TotalPointsUsed = P.RacialTraitPoints;
             foreach (TraitEntry traitEntry in AllTraits.Filter(t => t.Selected))
             {
                 TotalPointsUsed -= traitEntry.Trait.Cost;
@@ -270,6 +270,19 @@ namespace Ship_Game
                 RaceSummary.RepairMod              += trait.RepairMod;
                 RaceSummary.PassengerModifier      += trait.PassengerBonus;
                 RaceSummary.Pack                   += trait.Pack;
+                RaceSummary.Aquatic                += trait.Aquatic;
+                RaceSummary.EnvTerran   *= trait.EnvTerranMultiplier > 0   ? trait.EnvTerranMultiplier   : 1;
+                RaceSummary.EnvOceanic  *= trait.EnvOceanicMultiplier > 0  ? trait.EnvOceanicMultiplier  : 1;
+                RaceSummary.EnvSteppe   *= trait.EnvSteppeMultiplier > 0   ? trait.EnvSteppeMultiplier   : 1;
+                RaceSummary.EnvTundra   *= trait.EnvTundraMultiplier > 0   ? trait.EnvTundraMultiplier   : 1;
+                RaceSummary.EnvSwamp    *= trait.EnvSwampMultiplier > 0    ? trait.EnvSwampMultiplier    : 1;
+                RaceSummary.EnvDesert   *= trait.EnvDesertMultiplier > 0   ? trait.EnvDesertMultiplier   : 1;
+                RaceSummary.EnvIce      *= trait.EnvIceMultiplier > 0      ? trait.EnvIceMultiplier      : 1;
+                RaceSummary.EnvBarren   *= trait.EnvBarrenMultiplier > 0   ? trait.EnvBarrenMultiplier   : 1;
+                RaceSummary.EnvVolcanic *= trait.EnvVolcanicMultiplier > 0 ? trait.EnvVolcanicMultiplier : 1;
+                if (trait.PreferredEnv != PlanetCategory.Terran)
+                    RaceSummary.PreferredEnv = trait.PreferredEnv;
+
             }
         }
     }

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
@@ -185,7 +185,7 @@ namespace Ship_Game
         {
             foreach (TraitEntry traitEntry in AllTraits)
             {
-                traitEntry.Excluded= false;
+                traitEntry.ExcludedBy = new();
             }
 
             RaceSummary.ShipType = traits.ShipType;
@@ -215,7 +215,7 @@ namespace Ship_Game
         void UpdateTraits()
         {
             foreach (TraitEntry traitEntry in AllTraits)
-                traitEntry.Excluded = false;
+                traitEntry.ExcludedBy = new();
 
             TotalPointsUsed = P.RacialTraitPoints;
             foreach (TraitEntry traitEntry in AllTraits.Filter(t => t.Selected))
@@ -229,7 +229,7 @@ namespace Ship_Game
         {
             foreach (TraitEntry ex in AllTraits)
                 if (t.Trait.Excludes.Contains(ex.Trait.TraitName))
-                    ex.Excluded = true;
+                    ex.ExcludedBy.Add(t.Trait.LocalizedName.Text);
         }
         
         void CreateRaceSummary()
@@ -244,7 +244,7 @@ namespace Ship_Game
                 RacialTraitOption trait = t.Trait;
                 RaceSummary.ConsumptionModifier    += trait.ConsumptionModifier;
                 RaceSummary.DiplomacyMod           += trait.DiplomacyMod;
-                RaceSummary.EnergyDamageMod        += trait.EnergyDamageMod;
+                RaceSummary.TargetingModifier        += trait.EnergyDamageMod;
                 RaceSummary.MaintMod               += trait.MaintMod;
                 RaceSummary.ReproductionMod        += trait.ReproductionMod;
                 RaceSummary.PopGrowthMax           += trait.PopGrowthMax;
@@ -271,18 +271,19 @@ namespace Ship_Game
                 RaceSummary.PassengerModifier      += trait.PassengerBonus;
                 RaceSummary.Pack                   += trait.Pack;
                 RaceSummary.Aquatic                += trait.Aquatic;
-                RaceSummary.EnvTerran   *= trait.EnvTerranMultiplier > 0   ? trait.EnvTerranMultiplier   : 1;
-                RaceSummary.EnvOceanic  *= trait.EnvOceanicMultiplier > 0  ? trait.EnvOceanicMultiplier  : 1;
-                RaceSummary.EnvSteppe   *= trait.EnvSteppeMultiplier > 0   ? trait.EnvSteppeMultiplier   : 1;
-                RaceSummary.EnvTundra   *= trait.EnvTundraMultiplier > 0   ? trait.EnvTundraMultiplier   : 1;
-                RaceSummary.EnvSwamp    *= trait.EnvSwampMultiplier > 0    ? trait.EnvSwampMultiplier    : 1;
-                RaceSummary.EnvDesert   *= trait.EnvDesertMultiplier > 0   ? trait.EnvDesertMultiplier   : 1;
-                RaceSummary.EnvIce      *= trait.EnvIceMultiplier > 0      ? trait.EnvIceMultiplier      : 1;
-                RaceSummary.EnvBarren   *= trait.EnvBarrenMultiplier > 0   ? trait.EnvBarrenMultiplier   : 1;
-                RaceSummary.EnvVolcanic *= trait.EnvVolcanicMultiplier > 0 ? trait.EnvVolcanicMultiplier : 1;
+
+                RaceSummary.ExploreDistanceMultiplier *= trait.ExploreDistanceMultiplier;
+                RaceSummary.EnvTerran   *= trait.EnvTerranMultiplier;
+                RaceSummary.EnvOceanic  *= trait.EnvOceanicMultiplier;
+                RaceSummary.EnvSteppe   *= trait.EnvSteppeMultiplier;
+                RaceSummary.EnvTundra   *= trait.EnvTundraMultiplier;
+                RaceSummary.EnvSwamp    *= trait.EnvSwampMultiplier;
+                RaceSummary.EnvDesert   *= trait.EnvDesertMultiplier;
+                RaceSummary.EnvIce      *= trait.EnvIceMultiplier;
+                RaceSummary.EnvBarren   *= trait.EnvBarrenMultiplier;
+                RaceSummary.EnvVolcanic *= trait.EnvVolcanicMultiplier;
                 if (trait.PreferredEnv != PlanetCategory.Terran)
                     RaceSummary.PreferredEnv = trait.PreferredEnv;
-
             }
         }
     }

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
@@ -7,6 +7,7 @@ using Microsoft.Xna.Framework.Graphics;
 using SDUtils;
 using Ship_Game.Data;
 using Ship_Game.Gameplay;
+using Ship_Game.GameScreens.NewGame;
 using static System.Net.Mime.MediaTypeNames;
 
 namespace Ship_Game
@@ -179,6 +180,7 @@ namespace Ship_Game
 
             ChooseRaceList.OnItemClicked(archetype); // click on the archetype faction
             SetRacialTraits(traits);
+            EnvMenu.UpdatePreferences(RaceSummary);
         }
 
         void SetRacialTraits(RacialTrait traits)

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
@@ -183,6 +183,11 @@ namespace Ship_Game
 
         void SetRacialTraits(RacialTrait traits)
         {
+            foreach (TraitEntry traitEntry in AllTraits)
+            {
+                traitEntry.Excluded= false;
+            }
+
             RaceSummary.ShipType = traits.ShipType;
             Picker.CurrentColor  = traits.Color;
             FlagIndex = traits.FlagIndex;
@@ -203,17 +208,27 @@ namespace Ship_Game
                     TotalPointsUsed -= tEnt.Cost;
                     SetExclusions(traitEntry);
                 }
-
-                /*if (traitEntry.Selected)
-                    SetExclusions(traitEntry);*/
             }
             DoRaceDescription();
+        }
+
+        void UpdateTraits()
+        {
+            foreach (TraitEntry traitEntry in AllTraits)
+                traitEntry.Excluded = false;
+
+            TotalPointsUsed = 8;
+            foreach (TraitEntry traitEntry in AllTraits.Filter(t => t.Selected))
+            {
+                TotalPointsUsed -= traitEntry.Trait.Cost;
+                SetExclusions(traitEntry);
+            }
         }
 
         void SetExclusions(TraitEntry t)
         {
             foreach (TraitEntry ex in AllTraits)
-                if (t.Trait.Excludes == ex.Trait.TraitIndex)
+                if (t.Trait.Excludes.Contains(ex.Trait.TraitName))
                     ex.Excluded = true;
         }
         

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
@@ -273,6 +273,8 @@ namespace Ship_Game
                 RaceSummary.PassengerModifier      += trait.PassengerBonus;
                 RaceSummary.Pack                   += trait.Pack;
                 RaceSummary.Aquatic                += trait.Aquatic;
+                RaceSummary.CreditsPerKilledSlot   += trait.CreditsPerKilledSlot;
+                RaceSummary.PenaltyPerKilledSlot   += trait.PenaltyPerKilledSlot;
 
                 RaceSummary.ExploreDistanceMultiplier *= trait.ExploreDistanceMultiplier;
                 RaceSummary.EnvTerran   *= trait.EnvTerranMultiplier;

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
@@ -5,7 +5,9 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Xna.Framework.Graphics;
 using SDUtils;
+using Ship_Game.Data;
 using Ship_Game.Gameplay;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace Ship_Game
 {
@@ -191,63 +193,19 @@ namespace Ship_Game
             HomeWorldName = traits.HomeworldName;
             TotalPointsUsed = 8;
 
-            // because RacialTrait is used in both `Races/MyRace.xml` and in `RacialTraits/RacialTraits.xml`
-            // this monstrocity is needed to figure out which TraitEntry are selected by MyRace `traits`
             foreach (TraitEntry traitEntry in AllTraits)
             {
                 traitEntry.Selected = false;
-                RacialTrait tEnt = traitEntry.trait;
-
-                //Added by McShooterz: Searches for new trait tags
-                // checks for Physical/Sociological/Historical trait flag, but also checks for
-                // the modifier itself for handling saved race designs which don't set these flags
-                if ((traits.ConsumptionModifier > 0f || traits.PhysicalTraitGluttonous) && tEnt.ConsumptionModifier > 0f 
-                    || tEnt.ConsumptionModifier < 0f && (traits.ConsumptionModifier < 0f || traits.PhysicalTraitEfficientMetabolism)
-                    || (traits.DiplomacyMod > 0f || traits.PhysicalTraitAlluring) && tEnt.DiplomacyMod > 0f 
-                    || tEnt.DiplomacyMod < 0f && (traits.DiplomacyMod < 0f || traits.PhysicalTraitRepulsive)
-                    || (traits.EnergyDamageMod > 0f || traits.PhysicalTraitEagleEyed) && tEnt.EnergyDamageMod > 0f
-                    || tEnt.EnergyDamageMod < 0f && (traits.EnergyDamageMod < 0f || traits.PhysicalTraitBlind)
-                    || (traits.MaintMod > 0f || traits.SociologicalTraitWasteful) && tEnt.MaintMod > 0f 
-                    || tEnt.MaintMod < 0f && (traits.MaintMod < 0f || traits.SociologicalTraitEfficient)
-                    || (traits.PopGrowthMax > 0f || traits.PhysicalTraitLessFertile) && tEnt.PopGrowthMax > 0f 
-                    || (traits.PopGrowthMin > 0f || traits.PhysicalTraitFertile) && tEnt.PopGrowthMin > 0f 
-                    || (traits.ResearchMod > 0f || traits.PhysicalTraitSmart) && tEnt.ResearchMod > 0f 
-                    || tEnt.ResearchMod < 0f && (traits.ResearchMod < 0f || traits.PhysicalTraitDumb)
-                    || tEnt.ShipCostMod < 0f && (traits.ShipCostMod < 0f || traits.HistoryTraitNavalTraditions) 
-                    || (traits.TaxMod > 0f || traits.SociologicalTraitMeticulous) && tEnt.TaxMod > 0f 
-                    || tEnt.TaxMod < 0f && (traits.TaxMod < 0f || traits.SociologicalTraitCorrupt)
-                    || (traits.ProductionMod > 0f || traits.SociologicalTraitIndustrious) && tEnt.ProductionMod > 0f 
-                    || tEnt.ProductionMod < 0f && (traits.ProductionMod < 0f || traits.SociologicalTraitLazy)
-                    || (traits.ModHpModifier > 0f || traits.SociologicalTraitSkilledEngineers) && tEnt.ModHpModifier > 0f 
-                    || tEnt.ModHpModifier < 0f && (traits.ModHpModifier < 0f || traits.SociologicalTraitHaphazardEngineers)
-                    || (traits.Mercantile > 0f || traits.SociologicalTraitMercantile) && tEnt.Mercantile > 0f  
-                    || (traits.GroundCombatModifier > 0f || traits.PhysicalTraitSavage) && tEnt.GroundCombatModifier > 0f 
-                    || tEnt.GroundCombatModifier < 0f && (traits.GroundCombatModifier < 0f || traits.PhysicalTraitTimid)
-                    || (traits.Cybernetic > 0 || traits.HistoryTraitCybernetic) && tEnt.Cybernetic > 0 
-                    || (traits.DodgeMod > 0f || traits.PhysicalTraitReflexes) && tEnt.DodgeMod > 0f 
-                    || tEnt.DodgeMod < 0f && (traits.DodgeMod < 0f || traits.PhysicalTraitPonderous) 
-                    || (traits.HomeworldSizeMod > 0f || traits.HistoryTraitHugeHomeWorld) && tEnt.HomeworldSizeMod > 0f 
-                    || tEnt.HomeworldSizeMod < 0f && (traits.HomeworldSizeMod < 0f || traits.HistoryTraitSmallHomeWorld)
-                    || tEnt.HomeworldFertMod < 0f && (traits.HomeworldFertMod < 0f || traits.HistoryTraitPollutedHomeWorld) && tEnt.HomeworldRichMod == 0f
-                    || tEnt.HomeworldFertMod < 0f && (traits.HomeworldRichMod > 0f || traits.HistoryTraitIndustrializedHomeWorld) && tEnt.HomeworldRichMod != 0f
-                    || tEnt.HomeworldRichMod > 0 && (traits.HomeworldRichMod > 0f)
-                    || tEnt.HomeworldFertMod > 0 && (traits.HomeworldFertMod > 0f)
-                    || (traits.Militaristic > 0 || traits.HistoryTraitMilitaristic) && tEnt.Militaristic > 0 
-                    || (traits.PassengerModifier > 1 || traits.HistoryTraitManifestDestiny) && tEnt.PassengerModifier > 1
-                    || (traits.PassengerBonus > 0 || traits.HistoryTraitManifestDestiny) && tEnt.PassengerBonus > 0
-                    || (traits.BonusExplored > 0 || traits.HistoryTraitAstronomers) && tEnt.BonusExplored > 0 
-                    || (traits.Spiritual > 0f || traits.HistoryTraitSpiritual) && tEnt.Spiritual > 0f 
-                    || (traits.Prototype > 0 || traits.HistoryTraitPrototypeFlagship) && tEnt.Prototype > 0 
-                    || (traits.Pack || traits.HistoryTraitPackMentality) && tEnt.Pack 
-                    || (traits.SpyMultiplier > 0f || traits.HistoryTraitDuplicitous) && tEnt.SpyMultiplier > 0f 
-                    || (traits.SpyMultiplier < 0f || traits.HistoryTraitHonest) && tEnt.SpyMultiplier < 0f)
+                RacialTraitOption tEnt = traitEntry.Trait;
+                if (traits.TraitOptions.Contains(tEnt.TraitName))
                 {
                     traitEntry.Selected = true;
                     TotalPointsUsed -= tEnt.Cost;
+                    SetExclusions(traitEntry);
                 }
 
-                if (traitEntry.Selected)
-                    SetExclusions(traitEntry);
+                /*if (traitEntry.Selected)
+                    SetExclusions(traitEntry);*/
             }
             DoRaceDescription();
         }
@@ -255,7 +213,7 @@ namespace Ship_Game
         void SetExclusions(TraitEntry t)
         {
             foreach (TraitEntry ex in AllTraits)
-                if (t.trait.Excludes == ex.trait.TraitName)
+                if (t.Trait.Excludes == ex.Trait.TraitIndex)
                     ex.Excluded = true;
         }
         
@@ -267,7 +225,8 @@ namespace Ship_Game
             {
                 if (!t.Selected)
                     continue;
-                RacialTrait trait = t.trait;
+
+                RacialTraitOption trait = t.Trait;
                 RaceSummary.ConsumptionModifier    += trait.ConsumptionModifier;
                 RaceSummary.DiplomacyMod           += trait.DiplomacyMod;
                 RaceSummary.EnergyDamageMod        += trait.EnergyDamageMod;
@@ -295,8 +254,7 @@ namespace Ship_Game
                 RaceSummary.SpyMultiplier          += trait.SpyMultiplier;
                 RaceSummary.RepairMod              += trait.RepairMod;
                 RaceSummary.PassengerModifier      += trait.PassengerBonus;
-                if (trait.Pack)
-                    RaceSummary.Pack = trait.Pack;
+                RaceSummary.Pack                   += trait.Pack;
             }
         }
     }

--- a/Ship_Game/GameScreens/NewGame/TraitsListItem.cs
+++ b/Ship_Game/GameScreens/NewGame/TraitsListItem.cs
@@ -15,6 +15,7 @@ namespace Ship_Game
         readonly RaceDesignScreen Screen;
         readonly Graphics.Font TitleFont;
         readonly Graphics.Font DescrFont;
+        string Description;
         public TraitEntry Trait;
         Color GrayedoutColor = new Color(100, 100, 100);
 
@@ -24,9 +25,10 @@ namespace Ship_Game
             Trait = trait;
             TitleFont = screen.LowRes ? Fonts.Arial11Bold : Fonts.Arial14Bold;
             DescrFont = screen.LowRes ? Fonts.Arial10 : Fonts.Arial12;
+            Description = new LocalizedText(Trait.Trait.Description).Text;
         }
 
-        public override int ItemHeight => TitleFont.LineSpacing * 2 + DescrFont.LineSpacing;
+        public override int ItemHeight => TitleFont.LineSpacing * 3 + DescrFont.LineSpacing;
 
         public override void Draw(SpriteBatch batch, DrawTimes elapsed)
         {
@@ -62,7 +64,7 @@ namespace Ship_Game
             batch.DrawString(TitleFont, costText, curs, drawColor);
 
             pos.Y += TitleFont.LineSpacing;
-            batch.DrawString(DescrFont, DescrFont.ParseText(new LocalizedText(Trait.Trait.Description), textAreaWidth), pos, drawColor);
+            batch.DrawString(DescrFont, DescrFont.ParseText(GetDescrption(), textAreaWidth), pos, drawColor);
         }
 
         static float DotSpaceWidth;
@@ -81,6 +83,28 @@ namespace Ship_Game
                 sb.Append(" .");
 
             return sb.ToString();
+        }
+
+        string GetDescrption()
+        {
+            if (Trait.Selected)
+                return Description;
+
+            string extraDescription = string.Empty;
+            if (Trait.Excluded)
+            {
+                string excludedText = Trait.ExcludedBy[0];
+                for (int i = 1; i < Trait.ExcludedBy.Count; i++)
+                    excludedText = $"{excludedText}, {Trait.ExcludedBy[i]}";
+
+                extraDescription = $"(excluded by {excludedText}).";
+            }
+            else if (Screen.TotalPointsUsed - Trait.Trait.Cost < 0)
+            {
+                extraDescription = "(not enough points to spend).";
+            }
+
+            return $"{Description} {extraDescription}";
         }
     }
 }

--- a/Ship_Game/GameScreens/NewGame/TraitsListItem.cs
+++ b/Ship_Game/GameScreens/NewGame/TraitsListItem.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Xna.Framework.Graphics;
+using SDGraphics;
 using Ship_Game.Gameplay;
 using Vector2 = SDGraphics.Vector2;
 
@@ -42,7 +43,7 @@ namespace Ship_Game
             }
             if (Trait.Selected)
             {
-                drawColor = (cost > 0 ? Color.ForestGreen : Color.Crimson);
+                drawColor = (cost > 0 ? Color.ForestGreen : Color.Red);
             }
             else if (Trait.Excluded)
             {

--- a/Ship_Game/GameScreens/NewGame/TraitsListItem.cs
+++ b/Ship_Game/GameScreens/NewGame/TraitsListItem.cs
@@ -15,6 +15,8 @@ namespace Ship_Game
         readonly Graphics.Font TitleFont;
         readonly Graphics.Font DescrFont;
         public TraitEntry Trait;
+        Color grayedoutColor = new Color(100, 100, 100);
+
         public TraitsListItem(RaceDesignScreen screen, TraitEntry trait)
         {
             Screen = screen;
@@ -33,10 +35,10 @@ namespace Ship_Game
             string name = PaddedWithDots(TitleFont, Trait.Trait.LocalizedName.Text, textAreaWidth);
             int cost = Trait.Trait.Cost;
 
-            var drawColor = new Color(95, 95, 95, 95);
+            var drawColor = grayedoutColor;
             if (!Trait.Selected)
             {
-                drawColor = new Color(95, 95, 95, 95);
+                drawColor = grayedoutColor;
             }
             if (Trait.Selected)
             {
@@ -44,7 +46,7 @@ namespace Ship_Game
             }
             else if (Trait.Excluded)
             {
-                drawColor = new Color(95, 95, 95, 95);
+                drawColor = grayedoutColor;
             }
             else if (Screen.TotalPointsUsed >= 0 && Screen.TotalPointsUsed - cost >= 0 || cost < 0)
             {

--- a/Ship_Game/GameScreens/NewGame/TraitsListItem.cs
+++ b/Ship_Game/GameScreens/NewGame/TraitsListItem.cs
@@ -30,8 +30,8 @@ namespace Ship_Game
             base.Draw(batch, elapsed);
 
             float textAreaWidth = Width - 40;
-            string name = PaddedWithDots(TitleFont, Trait.trait.LocalizedName.Text, textAreaWidth);
-            int cost = Trait.trait.Cost;
+            string name = PaddedWithDots(TitleFont, Trait.Trait.LocalizedName.Text, textAreaWidth);
+            int cost = Trait.Trait.Cost;
 
             var drawColor = new Color(95, 95, 95, 95);
             if (!Trait.Selected)
@@ -59,7 +59,7 @@ namespace Ship_Game
             batch.DrawString(TitleFont, costText, curs, drawColor);
 
             pos.Y += TitleFont.LineSpacing;
-            batch.DrawString(DescrFont, DescrFont.ParseText(new LocalizedText(Trait.trait.Description), textAreaWidth), pos, drawColor);
+            batch.DrawString(DescrFont, DescrFont.ParseText(new LocalizedText(Trait.Trait.Description), textAreaWidth), pos, drawColor);
         }
 
         static float DotSpaceWidth;

--- a/Ship_Game/GameScreens/NewGame/TraitsListItem.cs
+++ b/Ship_Game/GameScreens/NewGame/TraitsListItem.cs
@@ -16,7 +16,7 @@ namespace Ship_Game
         readonly Graphics.Font TitleFont;
         readonly Graphics.Font DescrFont;
         public TraitEntry Trait;
-        Color grayedoutColor = new Color(100, 100, 100);
+        Color GrayedoutColor = new Color(100, 100, 100);
 
         public TraitsListItem(RaceDesignScreen screen, TraitEntry trait)
         {
@@ -36,10 +36,10 @@ namespace Ship_Game
             string name = PaddedWithDots(TitleFont, Trait.Trait.LocalizedName.Text, textAreaWidth);
             int cost = Trait.Trait.Cost;
 
-            var drawColor = grayedoutColor;
+            var drawColor = GrayedoutColor;
             if (!Trait.Selected)
             {
-                drawColor = grayedoutColor;
+                drawColor = GrayedoutColor;
             }
             if (Trait.Selected)
             {
@@ -47,7 +47,7 @@ namespace Ship_Game
             }
             else if (Trait.Excluded)
             {
-                drawColor = grayedoutColor;
+                drawColor = (cost > 0 ? Color.MediumSeaGreen.Alpha(0.4f) : Color.LightCoral.Alpha(0.4f));
             }
             else if (Screen.TotalPointsUsed >= 0 && Screen.TotalPointsUsed - cost >= 0 || cost < 0)
             {

--- a/Ship_Game/Gameplay/RacialTraits.cs
+++ b/Ship_Game/Gameplay/RacialTraits.cs
@@ -1,9 +1,10 @@
 using SDUtils;
+using Ship_Game.Data;
 
 namespace Ship_Game.Gameplay
 {
 	public sealed  class RacialTraits
 	{
-		public Array<RacialTrait> TraitList;
+		public Array<RacialTraitOption> TraitList;
 	}
 }

--- a/Ship_Game/Gameplay/TraitEntry.cs
+++ b/Ship_Game/Gameplay/TraitEntry.cs
@@ -1,4 +1,6 @@
+using SDUtils;
 using Ship_Game.Data;
+using System;
 using Rectangle = SDGraphics.Rectangle;
 
 namespace Ship_Game.Gameplay;
@@ -8,7 +10,8 @@ public sealed class TraitEntry
     public bool Selected;
     public RacialTraitOption Trait;
     public Rectangle rect;
-    public bool Excluded;
+    public bool Excluded => ExcludedBy.Count > 0;
+    public Array<string> ExcludedBy = new(); 
 
     public override string ToString() => $"TraitEntry {Trait.LocalizedName.Text} Selected={Selected} Excluded={Excluded}";
 }

--- a/Ship_Game/Gameplay/TraitEntry.cs
+++ b/Ship_Game/Gameplay/TraitEntry.cs
@@ -1,3 +1,4 @@
+using Ship_Game.Data;
 using Rectangle = SDGraphics.Rectangle;
 
 namespace Ship_Game.Gameplay;
@@ -5,9 +6,9 @@ namespace Ship_Game.Gameplay;
 public sealed class TraitEntry
 {
     public bool Selected;
-    public RacialTrait trait;
+    public RacialTraitOption Trait;
     public Rectangle rect;
     public bool Excluded;
 
-    public override string ToString() => $"TraitEntry {trait.LocalizedName.Text} Selected={Selected} Excluded={Excluded}";
+    public override string ToString() => $"TraitEntry {Trait.LocalizedName.Text} Selected={Selected} Excluded={Excluded}";
 }

--- a/Ship_Game/Gameplay/Weapon.cs
+++ b/Ship_Game/Gameplay/Weapon.cs
@@ -578,7 +578,7 @@ namespace Ship_Game.Gameplay
             if (Owner == null)
                 return;
 
-            if (Owner.Loyalty.data.Traits.Pack)
+            if (Owner.Loyalty.HavePackMentality)
                 projectile.DamageAmount += projectile.DamageAmount * Owner.PackDamageModifier;
 
             float actualShieldPenChance = Module?.GetParent().Loyalty.data.ShieldPenBonusChance * 100 ?? 0;

--- a/Ship_Game/Gameplay/Weapon.cs
+++ b/Ship_Game/Gameplay/Weapon.cs
@@ -293,12 +293,11 @@ namespace Ship_Game.Gameplay
             
             // reduce or increase error based on weapon and trait characteristics.
             // this could be pre-calculated in the flyweight
-            if (Tag_Cannon) adjust  *= (1f - (Owner?.Loyalty?.data.Traits.EnergyDamageMod ?? 0));
             if (Tag_Kinetic) adjust *= (1f - (Owner?.Loyalty?.data.OrdnanceEffectivenessBonus ?? 0));
             if (IsTurret) adjust    *= 0.5f;
             if (Tag_PD) adjust      *= 0.5f;
             if (TruePD) adjust      *= 0.5f;
-            return adjust;
+            return adjust * (1f - (Owner?.Loyalty?.data.Traits.TargetingModifier ?? 0));
         }
 
         // @note This is used for debugging

--- a/Ship_Game/GlobalStats.cs
+++ b/Ship_Game/GlobalStats.cs
@@ -388,7 +388,7 @@ public static class GlobalStats
 
     public static void SetActiveModNoSave(ModEntry me)
     {
-        if (me != null)
+        if (me != null && me.CheckSupport(me.Mod.SupportedBlackBoxVersions, me.Mod.FormatVersion))
         {
             ModName = me.Mod.Name;
             ModPath = me.Mod.Path;

--- a/Ship_Game/ModEntry.cs
+++ b/Ship_Game/ModEntry.cs
@@ -12,10 +12,14 @@ namespace Ship_Game
         public bool IsSupported { get; }
         public SubTexture PortraitTex;
 
+        // Make sure this mode can be loaded regarding data format. If this is spinned up,
+        // the mod will not be loaded and the modde will have to check the changes.
+        public const int FormatVersion = 1; 
+
         public ModEntry(GamePlayGlobals settings)
         {
             Settings = settings;
-            IsSupported = CheckSupport(Mod.SupportedBlackBoxVersions);
+            IsSupported = CheckSupport(Mod.SupportedBlackBoxVersions, Mod.FormatVersion);
         }
 
         public SubTexture LoadPortrait(GameScreen screen)
@@ -44,7 +48,7 @@ namespace Ship_Game
 
             if (!IsSupported)
             {
-                batch.DrawString(Fonts.Arial12Bold, "Not supported on This BlackBox Version", titlePos, Color.Red);
+                batch.DrawString(Fonts.Arial12Bold, "Not supported on This BlackBox Version, try update this mod.", titlePos, Color.Red);
                 titlePos.Y += Fonts.Arial12Bold.LineSpacing + 1;
             }
 
@@ -64,9 +68,9 @@ namespace Ship_Game
             batch.DrawRectangle(portrait, Color.White);
         }
 
-        bool CheckSupport(string supportedBbVers)
+        public bool CheckSupport(string supportedBbVers, int formatVersion)
         {
-            if (supportedBbVers.IsEmpty())
+            if (supportedBbVers.IsEmpty() || formatVersion != FormatVersion)
                 return false;
 
             foreach (string version in supportedBbVers.Split(',')) 

--- a/Ship_Game/ModInformation.cs
+++ b/Ship_Game/ModInformation.cs
@@ -17,6 +17,7 @@ public sealed class ModInformation
 
     [StarData] public string Version;
     [StarData] public string SupportedBlackBoxVersions;
+    [StarData] public int FormatVersion; // make sure this mode can be loaded regarding data format
 
     // TRUE by default, but if set false, no vanilla designs will be loaded
     // from StarDrive/Content/ShipDesigns and the mod is responsible to provide all required designs

--- a/Ship_Game/RandomItem.cs
+++ b/Ship_Game/RandomItem.cs
@@ -42,12 +42,11 @@ namespace Ship_Game
             switch (category)
             {
                 default:
-                case PlanetCategory.Other:
+                case PlanetCategory.Terran:   return (TerranChance,   TerranInstanceMin,   TerranInstanceMax);
                 case PlanetCategory.Barren:   return (BarrenChance,   BarrenInstanceMin,   BarrenInstanceMax);
                 case PlanetCategory.Desert:   return (DesertChance,   DesertInstanceMin,   DesertInstanceMax);
                 case PlanetCategory.Steppe:   return (SteppeChance,   SteppeInstanceMin,   SteppeInstanceMax);
                 case PlanetCategory.Tundra:   return (TundraChance,   TundraInstanceMin,   TundraInstanceMax);
-                case PlanetCategory.Terran:   return (TerranChance,   TerranInstanceMin,   TerranInstanceMax);
                 case PlanetCategory.Volcanic: return (VolcanicChance, VolcanicInstanceMin, VolcanicInstanceMax);
                 case PlanetCategory.Ice:      return (IceChance,      IceInstanceMin,      IceInstanceMax);
                 case PlanetCategory.Swamp:    return (SwampChance,    SwampInstanceMin,    SwampInstanceMax);

--- a/Ship_Game/SavedGame.cs
+++ b/Ship_Game/SavedGame.cs
@@ -24,7 +24,7 @@ namespace Ship_Game
     {
         // Every time the savegame layout changes significantly,
         // this version needs to be bumped to avoid loading crashes
-        public const int SaveGameVersion = 15;
+        public const int SaveGameVersion = 16;
 
         public bool Verbose;
 

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -130,8 +130,8 @@ namespace Ship_Game.Ships
         public void SetHighAlertStatus() => HighAlertTimer = HighAlertSeconds;
         public float GetHighAlertTimer() => HighAlertTimer;
 
-        public float ExplorePlanetDistance => (SensorRange * 0.1f).LowerBound(500);
-        public float ExploreSystemDistance => SensorRange;
+        public float ExplorePlanetDistance => (SensorRange * 0.1f).LowerBound(500) * Loyalty.data.Traits.ExploreDistanceMultiplier;
+        public float ExploreSystemDistance => SensorRange * Loyalty.data.Traits.ExploreDistanceMultiplier;
 
         public float InternalSlotsHealthPercent; // number_Alive_Internal_slots / number_Internal_slots
         Vector3 DieRotation;

--- a/Ship_Game/Ships/ShipInfoUIElement.cs
+++ b/Ship_Game/Ships/ShipInfoUIElement.cs
@@ -200,7 +200,7 @@ namespace Ship_Game.Ships
         {
             SubTexture iconPack = ResourceManager.Texture("StatusIcons/icon_pack");
 
-            if (!ship.Loyalty.data.Traits.Pack)
+            if (!ship.Loyalty.HavePackMentality)
                 return;
 
             var packRect = new Rectangle((int)StatusArea.X, (int)StatusArea.Y, 48, 32);

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
@@ -698,7 +698,7 @@ namespace Ship_Game
 
                 if (TilesList.Any(t => t.CanTerraform)
                     || TilesList.Any(t => t.BioCanTerraform || t.VolcanoHere)
-                    || Category != Owner.data.PreferredEnv
+                    || Category != Owner.data.PreferredEnvPlanet
                     || NonCybernetic && BaseMaxFertility.Less(1 / Empire.RacialEnvModifer(Category, Owner)))
                 {
                     return true;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
@@ -148,8 +148,8 @@ namespace Ship_Game
 
         static PlanetType GetPlanetType(Empire owner, SolarSystemData.Ring data = null)
         {
-            PlanetCategory preferred = owner.data.PreferredEnv == PlanetCategory.Other
-                                     ? PlanetCategory.Terran : owner.data.PreferredEnv;
+            PlanetCategory preferred = owner.data.PreferredEnvPlanet == PlanetCategory.Other
+                                     ? PlanetCategory.Terran : owner.data.PreferredEnvPlanet;
             return ResourceManager.Planets.PlanetOrRandom(data?.WhichPlanet ?? -1, preferred);
         }
 
@@ -294,7 +294,7 @@ namespace Ship_Game
 
         void TerraformPlanet()
         {
-            if (Category == Owner.data.PreferredEnv && BaseMaxFertility.GreaterOrEqual(TerraformedMaxFertility))
+            if (Category == Owner.data.PreferredEnvPlanet && BaseMaxFertility.GreaterOrEqual(TerraformedMaxFertility))
                 return;
 
             if (TerraformPoints.AlmostZero()) // Starting terraform
@@ -345,7 +345,7 @@ namespace Ship_Game
 
         void CompletePlanetTerraform()
         {
-            Terraform(Owner.data.PreferredEnv);
+            Terraform(Owner.data.PreferredEnvPlanet);
             TerraformPoints = 0;
             if (TerraformedMaxFertility.Greater(BaseMaxFertility))
             {
@@ -380,7 +380,7 @@ namespace Ship_Game
                     || terraLevel >= 2 && HasTilesToTerraform
                     || terraLevel == 3 && BioSpheresToTerraform
                     || terraLevel == 3 &&
-                        (Category != Owner.data.PreferredEnv || BaseMaxFertility.Less(TerraformedMaxFertility));
+                        (Category != Owner.data.PreferredEnvPlanet || BaseMaxFertility.Less(TerraformedMaxFertility));
             }
         }
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
@@ -146,33 +146,22 @@ namespace Ship_Game
             InitNewMinorPlanet(random, type, scale, data.MaxPopDefined);
         }
 
-        static PlanetType GetPlanetType(Empire owner, SolarSystemData.Ring data = null)
-        {
-            PlanetCategory preferred = owner.data.PreferredEnvPlanet == PlanetCategory.Other
-                                     ? PlanetCategory.Terran : owner.data.PreferredEnvPlanet;
-            return ResourceManager.Planets.PlanetOrRandom(data?.WhichPlanet ?? -1, preferred);
-        }
-
         public void GenerateNewHomeWorld(RandomBase random, Empire owner, SolarSystemData.Ring data = null)
         {
-            PlanetType type = GetPlanetType(owner, data);
+            PlanetType type = ResourceManager.Planets.RandomPlanet(owner.data.PreferredEnvPlanet);
             float scale = 1f * owner.data.Traits.HomeworldSizeMultiplier; // base max pop is affected by scale
 
             InitPlanetType(type, scale, fromSave: false);
-
             SetOwner(owner);
             IsHomeworld = true;
             Owner.SetCapital(this);
             SetTileHabitability(random, 0, out _); // Create the homeworld's tiles without making them habitable yet
             SetHomeworldTiles(random);
-
             ResetGarrisonSize();
-
             if (OwnerIsPlayer)
                 CType = ColonyType.Colony;
 
             CreateHomeWorldFertilityAndRichness();
-
             int numHabitableTiles = TilesList.Count(t => t.Habitable);
             float preDefinedPop = data?.MaxPopDefined ?? 0f;
             CreateHomeWorldPopulation(preDefinedPop, numHabitableTiles);

--- a/Ship_Game/Universe/SolarBodies/SolarSystemBody.cs
+++ b/Ship_Game/Universe/SolarBodies/SolarSystemBody.cs
@@ -548,7 +548,7 @@ namespace Ship_Game
                 newOwner.data.Traits.ShipMaintMultiplier  = GetTraitMin(newOwner.data.Traits.ShipMaintMultiplier, ownerTraits.ShipMaintMultiplier);
                 newOwner.data.Traits.DiplomacyMod         = GetTraitMax(newOwner.data.Traits.DiplomacyMod, ownerTraits.DiplomacyMod);
                 newOwner.data.Traits.DodgeMod             = GetTraitMax(newOwner.data.Traits.DodgeMod, ownerTraits.DodgeMod);
-                newOwner.data.Traits.EnergyDamageMod      = GetTraitMax(newOwner.data.Traits.EnergyDamageMod, ownerTraits.EnergyDamageMod);
+                newOwner.data.Traits.TargetingModifier    = GetTraitMax(newOwner.data.Traits.TargetingModifier, ownerTraits.TargetingModifier);
                 newOwner.data.Traits.GroundCombatModifier = GetTraitMax(newOwner.data.Traits.GroundCombatModifier, ownerTraits.GroundCombatModifier);
                 newOwner.data.Traits.Mercantile           = GetTraitMax(newOwner.data.Traits.Mercantile, ownerTraits.Mercantile);
                 newOwner.data.Traits.PassengerModifier    = GetTraitMax(newOwner.data.Traits.PassengerModifier, ownerTraits.PassengerModifier);

--- a/Ship_Game/Universe/SolarBodies/SolarSystemBody.cs
+++ b/Ship_Game/Universe/SolarBodies/SolarSystemBody.cs
@@ -31,7 +31,6 @@ namespace Ship_Game
 
     public enum PlanetCategory
     {
-        Other,
         Barren,
         Desert,
         Steppe,

--- a/Ship_Game/Universe/UniverseParams.cs
+++ b/Ship_Game/Universe/UniverseParams.cs
@@ -25,6 +25,7 @@ public class UniverseParams
     
     [StarData] public int NumSystems;
     [StarData] public int NumOpponents;
+    [StarData] public int RacialTraitPoints;
     [StarData] public GameMode Mode = GameMode.Sandbox;
     [StarData(DefaultValue=1f)] public float Pace = 1f;
     [StarData(DefaultValue=1f)] public float StarsModifier = 1f;
@@ -84,6 +85,7 @@ public class UniverseParams
         var s = GlobalStats.Defaults;
 
         NumOpponents = s.DefaultNumOpponents.UpperBound(ResourceManager.MajorRaces.Count - 1);
+        RacialTraitPoints = s.TraitPoints;
         MinAcceptableShipWarpRange = s.MinAcceptableShipWarpRange;
         TurnTimer = s.TurnTimer;
         CustomMineralDecay = s.CustomMineralDecay;

--- a/Ship_Game/Universe/UniverseState_Empires.cs
+++ b/Ship_Game/Universe/UniverseState_Empires.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Xna.Framework.Graphics;
 using SDGraphics;
 using SDUtils;
@@ -283,13 +284,8 @@ public partial class UniverseState
         else if (data.MinorRace) Log.Info($"Creating MinorRace {data.Traits.Name}");
         else                     Log.Info($"Creating MajorEmpire {data.Traits.Name}");
 
-        DTrait[] dipTraits = dt.DiplomaticTraitsList.Filter(
-            dip => !data.ExcludedDTraits.Any(trait => trait == dip.Name));
-        data.DiplomaticPersonality = empire.Random.Item(dipTraits);
-
-        ETrait[] ecoTraits = dt.EconomicTraitsList.Filter(
-            eco => !data.ExcludedETraits.Any(trait => trait == eco.Name));
-        data.EconomicPersonality = empire.Random.Item(ecoTraits);
+        data.DiplomaticPersonality = CreateDiplomaticTrait();
+        data.EconomicPersonality = CreateEconimicTrait();
 
         // Added by McShooterz: set values for alternate race file structure
         data.Traits.LoadTraitConstraints();
@@ -301,6 +297,46 @@ public partial class UniverseState
         empire.EmpireColor = data.Traits.Color;
         empire.Initialize();
         return empire;
+
+        DTrait CreateDiplomaticTrait()
+        {
+            if (data.PersonalityTraitsWeights.Count > 0)
+            {
+                string dTrait = empire.Random.Item(data.PersonalityTraitsWeights);
+                var selectedDt = dt.DiplomaticTraitsList.Filter(t => dTrait == t.Name);
+                if (selectedDt != null)
+                {
+                    return selectedDt.First();
+                }
+                else
+                {
+                    Log.Warning($"Selected Diplomatic Trait failed - {dTrait} was not " +
+                        "found in DiplomaticTraits.xml. Reverting to random.");
+                }
+            }
+            
+            return empire.Random.Item(dt.DiplomaticTraitsList);
+        }
+
+        ETrait CreateEconimicTrait()
+        {
+            if (data.EconomicTraitsWeights.Count > 0)
+            {
+                string eTrait = empire.Random.Item(data.EconomicTraitsWeights);
+                var selectedEt = dt.EconomicTraitsList.Filter(t => eTrait == t.Name);
+                if (selectedEt != null)
+                {
+                    return selectedEt.First();
+                }
+                else
+                {
+                    Log.Warning($"Selected Economic Trait failed - {eTrait} was not " +
+                        "found in DiplomaticTraits.xml. Reverting to random.");
+                }
+            }
+
+            return empire.Random.Item(dt.EconomicTraitsList);
+        }
     }
 
     public Empire CreateRebelsFromEmpireData(IEmpireData readOnlyData, Empire parent)

--- a/StarDrive.csproj
+++ b/StarDrive.csproj
@@ -190,6 +190,7 @@
     <Compile Include="Ship_Game\Data\Binary\Writer.cs" />
     <Compile Include="Ship_Game\Data\Binary\FieldInfo.cs" />
     <Compile Include="Ship_Game\Data\Binary\TypeInfo.cs" />
+    <Compile Include="Ship_Game\Data\RacialTraitOption.cs" />
     <Compile Include="Ship_Game\Data\Serialization\CollectionSerializer.cs" />
     <Compile Include="Ship_Game\Data\Binary\EventContextOnDeserialized.cs" />
     <Compile Include="Ship_Game\Data\Serialization\SerializerCategory.cs" />

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -10434,6 +10434,12 @@ InRandomGameMode:
  ENG: "Random game mode is very similar to Sandbox Game Mode but starting positions are randomized. Some empires might start very close to eachother and some may have a lot of space to expand."
  RUS: "Случайный режим игры очень похож на режим песочницы, но стартовые позиции случайны. Некоторые империи могут начинаться очень близко друг к другу, а у некоторых может быть много места для расширения."
  SPA: "El modo de juego aleatorio es muy similar al modo de juego Sandbox, pero las posiciones iniciales son aleatorias. Algunos imperios pueden comenzar muy cerca uno del otro y otros pueden tener mucho espacio para expandirse."  
+TraitAquaticName:
+  Id: 4986
+  ENG: "Aquatic"   
+TraitAquaticDesc:
+  Id: 4987
+  ENG: "This Race prefers to reproduce and live in water. It can swim well and breath underwater."     
 ShipMaintenanceMultiplier:
  Id: 4988
  ENG: "Ship Maintenance Multiplier"

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -10439,7 +10439,7 @@ TraitSalvagersName:
   ENG: "Salvagers"   
 TraitSalvagersDesc:
   Id: 4967
-  ENG: "Your empire will get 1 credit per 20 slots of enemiy ships killed."       
+  ENG: "salvagers like to collect scrap matel and upgrades. Your empire will get 1 credit per 20 slots of enemy ships killed."       
 TraitCompensationName:
   Id: 4968
   ENG: "Crew Compensation Plan"   

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -10434,6 +10434,18 @@ InRandomGameMode:
  ENG: "Random game mode is very similar to Sandbox Game Mode but starting positions are randomized. Some empires might start very close to eachother and some may have a lot of space to expand."
  RUS: "Случайный режим игры очень похож на режим песочницы, но стартовые позиции случайны. Некоторые империи могут начинаться очень близко друг к другу, а у некоторых может быть много места для расширения."
  SPA: "El modo de juego aleatorio es muy similar al modo de juego Sandbox, pero las posiciones iniciales son aleatorias. Algunos imperios pueden comenzar muy cerca uno del otro y otros pueden tener mucho espacio para expandirse."  
+TraitSalvagersName:
+  Id: 4966
+  ENG: "Salvagers"   
+TraitSalvagersDesc:
+  Id: 4967
+  ENG: "Your empire will get 1 credit per 20 slots of enemiy ships killed."       
+TraitCompensationName:
+  Id: 4968
+  ENG: "Crew Compensation Plan"   
+TraitCompensationDesc:
+  Id: 4969
+  ENG: "Your empire will compansate the families of battle casualties at a rate of 1 credit per 20 slots of ships killed by enemies."         
 TraitTerranHomeworldName:
   Id: 4970
   ENG: "Terran Homeworld"   

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -10434,6 +10434,12 @@ InRandomGameMode:
  ENG: "Random game mode is very similar to Sandbox Game Mode but starting positions are randomized. Some empires might start very close to eachother and some may have a lot of space to expand."
  RUS: "Случайный режим игры очень похож на режим песочницы, но стартовые позиции случайны. Некоторые империи могут начинаться очень близко друг к другу, а у некоторых может быть много места для расширения."
  SPA: "El modo de juego aleatorio es muy similar al modo de juego Sandbox, pero las posiciones iniciales son aleatorias. Algunos imperios pueden comenzar muy cerca uno del otro y otros pueden tener mucho espacio para expandirse."  
+TraitExplorers_Name: 
+ Id: 4984
+ ENG: "Explorers"
+TraitExplorers_Desc:
+ Id: 4985
+ ENG: "Explorer races are very curious and like exploring their surroundings. As a result, the minimum exploration distance required to explore new solar systems and planets is doubled."
 TraitAquaticName:
   Id: 4986
   ENG: "Aquatic"   

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -10434,6 +10434,48 @@ InRandomGameMode:
  ENG: "Random game mode is very similar to Sandbox Game Mode but starting positions are randomized. Some empires might start very close to eachother and some may have a lot of space to expand."
  RUS: "Случайный режим игры очень похож на режим песочницы, но стартовые позиции случайны. Некоторые империи могут начинаться очень близко друг к другу, а у некоторых может быть много места для расширения."
  SPA: "El modo de juego aleatorio es muy similar al modo de juego Sandbox, pero las posiciones iniciales son aleatorias. Algunos imperios pueden comenzar muy cerca uno del otro y otros pueden tener mucho espacio para expandirse."  
+TraitTerranHomeworldName:
+  Id: 4970
+  ENG: "Terran Homeworld"   
+TraitTerranHomeworldDesc:
+  Id: 4971
+  ENG: "Your empire starts in a Terran homeworld and gets +25% Fertility and Max Population for other Terran worlds."      
+TraitOceanicHomeworldName:
+  Id: 4972
+  ENG: "Oceanic Homeworld"   
+TraitOceanicHomeworldDesc:
+  Id: 4973
+  ENG: "Your empire starts in an Oceanic homeworld and gets +25% Fertility and Max Population for other Oceanic worlds."      
+TraitSteppeHomeworldName:
+  Id: 4974
+  ENG: "Steppe Homeworld"   
+TraitSteppeHomeworldDesc:
+  Id: 4975
+  ENG: "Your empire starts in a Steppe homeworld and gets +25% Fertility and Max Population for other Steppe worlds."      
+TraitTundraHomeworldName:
+  Id: 4976
+  ENG: "Tundra Homeworld"   
+TraitTundraHomeworldDesc:
+  Id: 4977
+  ENG: "Your empire starts in a Tuntra homeworld and gets +25% Fertility and Max Population for other Tundra worlds."      
+TraitSwampHomeworldName:
+  Id: 4978
+  ENG: "Swamp Homeworld"   
+TraitSwampHomeworldDesc:
+  Id: 4979
+  ENG: "Your empire starts in a Swamp homeworld and gets +25% Fertility and Max Population for other Swamp worlds."      
+TraitDesertHomeworldName:
+  Id: 4980
+  ENG: "Desert Homeworld"   
+TraitDesertHomeworldDesc:
+  Id: 4981
+  ENG: "Your empire starts in a Desert homeworld and gets +25% Fertility and Max Population for other Desert worlds."      
+TraitIceHomeworldName:
+  Id: 4982
+  ENG: "Ice Homeworld"   
+TraitIceHomeworldDesc:
+  Id: 4983
+  ENG: "Your empire starts in an Ice homeworld and gets +25% Fertility and Max Population for other Ice worlds."      
 TraitExplorers_Name: 
  Id: 4984
  ENG: "Explorers"
@@ -10445,7 +10487,7 @@ TraitAquaticName:
   ENG: "Aquatic"   
 TraitAquaticDesc:
   Id: 4987
-  ENG: "This Race prefers to reproduce and live in water. It can swim well and breath underwater."     
+  ENG: "This Race prefers to reproduce and live in water. It can swim well and breath underwater. It starts with Oceanic Homeworld and has different preferences for other planet types."     
 ShipMaintenanceMultiplier:
  Id: 4988
  ENG: "Ship Maintenance Multiplier"

--- a/game/Content/Globals.yaml
+++ b/game/Content/Globals.yaml
@@ -36,7 +36,6 @@ Globals:
   # feature flags
   DisableShipPicker: true
   ChangeResearchCostBasedOnSize: true
-  DisplayEnvPreferenceInRaceDesign: false
   EnableShipTechLineFocusing: true
   UseHullBonuses: false
   UseDestroyers: false

--- a/game/Content/Globals.yaml
+++ b/game/Content/Globals.yaml
@@ -5,6 +5,7 @@ Globals:
   MaxOpponents: 7
   DefaultNumOpponents: 5
   TurnTimer: 5 # default time in seconds for a single turn
+  
 
   # gameplay modifiers
   ShipDestroyThreshold: 0.5 # ships with internal slots below this ratio will Die

--- a/game/Content/Races/Cordrazine.xml
+++ b/game/Content/Races/Cordrazine.xml
@@ -28,18 +28,6 @@
   <ThrustColor1R>34</ThrustColor1R>
   <ThrustColor1G>139</ThrustColor1G>
   <ThrustColor1B>34</ThrustColor1B>      
-  
-  <!-- Fertility multipliers for environments. The default is 1 in the code, but the tags are included here for reference -->
-  <EnvTerran>1</EnvTerran>
-  <EnvOceanic>1</EnvOceanic>
-  <EnvSteppe>1</EnvSteppe>
-  <EnvTundra>1</EnvTundra>
-  <EnvSwamp>1</EnvSwamp>
-  <EnvDesert>1</EnvDesert>
-  <EnvIce>1</EnvIce>
-  <EnvBarren>1</EnvBarren>
-  <EnvVolcanic>1</EnvVolcanic>
-  <PreferredEnv>Terran</PreferredEnv> <!-- Terraformers will terraform a planet to this environment -->
 
   <Traits>
     <Name>Cordrazine Collective</Name>

--- a/game/Content/Races/Cordrazine.xml
+++ b/game/Content/Races/Cordrazine.xml
@@ -57,36 +57,17 @@
     <B>0</B>
     <RaceDescription>KWAK!</RaceDescription>
     <Cost>0</Cost>
-    <ConsumptionModifier>-.2</ConsumptionModifier>
-    <PopGrowthMax>.02</PopGrowthMax>
-    <DiplomacyMod>.2</DiplomacyMod>
-    <GenericMaxPopMod>0</GenericMaxPopMod>
-    <Aquatic>0</Aquatic>
-    <Burrowers>0</Burrowers>
-    <Blind>0</Blind>
-    <BonusExplored>0</BonusExplored>
-    <Pioneers>0</Pioneers>
-    <Militaristic>0</Militaristic>
-    <HomeworldSizeMod>.25</HomeworldSizeMod>
-    <Prewarp>0</Prewarp>
-    <Spiritual>0</Spiritual>
-    <HomeworldFertMod>0</HomeworldFertMod>
-    <DodgeMod>-.25</DodgeMod>
-    <EnergyDamageMod>0</EnergyDamageMod>
-    <ResearchMod>0</ResearchMod>
-    <Mercantile>0</Mercantile>
-    <Miners>0</Miners>
-    <ProductionMod>0</ProductionMod>
-    <MaintMod>-.25</MaintMod>
-    <TaxMod>0</TaxMod>
-    <ShipCostMod>0</ShipCostMod>
-    <ModHpModifier>.2</ModHpModifier>
-    <SmallSize>0</SmallSize>
-    <HugeSize>0</HugeSize>
-    <GroundCombatModifier>-.20</GroundCombatModifier>
-    <RepairRateMod>0</RepairRateMod>
-    <Cybernetic>0</Cybernetic>
-    <Prototype>1</Prototype>
+	<TraitOptions>
+		<string>Huge Homeworld</string>
+		<string>Alluring</string>
+		<string>Less Fertile</string>
+		<string>Efficient Metabolism</string>
+		<string>Timid</string>
+		<string>Prototype Flagship</string>
+		<string>Skilled Engineers</string>		
+		<string>Ponderous</string>
+		<string>Efficient</string>
+	</TraitOptions>	
   </Traits>
   <Faction>0</Faction>
 </EmpireData>

--- a/game/Content/Races/Corsairs.xml
+++ b/game/Content/Races/Corsairs.xml
@@ -50,34 +50,6 @@
     <B>29</B>
     <RaceDescription>Mighty Pirates</RaceDescription>
     <Cost>0</Cost>
-    <ConsumptionModifier>0</ConsumptionModifier>
-    <ReproductionMod>0</ReproductionMod>
-    <DiplomacyMod>0</DiplomacyMod>
-    <GenericMaxPopMod>0</GenericMaxPopMod>
-    <Aquatic>0</Aquatic>
-    <Burrowers>0</Burrowers>
-    <Blind>0</Blind>
-    <BonusExplored>0</BonusExplored>
-    <Pioneers>0</Pioneers>
-    <Militaristic>0</Militaristic>
-    <HomeworldSizeMod>0</HomeworldSizeMod>
-    <Prewarp>0</Prewarp>
-    <Spiritual>0</Spiritual>
-    <HomeworldFertMod>0</HomeworldFertMod>
-    <DodgeMod>0</DodgeMod>
-    <EnergyDamageMod>0</EnergyDamageMod>
-    <ResearchMod>0</ResearchMod>
-    <Mercantile>0</Mercantile>
-    <Miners>0</Miners>
-    <ProductionMod>0</ProductionMod>
-    <MaintMod>0</MaintMod>
-    <TaxMod>0</TaxMod>
-    <ShipCostMod>0</ShipCostMod>
-    <ModHpModifier>0</ModHpModifier>
-    <SmallSize>0</SmallSize>
-    <HugeSize>0</HugeSize>
-    <GroundCombatModifier>0</GroundCombatModifier>
-    <RepairRateMod>0</RepairRateMod>
-    <Cybernetic>0</Cybernetic>
+	<TraitOptions></TraitOptions>
   </Traits>
 </EmpireData>

--- a/game/Content/Races/Draugar.xml
+++ b/game/Content/Races/Draugar.xml
@@ -50,34 +50,6 @@
     <B>253</B>
     <RaceDescription>Deadly Pirates</RaceDescription>
     <Cost>0</Cost>
-    <ConsumptionModifier>0</ConsumptionModifier>
-    <ReproductionMod>0</ReproductionMod>
-    <DiplomacyMod>0</DiplomacyMod>
-    <GenericMaxPopMod>0</GenericMaxPopMod>
-    <Aquatic>0</Aquatic>
-    <Burrowers>0</Burrowers>
-    <Blind>0</Blind>
-    <BonusExplored>0</BonusExplored>
-    <Pioneers>0</Pioneers>
-    <Militaristic>0</Militaristic>
-    <HomeworldSizeMod>0</HomeworldSizeMod>
-    <Prewarp>0</Prewarp>
-    <Spiritual>0</Spiritual>
-    <HomeworldFertMod>0</HomeworldFertMod>
-    <DodgeMod>0</DodgeMod>
-    <EnergyDamageMod>0</EnergyDamageMod>
-    <ResearchMod>0</ResearchMod>
-    <Mercantile>0</Mercantile>
-    <Miners>0</Miners>
-    <ProductionMod>0</ProductionMod>
-    <MaintMod>0</MaintMod>
-    <TaxMod>0</TaxMod>
-    <ShipCostMod>0</ShipCostMod>
-    <ModHpModifier>0</ModHpModifier>
-    <SmallSize>0</SmallSize>
-    <HugeSize>0</HugeSize>
-    <GroundCombatModifier>0</GroundCombatModifier>
-    <RepairRateMod>0</RepairRateMod>
-    <Cybernetic>0</Cybernetic>
+	<TraitOptions></TraitOptions>
   </Traits>
 </EmpireData>

--- a/game/Content/Races/Draylok.xml
+++ b/game/Content/Races/Draylok.xml
@@ -31,17 +31,6 @@
   <ThrustColor1G>245</ThrustColor1G>
   <ThrustColor1B>245</ThrustColor1B>     
 
-  <!-- Fertility multipliers for environments. The default is 1 in the code, but the tags are included here for reference -->
-  <EnvTerran>1</EnvTerran>
-  <EnvOceanic>1</EnvOceanic>
-  <EnvSteppe>1</EnvSteppe>
-  <EnvTundra>1</EnvTundra>
-  <EnvSwamp>1</EnvSwamp>
-  <EnvDesert>1</EnvDesert>
-  <EnvIce>1</EnvIce>
-  <EnvBarren>1</EnvBarren>
-  <EnvVolcanic>1</EnvVolcanic>
-  <PreferredEnv>Terran</PreferredEnv> <!-- Terraformers will terraform a planet to this environment -->
 
   <Traits>
     <Name>The Draylok Council</Name>

--- a/game/Content/Races/Draylok.xml
+++ b/game/Content/Races/Draylok.xml
@@ -59,37 +59,13 @@
     <B>143</B>
     <RaceDescription>Deprecated </RaceDescription>
     <Cost>0</Cost>
-    <ConsumptionModifier>0</ConsumptionModifier>
-    <ReproductionMod>0</ReproductionMod>
-    <DiplomacyMod>.2</DiplomacyMod>
-    <GenericMaxPopMod>0</GenericMaxPopMod>
-    <Aquatic>0</Aquatic>
-    <Burrowers>0</Burrowers>
-    <Blind>0</Blind>
-    <BonusExplored>0</BonusExplored>
-    <Pioneers>0</Pioneers>
-    <Militaristic>0</Militaristic>
-    <Prewarp>0</Prewarp>
-    <Spiritual>0</Spiritual>
-    <HomeworldFertMod>0</HomeworldFertMod>
-    <DodgeMod>0</DodgeMod>
-    <EnergyDamageMod>0</EnergyDamageMod>
-    <ResearchMod>.35</ResearchMod>
-    <Mercantile>0.5</Mercantile>
-    <Miners>0</Miners>
-    <ProductionMod>0</ProductionMod>
-    <MaintMod>0.25</MaintMod>
-    <TaxMod>0</TaxMod>
-    <ShipCostMod>0.25</ShipCostMod>
-    <ModHpModifier>0</ModHpModifier>
-    <SmallSize>0</SmallSize>
-    <HugeSize>0</HugeSize>
-    <HomeworldSizeMod>0.25</HomeworldSizeMod>
-    <GroundCombatModifier>0</GroundCombatModifier>
-    <RepairRateMod>0</RepairRateMod>
-    <Cybernetic>0</Cybernetic>
-    <SpyMultiplier>10</SpyMultiplier>
-    <PassengerBonus>0</PassengerBonus>
+	<TraitOptions>
+		<string>Smart</string>
+		<string>Corrupt</string>
+		<string>Mercantile</string>
+		<string>Alluring</string>
+		<string>Duplicitous</string>
+	</TraitOptions>	
   </Traits>
   <Faction>0</Faction>
 </EmpireData>

--- a/game/Content/Races/Human.xml
+++ b/game/Content/Races/Human.xml
@@ -20,9 +20,23 @@
   <ThrustColor1G>196</ThrustColor1G>
   <ThrustColor1B>222</ThrustColor1B>
   
-  <ExcludedDTraits>
+  <PersonalityTraitsWeights>
+	<string>Aggressive</string>
+	<string>Aggressive</string>
+	<string>Aggressive</string>
+    <string>Ruthless</string>
+	<string>Ruthless</string>
+	<string>Ruthless</string>
+	<string>Xenophobic</string>
+	<string>Xenophobic</string>
+    <string>Cunning</string>
+	<string>Cunning</string>
+	<string>Cunning</string>
+    <string>Honorable</string>	
+	<string>Honorable</string>	
+	<string>Honorable</string>	
     <string>Pacifist</string>
-  </ExcludedDTraits>
+  </PersonalityTraitsWeights>  
   
   <!-- Rebel Faction data.-->
   <RebelName>Confederate Rebels</RebelName>

--- a/game/Content/Races/Human.xml
+++ b/game/Content/Races/Human.xml
@@ -58,43 +58,15 @@
     <G>140</G>
     <B>203</B>
     <RaceDescription>The United Federation is an expasionist republic with a strong emphasis on scientific and military power.  Humans are somewhat xenophobic, and they can be slow to trust other empires while also being quick to make war.    </RaceDescription>
-    <PhysicalTraitAlluring>false</PhysicalTraitAlluring>                                 <!--( 3)-->    
-    <PhysicalTraitRepulsive>false</PhysicalTraitRepulsive>                                 <!--(-3)-->
-    <PhysicalTraitEagleEyed>false</PhysicalTraitEagleEyed>                                 <!--( 2)-->
-    <PhysicalTraitBlind>false</PhysicalTraitBlind>                                         <!--(-2)-->
-    <PhysicalTraitEfficientMetabolism>false</PhysicalTraitEfficientMetabolism>             <!--( 3)-->
-    <PhysicalTraitGluttonous>false</PhysicalTraitGluttonous>                             <!--(-3)-->
-    <PhysicalTraitFertile>false</PhysicalTraitFertile>                                     <!--( 3)-->
-    <PhysicalTraitLessFertile>false</PhysicalTraitLessFertile>                             <!--(-3)-->
-    <PhysicalTraitSmart>false</PhysicalTraitSmart>                                         <!--( 3)-->
-    <PhysicalTraitDumb>false</PhysicalTraitDumb>                                         <!--(-3)-->
-    <PhysicalTraitReflexes>false</PhysicalTraitReflexes>                                 <!--( 3)-->
-    <PhysicalTraitPonderous>false</PhysicalTraitPonderous>                                 <!--(-3)-->
-    <PhysicalTraitSavage>false</PhysicalTraitSavage>                                     <!--( 2)-->
-    <PhysicalTraitTimid>false</PhysicalTraitTimid>                                         <!--(-2)-->
-    <SociologicalTraitEfficient>false</SociologicalTraitEfficient>                         <!--( 4)-->
-    <SociologicalTraitWasteful>false</SociologicalTraitWasteful>                         <!--(-4)-->
-    <SociologicalTraitIndustrious>true</SociologicalTraitIndustrious>                     <!--( 3)-->
-    <SociologicalTraitLazy>false</SociologicalTraitLazy>                                 <!--(-3)-->
-    <SociologicalTraitMercantile>false</SociologicalTraitMercantile>                     <!--( 3)-->
-    <SociologicalTraitMeticulous>false</SociologicalTraitMeticulous>                     <!--( 1)-->
-    <SociologicalTraitCorrupt>true</SociologicalTraitCorrupt>                             <!--(-1)-->
-    <SociologicalTraitSkilledEngineers>false</SociologicalTraitSkilledEngineers>         <!--( 2)-->
-    <SociologicalTraitHaphazardEngineers>false</SociologicalTraitHaphazardEngineers>     <!--(-2)-->
-    <HistoryTraitAstronomers>true</HistoryTraitAstronomers>                             <!--( 2)-->
-    <HistoryTraitCybernetic>false</HistoryTraitCybernetic>                                 <!--( 7)-->
-    <HistoryTraitManifestDestiny>false</HistoryTraitManifestDestiny>                     <!--( 3)-->
-    <HistoryTraitMilitaristic>true</HistoryTraitMilitaristic>                             <!--( 4)-->
-    <HistoryTraitNavalTraditions>false</HistoryTraitNavalTraditions>                     <!--( 4)-->
-    <HistoryTraitPackMentality>false</HistoryTraitPackMentality>                         <!--( 2)-->
-    <HistoryTraitPrototypeFlagship>true</HistoryTraitPrototypeFlagship>                 <!--( 1)-->
-    <HistoryTraitSpiritual>false</HistoryTraitSpiritual>                                 <!--( 2)-->
-    <HistoryTraitPollutedHomeWorld>true</HistoryTraitPollutedHomeWorld>                 <!--(-2)-->
-    <HistoryTraitIndustrializedHomeWorld>false</HistoryTraitIndustrializedHomeWorld>     <!--( 1)-->
-    <HistoryTraitDuplicitous>false</HistoryTraitDuplicitous>                             <!--( 2)-->
-    <HistoryTraitHonest>false</HistoryTraitHonest>                                         <!--(-2)-->
-    <HistoryTraitHugeHomeWorld>true</HistoryTraitHugeHomeWorld>                         <!--( 3)-->
-    <HistoryTraitSmallHomeWorld>false</HistoryTraitSmallHomeWorld>                        <!--(-3)-->
+	<TraitOptions>
+		<string>Prototype Flagship</string>
+		<string>Militaristic</string>
+		<string>Astronomers</string>
+		<string>Huge Homeworld</string>
+		<string>Polluted Homeworld</string>
+		<string>Corrupt</string>
+		<string>Industrious</string>
+	</TraitOptions>		
   </Traits>
   <Faction>0</Faction>
 </EmpireData>

--- a/game/Content/Races/Human.xml
+++ b/game/Content/Races/Human.xml
@@ -31,18 +31,6 @@
   <TroopNameIndex>2083</TroopNameIndex>
   <TroopDescriptionIndex>2092</TroopDescriptionIndex>
 
-  <!-- Fertility multipliers for environments. The default is 1 in the code, but the tags are included here for reference -->
-  <EnvTerran>1</EnvTerran>
-  <EnvOceanic>1</EnvOceanic>
-  <EnvSteppe>1</EnvSteppe>
-  <EnvTundra>1</EnvTundra>
-  <EnvSwamp>1</EnvSwamp>
-  <EnvDesert>1</EnvDesert>
-  <EnvIce>1</EnvIce>
-  <EnvBarren>1</EnvBarren>
-  <EnvVolcanic>1</EnvVolcanic>
-  <PreferredEnv>Terran</PreferredEnv> <!-- Terraformers will terraform a planet to this environment -->
-  
   <Traits>
     <Name>The United Federation</Name>
     <Singular>Human</Singular>

--- a/game/Content/Races/Kulrathi.xml
+++ b/game/Content/Races/Kulrathi.xml
@@ -32,11 +32,20 @@
   <ThrustColor1G>0</ThrustColor1G>
   <ThrustColor1B>128</ThrustColor1B>      
   
-  
-  <ExcludedDTraits>
-    <string>Pacifist</string>
+  <PersonalityTraitsWeights>
+	<string>Aggressive</string>
+	<string>Aggressive</string>
     <string>Ruthless</string>
-  </ExcludedDTraits>
+	<string>Xenophobic</string>
+	<string>Xenophobic</string>
+    <string>Cunning</string>
+	<string>Cunning</string>
+    <string>Honorable</string>	
+	<string>Honorable</string>	
+	<string>Honorable</string>	
+    <string>Pacifist</string>
+  </PersonalityTraitsWeights>    
+  
   <Traits>
     <Name>The Kulrathi Shogunate</Name>
     <Singular>Kulrathi</Singular>

--- a/game/Content/Races/Kulrathi.xml
+++ b/game/Content/Races/Kulrathi.xml
@@ -32,17 +32,6 @@
   <ThrustColor1G>0</ThrustColor1G>
   <ThrustColor1B>128</ThrustColor1B>      
   
-  <!-- Fertility multipliers for environments. The default is 1 in the code, but the tags are included here for reference -->
-  <EnvTerran>1</EnvTerran>
-  <EnvOceanic>1</EnvOceanic>
-  <EnvSteppe>1</EnvSteppe>
-  <EnvTundra>1</EnvTundra>
-  <EnvSwamp>1</EnvSwamp>
-  <EnvDesert>1</EnvDesert>
-  <EnvIce>1</EnvIce>
-  <EnvBarren>1</EnvBarren>
-  <EnvVolcanic>1</EnvVolcanic>
-  <PreferredEnv>Terran</PreferredEnv> <!-- Terraformers will terraform a planet to this environment -->
   
   <ExcludedDTraits>
     <string>Pacifist</string>

--- a/game/Content/Races/Kulrathi.xml
+++ b/game/Content/Races/Kulrathi.xml
@@ -64,37 +64,16 @@
     <B>96</B>
     <RaceDescription>The Kulrathi are a noble and proud race who value beauty, honor, and battle. They are fiercely territorial race and they prefer personal, hand-to-hand engagements over modern weaponry. The Kulrathi make great allies and terrible enemies. </RaceDescription>
     <Cost>0</Cost>
-    <ConsumptionModifier>0</ConsumptionModifier>
-    <ReproductionMod>0</ReproductionMod>
-    <DiplomacyMod>0</DiplomacyMod>
-    <GenericMaxPopMod>0</GenericMaxPopMod>
-    <Aquatic>0</Aquatic>
-    <Burrowers>0</Burrowers>
-    <Blind>0</Blind>
-    <BonusExplored>0</BonusExplored>
-    <Pioneers>0</Pioneers>
-    <Militaristic>1</Militaristic>
-    <Prewarp>0</Prewarp>
-    <Spiritual>0</Spiritual>
-    <HomeworldFertMod>0</HomeworldFertMod>
-    <DodgeMod>0</DodgeMod>
-    <EnergyDamageMod>0</EnergyDamageMod>
-    <ResearchMod>0</ResearchMod>
-    <Mercantile>0</Mercantile>
-    <Miners>0</Miners>
-    <ProductionMod>0</ProductionMod>
-    <MaintMod>0</MaintMod>
-    <TaxMod>.25</TaxMod>
+	<TraitOptions>
+		<string>Prototype Flagship</string>
+		<string>Honest</string>
+		<string>Meticulous</string>
+		<string>Militaristic</string>
+		<string>Skilled Engineers</string>
+		<string>Savage</string>
+		<string>Naval Tradition</string>
+	</TraitOptions>	
     <ShipCostMod>-0.35</ShipCostMod>
-    <ModHpModifier>.20</ModHpModifier>
-    <SmallSize>0</SmallSize>
-    <HugeSize>0</HugeSize>
-    <GroundCombatModifier>.30</GroundCombatModifier>
-    <RepairRateMod>0</RepairRateMod>
-    <HomeworldSizeMod>0</HomeworldSizeMod>
-    <Cybernetic>0</Cybernetic>
-    <SpyMultiplier>-10</SpyMultiplier>
-    <Prototype>1</Prototype>
   </Traits>
   <Faction>0</Faction>
 </EmpireData>

--- a/game/Content/Races/Opteris.xml
+++ b/game/Content/Races/Opteris.xml
@@ -65,39 +65,21 @@
     <B>51</B>
     <RaceDescription>bzzz!</RaceDescription>
     <Cost>0</Cost>
-    <ConsumptionModifier>-.25</ConsumptionModifier>
-    <PopGrowthMin>.01</PopGrowthMin>
-    <ReproductionMod>0.01</ReproductionMod>
-    <DiplomacyMod>0</DiplomacyMod>
-    <GenericMaxPopMod>0</GenericMaxPopMod>
-    <Aquatic>0</Aquatic>
-    <Burrowers>0</Burrowers>
-    <Blind>0</Blind>
-    <BonusExplored>0</BonusExplored>
-    <Pioneers>0</Pioneers>
-    <Militaristic>1</Militaristic>
-    <HomeworldSizeMod>-.25</HomeworldSizeMod>
-    <Prewarp>0</Prewarp>
-    <Spiritual>0</Spiritual>
-    <HomeworldFertMod>-.5</HomeworldFertMod>
-    <DodgeMod>0</DodgeMod>
-    <EnergyDamageMod>-.2</EnergyDamageMod>
-    <ResearchMod>0</ResearchMod>
-    <Mercantile>0</Mercantile>
-    <Miners>0</Miners>
-    <ProductionMod>.35</ProductionMod>
-    <MaintMod>0</MaintMod>
-    <TaxMod>-0.2</TaxMod>
-    <ShipCostMod>0</ShipCostMod>
-    <ModHpModifier>0</ModHpModifier>
-    <SmallSize>0</SmallSize>
-    <HugeSize>0</HugeSize>
-    <HomeworldRichMod>1.0</HomeworldRichMod>
-    <GroundCombatModifier>-.20</GroundCombatModifier>
-    <RepairRateMod>0</RepairRateMod>
-    <Cybernetic>1</Cybernetic>
-    <Prototype>1</Prototype>
-    <SpyMultiplier>-10</SpyMultiplier>
+	<TraitOptions>
+		<string>Efficient Metabolism</string>
+		<string>Fertile</string>
+		<string>Timid</string>
+		<string>Militaristic</string>
+		<string>Small homeworld</string>
+		<string>Polluted Homeworld</string>
+		<string>Blind</string>
+		<string>Industrious</string>
+		<string>Corrupt</string>
+		<string>Industrialized Homeworld</string>
+		<string>Cybernetic</string>
+		<string>Prototype Flagship</string>
+		<string>Honest</string>
+	</TraitOptions>	
   </Traits>
   <Faction>0</Faction>
 </EmpireData>

--- a/game/Content/Races/Opteris.xml
+++ b/game/Content/Races/Opteris.xml
@@ -29,14 +29,38 @@
   <ThrustColor1G>0</ThrustColor1G>
   <ThrustColor1B>255</ThrustColor1B>    
 
-  <ExcludedDTraits>
+  <PersonalityTraitsWeights>
+	<string>Aggressive</string>
+	<string>Aggressive</string>
+	<string>Aggressive</string>
+	<string>Ruthless</string>
+	<string>Ruthless</string>
+	<string>Ruthless</string>
+	<string>Xenophobic</string>
+	<string>Xenophobic</string>
+    <string>Cunning</string>
+	<string>Cunning</string>
+	<string>Cunning</string>
+    <string>Honorable</string>	
     <string>Pacifist</string>
-    <string>Honorable</string>
-    <string>Xenophobic</string>
-  </ExcludedDTraits>
-  <ExcludedETraits>
-    <string>Generalists</string>
-  </ExcludedETraits>
+  </PersonalityTraitsWeights>  
+
+  <EconomicTraitsWeights>
+    <string>Technologists</string>
+	<string>Technologists</string>
+	<string>Technologists</string>
+	<string>Industrialists</string>
+	<string>Industrialists</string>
+	<string>Industrialists</string>
+	<string>Generalists</string>
+	<string>Militarists</string>
+	<string>Militarists</string>
+	<string>Militarists</string>
+	<string>Expansionists</string>
+	<string>Expansionists</string>
+	<string>Expansionists</string>
+  </EconomicTraitsWeights>
+  
   <Traits>
     <Name>Opteris</Name>
     <Singular>Opteris</Singular>

--- a/game/Content/Races/Opteris.xml
+++ b/game/Content/Races/Opteris.xml
@@ -70,7 +70,7 @@
 		<string>Fertile</string>
 		<string>Timid</string>
 		<string>Militaristic</string>
-		<string>Small homeworld</string>
+		<string>Small Homeworld</string>
 		<string>Polluted Homeworld</string>
 		<string>Blind</string>
 		<string>Industrious</string>

--- a/game/Content/Races/Opteris.xml
+++ b/game/Content/Races/Opteris.xml
@@ -29,18 +29,6 @@
   <ThrustColor1G>0</ThrustColor1G>
   <ThrustColor1B>255</ThrustColor1B>    
 
-  <!-- Fertility multipliers for environments. The default is 1 in the code, but the tags are included here for reference -->
-  <EnvTerran>1</EnvTerran>
-  <EnvOceanic>1</EnvOceanic>
-  <EnvSteppe>1</EnvSteppe>
-  <EnvTundra>1</EnvTundra>
-  <EnvSwamp>1</EnvSwamp>
-  <EnvDesert>1</EnvDesert>
-  <EnvIce>1</EnvIce>
-  <EnvBarren>1</EnvBarren>
-  <EnvVolcanic>1</EnvVolcanic>
-  <PreferredEnv>Terran</PreferredEnv> <!-- Terraformers will terraform a planet to this environment -->
-
   <ExcludedDTraits>
     <string>Pacifist</string>
     <string>Honorable</string>

--- a/game/Content/Races/Pollops.xml
+++ b/game/Content/Races/Pollops.xml
@@ -66,36 +66,15 @@
     <B>0</B>
     <RaceDescription>Pollops are a peculiar race of mobile plant-like organisms. Though physically weak, they grow at a rapid pace and have long lifespans. Pollops tend to be quite friendly.</RaceDescription>
     <Cost>0</Cost>
-    <ConsumptionModifier>-.25</ConsumptionModifier>
-    <PopGrowthMin>.005</PopGrowthMin>
-    <DiplomacyMod>0</DiplomacyMod>
-    <GenericMaxPopMod>0</GenericMaxPopMod>
-    <Aquatic>0</Aquatic>
-    <Burrowers>0</Burrowers>
-    <Blind>0</Blind>
-    <BonusExplored>0</BonusExplored>
-    <Pioneers>0</Pioneers>
-    <Militaristic>0</Militaristic>
-    <Prewarp>0</Prewarp>
-    <Spiritual>0</Spiritual>
-    <HomeworldFertMod>0</HomeworldFertMod>
-    <DodgeMod>0.25</DodgeMod>
-    <EnergyDamageMod>0</EnergyDamageMod>
-    <ResearchMod>0</ResearchMod>
-    <Mercantile>0</Mercantile>
-    <Miners>0</Miners>
-    <ProductionMod>-0.15</ProductionMod>
-    <MaintMod>-.25</MaintMod>
-    <TaxMod>0</TaxMod>
-    <ShipCostMod>0</ShipCostMod>
-    <ModHpModifier>0</ModHpModifier>
-    <SmallSize>0</SmallSize>
-    <HugeSize>0</HugeSize>
-    <GroundCombatModifier>-.20</GroundCombatModifier>
-    <RepairRateMod>0</RepairRateMod>
-    <Cybernetic>0</Cybernetic>
-    <HomeworldSizeMod>0</HomeworldSizeMod>
-    <PassengerBonus>2</PassengerBonus>
+	<TraitOptions>
+		<string>Manifest Destiny</string>
+		<string>Timid</string>
+		<string>Efficient</string>
+		<string>Fertile</string>
+		<string>Efficient Metabolism</string>
+		<string>Reflexes</string>
+		<string>Lazy</string>
+	</TraitOptions>
   </Traits>
   <Faction>0</Faction>
 </EmpireData>

--- a/game/Content/Races/Pollops.xml
+++ b/game/Content/Races/Pollops.xml
@@ -30,18 +30,6 @@
   <ThrustColor1R>255</ThrustColor1R> <!-- Yellow -->
   <ThrustColor1G>255</ThrustColor1G>
   <ThrustColor1B>0</ThrustColor1B>    
-  
-  <!-- Fertility multipliers for environments. The default is 1 in the code, but the tags are included here for reference -->
-  <EnvTerran>1</EnvTerran>
-  <EnvOceanic>1</EnvOceanic>
-  <EnvSteppe>1</EnvSteppe>
-  <EnvTundra>1</EnvTundra>
-  <EnvSwamp>1</EnvSwamp>
-  <EnvDesert>1</EnvDesert>
-  <EnvIce>1</EnvIce>
-  <EnvBarren>1</EnvBarren>
-  <EnvVolcanic>1</EnvVolcanic>
-  <PreferredEnv>Terran</PreferredEnv> <!-- Terraformers will terraform a planet to this environment -->
 
   <ExcludedDTraits>
     <string>Ruthless</string>

--- a/game/Content/Races/Pollops.xml
+++ b/game/Content/Races/Pollops.xml
@@ -31,13 +31,38 @@
   <ThrustColor1G>255</ThrustColor1G>
   <ThrustColor1B>0</ThrustColor1B>    
 
-  <ExcludedDTraits>
-    <string>Ruthless</string>
-    <string>Aggressive</string>
-  </ExcludedDTraits>
-  <ExcludedETraits>
-    <string>Militarists</string>
-  </ExcludedETraits>
+  <PersonalityTraitsWeights>
+	<string>Aggressive</string>
+	<string>Ruthless</string>
+	<string>Xenophobic</string>
+	<string>Xenophobic</string>
+    <string>Cunning</string>
+	<string>Cunning</string>
+	<string>Cunning</string>
+    <string>Honorable</string>	
+	<string>Honorable</string>	
+	<string>Honorable</string>	
+    <string>Pacifist</string>
+	<string>Pacifist</string>
+	<string>Pacifist</string>
+	<string>Pacifist</string>
+  </PersonalityTraitsWeights>  
+
+  <EconomicTraitsWeights>
+    <string>Technologists</string>
+	<string>Technologists</string>
+	<string>Technologists</string>
+	<string>Industrialists</string>
+	<string>Industrialists</string>
+	<string>Generalists</string>
+	<string>Generalists</string>
+	<string>Generalists</string>
+	<string>Militarists</string>
+	<string>Expansionists</string>
+	<string>Expansionists</string>
+	<string>Expansionists</string>
+  </EconomicTraitsWeights>
+
   <Traits>
     <Name>Pollops</Name>
     <Singular>Pollop</Singular>

--- a/game/Content/Races/Ralyeh.xml
+++ b/game/Content/Races/Ralyeh.xml
@@ -23,11 +23,22 @@
   <WarpStart>sd_warp_start_ralyeh_01</WarpStart>
   <WarpEnd>sd_warp_stop_ralyeh_01</WarpEnd>
   
-  <ExcludedDTraits>
-    <string>Pacifist</string>
-    <string>Honorable</string>
+  <PersonalityTraitsWeights>
+	<string>Aggressive</string>
+	<string>Aggressive</string>
+	<string>Aggressive</string>
+    <string>Ruthless</string>
+	<string>Ruthless</string>
+	<string>Ruthless</string>
+	<string>Ruthless</string>
+	<string>Xenophobic</string>
+	<string>Xenophobic</string>
+	<string>Xenophobic</string>
     <string>Cunning</string>
-  </ExcludedDTraits>
+    <string>Honorable</string>	
+    <string>Pacifist</string>
+  </PersonalityTraitsWeights>  
+  
   <Traits>
     <Name>The Ralyeh Devoted</Name>
     <Singular>Ralyeh</Singular>

--- a/game/Content/Races/Ralyeh.xml
+++ b/game/Content/Races/Ralyeh.xml
@@ -56,37 +56,17 @@
     <B>253</B>
     <RaceDescription>KWAK!</RaceDescription>
     <Cost>0</Cost>
-    <PopGrowthMin>0.01</PopGrowthMin>
-    <ConsumptionModifier>0.1</ConsumptionModifier>
-    <ReproductionMod>0</ReproductionMod>
-    <DiplomacyMod>0</DiplomacyMod>
-    <GenericMaxPopMod>0</GenericMaxPopMod>
-    <Aquatic>0</Aquatic>
-    <Burrowers>0</Burrowers>
-    <Blind>0</Blind>
-    <BonusExplored>0</BonusExplored>
-    <Pioneers>1</Pioneers>
-    <Militaristic>0</Militaristic>
-    <HomeworldSizeMod>.25</HomeworldSizeMod>
-    <Prewarp>0</Prewarp>
-    <HomeworldFertMod>0</HomeworldFertMod>
-    <DodgeMod>0</DodgeMod>
-    <EnergyDamageMod>0</EnergyDamageMod>
-    <ResearchMod>.35</ResearchMod>
-    <Mercantile>0</Mercantile>
-    <Miners>0</Miners>
-    <ProductionMod>-0.15</ProductionMod>
-    <MaintMod>0</MaintMod>
-    <TaxMod>0</TaxMod>
-    <ShipCostMod>0</ShipCostMod>
-    <ModHpModifier>0.25</ModHpModifier>
-    <SmallSize>0</SmallSize>
-    <HugeSize>0</HugeSize>
-    <GroundCombatModifier>0</GroundCombatModifier>
-    <RepairRateMod>0</RepairRateMod>
-    <Cybernetic>0</Cybernetic>
-    <Spiritual>.5</Spiritual>
-    <PassengerBonus>3</PassengerBonus>
+	<TraitOptions>
+		<string>Gluttonous</string>
+		<string>Fertile</string>
+		<string>Huge Homeworld</string>
+		<string>Lazy</string>
+		<string>Skilled Engineers</string>
+		<string>Spiritual</string>
+		<string>Manifest Destiny</string>
+		<string>Prototype Flagship</string>
+		<string>Astronomers</string>
+	</TraitOptions>
   </Traits>
   <Faction>0</Faction>
 </EmpireData>

--- a/game/Content/Races/Ralyeh.xml
+++ b/game/Content/Races/Ralyeh.xml
@@ -23,18 +23,6 @@
   <WarpStart>sd_warp_start_ralyeh_01</WarpStart>
   <WarpEnd>sd_warp_stop_ralyeh_01</WarpEnd>
   
-  <!-- Fertility multipliers for environments. The default is 1 in the code, but the tags are included here for reference -->
-  <EnvTerran>1</EnvTerran>
-  <EnvOceanic>1</EnvOceanic>
-  <EnvSteppe>1</EnvSteppe>
-  <EnvTundra>1</EnvTundra>
-  <EnvSwamp>1</EnvSwamp>
-  <EnvDesert>1</EnvDesert>
-  <EnvIce>1</EnvIce>
-  <EnvBarren>1</EnvBarren>
-  <EnvVolcanic>1</EnvVolcanic>
-  <PreferredEnv>Terran</PreferredEnv> <!-- Terraformers will terraform a planet to this environment -->
-
   <ExcludedDTraits>
     <string>Pacifist</string>
     <string>Honorable</string>

--- a/game/Content/Races/Remnant.xml
+++ b/game/Content/Races/Remnant.xml
@@ -57,34 +57,6 @@ Remnant government is functional but unremarkable while society at large is neit
  
 The Remnant homeworld of Earth is of an average size for a terran planet. </RaceDescription>
     <Cost>0</Cost>
-    <ConsumptionModifier>0</ConsumptionModifier>
-    <ReproductionMod>0</ReproductionMod>
-    <DiplomacyMod>0</DiplomacyMod>
-    <GenericMaxPopMod>0</GenericMaxPopMod>
-    <Aquatic>0</Aquatic>
-    <Burrowers>0</Burrowers>
-    <Blind>0</Blind>
-    <BonusExplored>0</BonusExplored>
-    <Pioneers>0</Pioneers>
-    <Militaristic>0</Militaristic>
-    <HomeworldSizeMod>0</HomeworldSizeMod>
-    <Prewarp>0</Prewarp>
-    <Spiritual>0</Spiritual>
-    <HomeworldFertMod>0</HomeworldFertMod>
-    <DodgeMod>0</DodgeMod>
-    <EnergyDamageMod>0</EnergyDamageMod>
-    <ResearchMod>.25</ResearchMod>
-    <Mercantile>0</Mercantile>
-    <Miners>0</Miners>
-    <ProductionMod>0</ProductionMod>
-    <MaintMod>0</MaintMod>
-    <TaxMod>0</TaxMod>
-    <ShipCostMod>0</ShipCostMod>
-    <ModHpModifier>0</ModHpModifier>
-    <SmallSize>0</SmallSize>
-    <HugeSize>0</HugeSize>
-    <GroundCombatModifier>0</GroundCombatModifier>
-    <RepairRateMod>0</RepairRateMod>
-    <Cybernetic>0</Cybernetic>
+	<TraitOptions></TraitOptions>
   </Traits>
 </EmpireData>

--- a/game/Content/Races/Revoran.xml
+++ b/game/Content/Races/Revoran.xml
@@ -16,34 +16,6 @@
     <B>0</B>
 
     <Cost>0</Cost>
-    <ConsumptionModifier>0</ConsumptionModifier>
-    <ReproductionMod>0</ReproductionMod>
-    <DiplomacyMod>0</DiplomacyMod>
-    <GenericMaxPopMod>0</GenericMaxPopMod>
-    <Aquatic>0</Aquatic>
-    <Burrowers>0</Burrowers>
-    <Blind>0</Blind>
-    <BonusExplored>0</BonusExplored>
-    <Pioneers>0</Pioneers>
-    <Militaristic>0</Militaristic>
-    <HomeworldSizeMod>0</HomeworldSizeMod>
-    <Prewarp>0</Prewarp>
-    <Spiritual>0</Spiritual>
-    <HomeworldFertMod>0</HomeworldFertMod>
-    <DodgeMod>0</DodgeMod>
-    <EnergyDamageMod>0</EnergyDamageMod>
-    <ResearchMod>0</ResearchMod>
-    <Mercantile>0</Mercantile>
-    <Miners>0</Miners>
-    <ProductionMod>0</ProductionMod>
-    <MaintMod>0</MaintMod>
-    <TaxMod>0</TaxMod>
-    <ShipCostMod>0</ShipCostMod>
-    <ModHpModifier>0</ModHpModifier>
-    <SmallSize>0</SmallSize>
-    <HugeSize>0</HugeSize>
-    <GroundCombatModifier>0</GroundCombatModifier>
-    <RepairRateMod>0</RepairRateMod>
-    <Cybernetic>0</Cybernetic>
+	<TraitOptions></TraitOptions>
   </Traits>
 </EmpireData>

--- a/game/Content/Races/Unknown.xml
+++ b/game/Content/Races/Unknown.xml
@@ -15,34 +15,6 @@
     <G>137</G>
     <B>137</B>
     <Cost>0</Cost>
-    <ConsumptionModifier>0</ConsumptionModifier>
-    <ReproductionMod>0</ReproductionMod>
-    <DiplomacyMod>0</DiplomacyMod>
-    <GenericMaxPopMod>0</GenericMaxPopMod>
-    <Aquatic>0</Aquatic>
-    <Burrowers>0</Burrowers>
-    <Blind>0</Blind>
-    <BonusExplored>0</BonusExplored>
-    <Pioneers>0</Pioneers>
-    <Militaristic>0</Militaristic>
-    <HomeworldSizeMod>0</HomeworldSizeMod>
-    <Prewarp>0</Prewarp>
-    <Spiritual>0</Spiritual>
-    <HomeworldFertMod>0</HomeworldFertMod>
-    <DodgeMod>0</DodgeMod>
-    <EnergyDamageMod>0</EnergyDamageMod>
-    <ResearchMod>0</ResearchMod>
-    <Mercantile>0</Mercantile>
-    <Miners>0</Miners>
-    <ProductionMod>0</ProductionMod>
-    <MaintMod>0</MaintMod>
-    <TaxMod>0</TaxMod>
-    <ShipCostMod>0</ShipCostMod>
-    <ModHpModifier>0</ModHpModifier>
-    <SmallSize>0</SmallSize>
-    <HugeSize>0</HugeSize>
-    <GroundCombatModifier>0</GroundCombatModifier>
-    <RepairRateMod>0</RepairRateMod>
-    <Cybernetic>0</Cybernetic>
+	<TraitOptions></TraitOptions>
   </Traits>
 </EmpireData>

--- a/game/Content/Races/Vulfen.xml
+++ b/game/Content/Races/Vulfen.xml
@@ -30,14 +30,36 @@
   <ThrustColor1G>134</ThrustColor1G>
   <ThrustColor1B>11</ThrustColor1B>
 
-  <ExcludedDTraits>
-    <string>Pacifist</string>
-    <string>Honorable</string>
+  <PersonalityTraitsWeights>
+	<string>Aggressive</string>
+	<string>Aggressive</string>
+	<string>Aggressive</string>
+	<string>Aggressive</string>
+    <string>Ruthless</string>
+	<string>Ruthless</string>
+	<string>Ruthless</string>
+	<string>Xenophobic</string>
+	<string>Xenophobic</string>
+	<string>Xenophobic</string>
     <string>Cunning</string>
-  </ExcludedDTraits>
-  <ExcludedETraits>
+    <string>Honorable</string>	
+    <string>Pacifist</string>
+  </PersonalityTraitsWeights>
+  
+  <EconomicTraitsWeights>
     <string>Technologists</string>
-  </ExcludedETraits>
+	<string>Industrialists</string>
+	<string>Industrialists</string>
+	<string>Generalists</string>
+	<string>Generalists</string>
+	<string>Militarists</string>
+	<string>Militarists</string>
+	<string>Militarists</string>
+	<string>Expansionists</string>
+	<string>Expansionists</string>
+	<string>Expansionists</string>
+  </EconomicTraitsWeights>  
+  
   <Traits>
     <Name>The Vulfen Imperium</Name>
     <Singular>Vulfar</Singular>

--- a/game/Content/Races/Vulfen.xml
+++ b/game/Content/Races/Vulfen.xml
@@ -29,17 +29,6 @@
   <ThrustColor1R>184</ThrustColor1R>
   <ThrustColor1G>134</ThrustColor1G>
   <ThrustColor1B>11</ThrustColor1B>
-  <!-- Fertility multipliers for environments. The default is 1 in the code, but the tags are included here for reference -->
-  <EnvTerran>1</EnvTerran>
-  <EnvOceanic>1</EnvOceanic>
-  <EnvSteppe>1</EnvSteppe>
-  <EnvTundra>1</EnvTundra>
-  <EnvSwamp>1</EnvSwamp>
-  <EnvDesert>1</EnvDesert>
-  <EnvIce>1</EnvIce>
-  <EnvBarren>1</EnvBarren>
-  <EnvVolcanic>1</EnvVolcanic>
-  <PreferredEnv>Terran</PreferredEnv> <!-- Terraformers will terraform a planet to this environment -->
 
   <ExcludedDTraits>
     <string>Pacifist</string>

--- a/game/Content/Races/Vulfen.xml
+++ b/game/Content/Races/Vulfen.xml
@@ -65,38 +65,19 @@
     <B>0</B>
     <RaceDescription>The Vulfen Imperium believes in the superiority of the Vulfen race. They are an aggressive an industrialist race preferring strength through numbers in their many and varied conflicts. </RaceDescription>
     <Cost>0</Cost>
-    <ConsumptionModifier>0</ConsumptionModifier>
-    <PopGrowthMin>0</PopGrowthMin>
-    <DiplomacyMod>-.2</DiplomacyMod>
-    <GenericMaxPopMod>0</GenericMaxPopMod>
-    <Aquatic>0</Aquatic>
-    <Burrowers>0</Burrowers>
-    <Blind>0</Blind>
-    <BonusExplored>0</BonusExplored>
-    <Pioneers>0</Pioneers>
-    <Militaristic>1</Militaristic>
-    <HomeworldSizeMod>0</HomeworldSizeMod>
-    <Prewarp>0</Prewarp>
-    <Spiritual>0</Spiritual>
-    <HomeworldFertMod>0</HomeworldFertMod>
-    <DodgeMod>-0.25</DodgeMod>
-    <EnergyDamageMod>0.2</EnergyDamageMod>
-    <ResearchMod>-.35</ResearchMod>
-    <Mercantile>0</Mercantile>
-    <Miners>0</Miners>
-    <ProductionMod>.35</ProductionMod>
-    <MaintMod>-0.30</MaintMod>
-    <TaxMod>0</TaxMod>
-    <ShipCostMod>-.35</ShipCostMod>
-    <ModHpModifier>-.2</ModHpModifier>
-    <SmallSize>0</SmallSize>
-    <HugeSize>0</HugeSize>
-    <GroundCombatModifier>0</GroundCombatModifier>
-    <RepairRateMod>0</RepairRateMod>
-    <Pack>true</Pack>
-    <Cybernetic>0</Cybernetic>
-    <PassengerBonus>0</PassengerBonus>
-    <Prototype>1</Prototype>
+	<TraitOptions>
+		<string>Pack</string>
+		<string>Prototype Flagship</string>
+		<string>Militaristic</string>
+    	<string>Haphazard Engineers</string>
+		<string>Naval Tradition</string>
+		<string>Efficient</string>
+		<string>Dumb</string>
+		<string>Ponderous</string>
+		<string>Repulsive</string>
+		<string>Eagle Eyed</string>
+		<string>Industrious</string>		
+	</TraitOptions>	
   </Traits>
   <Faction>0</Faction>
 </EmpireData>

--- a/game/Content/RacialTraits/RacialTraits.xml
+++ b/game/Content/RacialTraits/RacialTraits.xml
@@ -10,7 +10,9 @@
     <Cost>3</Cost>
     <Description>33</Description>
     <ConsumptionModifier>-0.15</ConsumptionModifier>
-    <Excludes>34</Excludes>
+    <Excludes>
+		<string>Gluttonous</string>
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!--Gluttonous-->
@@ -20,7 +22,9 @@
     <Cost>-2</Cost>
     <Description>35</Description>
     <ConsumptionModifier>0.1</ConsumptionModifier>
-    <Excludes>32</Excludes>
+    <Excludes>
+		<string>Efficient Metabolism</string>
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!-- Fertile -->
@@ -30,7 +34,9 @@
     <Cost>2</Cost>
     <Description>37</Description>
     <PopGrowthMin>0.005</PopGrowthMin>
-    <Excludes>38</Excludes>
+    <Excludes>
+		<string>Less Fertile</string>
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!-- Less Fertile -->
@@ -40,7 +46,9 @@
     <Cost>-3</Cost>
     <Description>39</Description>
     <PopGrowthMax>0.015</PopGrowthMax>
-    <Excludes>36</Excludes>
+    <Excludes>
+		<string>Less Fertile</string>
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!-- Savage -->
@@ -50,7 +58,9 @@
     <Cost>2</Cost>
     <Description>41</Description>
     <GroundCombatModifier>0.3</GroundCombatModifier>
-    <Excludes>42</Excludes>
+    <Excludes>
+		<string>Timid</string>
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!-- Timid -->
@@ -60,7 +70,9 @@
     <Cost>-2</Cost>
     <Description>43</Description>
     <GroundCombatModifier>-0.30</GroundCombatModifier>
-    <Excludes>40</Excludes>
+    <Excludes>
+		<string>Savage</string>
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!-- Alluring -->
@@ -70,7 +82,9 @@
     <Cost>2</Cost>
     <Description>45</Description>
     <DiplomacyMod>0.2</DiplomacyMod>
-    <Excludes>46</Excludes>
+    <Excludes>
+		<string>Repulsive</string>
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!-- Repulsive -->
@@ -80,7 +94,9 @@
     <Cost>-2</Cost>
     <Description>47</Description>
     <DiplomacyMod>-0.2</DiplomacyMod>
-    <Excludes>44</Excludes>
+    <Excludes>
+		<string>Alluring</string>
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!-- Smart -->
@@ -90,7 +106,9 @@
     <Cost>3</Cost>
     <Description>49</Description>
     <ResearchMod>0.2</ResearchMod>
-    <Excludes>50</Excludes>
+    <Excludes>
+		<string>Dumb</string>		
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!-- Dumb -->
@@ -100,7 +118,9 @@
     <Cost>-2</Cost>
     <Description>51</Description>
     <ResearchMod>-0.1</ResearchMod>
-    <Excludes>48</Excludes>
+    <Excludes>
+		<string>Smart</string>		
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!-- Eagle Eyed -->
@@ -110,8 +130,10 @@
     <Cost>2</Cost>
     <Description>53</Description>
     <EnergyDamageMod>0.2</EnergyDamageMod>
-    <Excludes>54</Excludes>
-  </RacialTraitOption>
+    <Excludes>
+		<string>Blind</string>
+	</Excludes>
+  </RacialTraitOption>    
   <RacialTraitOption>
     <!-- Blind  -->
 	<TraitName>Blind</TraitName>
@@ -120,7 +142,9 @@
     <Cost>-2</Cost>
     <Description>55</Description>
     <EnergyDamageMod>-0.2</EnergyDamageMod>
-    <Excludes>52</Excludes>
+    <Excludes>
+		<string>Eagle Eyed</string>
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!-- Reflexes -->
@@ -130,7 +154,9 @@
     <Cost>2</Cost>
     <Description>57</Description>
     <DodgeMod>0.25</DodgeMod>
-    <Excludes>58</Excludes>
+    <Excludes>
+		<string>Ponderous</string>
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!-- Ponderous -->
@@ -140,7 +166,9 @@
     <Cost>-2</Cost>
     <Description>59</Description>
     <DodgeMod>-0.25</DodgeMod>
-    <Excludes>56</Excludes>
+    <Excludes>
+		<string>Reflexes</string>
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!-- Cybernetic -->
@@ -151,17 +179,18 @@
     <Description>61</Description>
     <Cybernetic>1</Cybernetic>
     <RepairMod>1</RepairMod>
-    <Excludes>17997</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
-    <!--industrious -->
+    <!--Industrious -->
 	<TraitName>Industrious</TraitName>
     <TraitIndex>62</TraitIndex>
     <Category>Industry</Category>
     <Cost>3</Cost>
     <Description>63</Description>
     <ProductionMod>0.25</ProductionMod>
-    <Excludes>64</Excludes>
+    <Excludes>
+		<string>Lazy</string>
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!--Lazy -->
@@ -171,7 +200,9 @@
     <Cost>-2</Cost>
     <Description>65</Description>
     <ProductionMod>-0.15</ProductionMod>
-    <Excludes>62</Excludes>
+    <Excludes>
+		<string>Industrious</string>		
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!--Mercantile-->
@@ -183,16 +214,6 @@
     <Mercantile>0.5</Mercantile>
   </RacialTraitOption>
   <RacialTraitOption>
-    <!-- Wasteful -->
-	<TraitName>Wasteful</TraitName>
-    <TraitIndex>68</TraitIndex>
-    <Category>Industry</Category>
-    <Cost>-4</Cost>
-    <Description>69</Description>
-    <MaintMod>0.25</MaintMod>
-    <Excludes>70</Excludes>
-  </RacialTraitOption>
-  <RacialTraitOption>
     <!-- Efficient-->
 	<TraitName>Efficient</TraitName>
     <TraitIndex>70</TraitIndex>
@@ -200,17 +221,21 @@
     <Cost>4</Cost>
     <Description>71</Description>
     <MaintMod>-0.25</MaintMod>
-    <Excludes>68</Excludes>
-  </RacialTraitOption>
+    <Excludes>
+		<string>Wasteful</string>
+	</Excludes>
+  </RacialTraitOption>  
   <RacialTraitOption>
-    <!-- Corrupt -->
-	<TraitName>Corrupt</TraitName>
-    <TraitIndex>72</TraitIndex>
+    <!-- Wasteful -->
+	<TraitName>Wasteful</TraitName>
+    <TraitIndex>68</TraitIndex>
     <Category>Industry</Category>
-    <Cost>-1</Cost>
-    <Description>73</Description>
-    <TaxMod>-0.25</TaxMod>
-    <Excludes>74</Excludes>
+    <Cost>-4</Cost>
+    <Description>69</Description>
+    <MaintMod>0.25</MaintMod>
+    <Excludes>
+		<string>Efficient</string>
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!-- Meticulous -->
@@ -220,7 +245,21 @@
     <Cost>1</Cost>
     <Description>75</Description>
     <TaxMod>0.25</TaxMod>
-    <Excludes>72</Excludes>
+    <Excludes>
+		<string>Corrupt</string>
+	</Excludes>
+  </RacialTraitOption>  
+  <RacialTraitOption>
+    <!-- Corrupt -->
+	<TraitName>Corrupt</TraitName>
+    <TraitIndex>72</TraitIndex>
+    <Category>Industry</Category>
+    <Cost>-1</Cost>
+    <Description>73</Description>
+    <TaxMod>-0.25</TaxMod>
+    <Excludes>
+		<string>Meticulous</string>
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!-- Skilled Engineers -->
@@ -230,8 +269,9 @@
     <Cost>2</Cost>
     <Description>77</Description>
     <ModHpModifier>0.2</ModHpModifier>
-    <Excludes>78</Excludes>
-    <Excludes>5091</Excludes>
+    <Excludes>
+		<string>Haphazard Engineers</string>
+	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>
     <!-- Haphazard Engineers -->
@@ -241,7 +281,9 @@
     <Cost>-2</Cost>
     <Description>79</Description>
     <ModHpModifier>-0.2</ModHpModifier>
-    <Excludes>76</Excludes>
+    <Excludes>
+		<string>Skilled Engineers</string>
+	</Excludes>
   </RacialTraitOption>
     <RacialTraitOption>
       <!-- Astronomers -->
@@ -287,8 +329,6 @@
       <Cost>-2</Cost>
       <Description>87</Description>
       <HomeworldFertMod>-0.5</HomeworldFertMod>
-      <Excludes>5087</Excludes>
-      <Excludes>17997</Excludes>
     </RacialTraitOption>
     <RacialTraitOption>
       <!-- Industrialized Homeworld -->
@@ -299,8 +339,6 @@
       <Description>5082</Description>
       <HomeworldFertMod>-1.0</HomeworldFertMod>
       <HomeworldRichMod>1.0</HomeworldRichMod>
-      <Excludes>5087</Excludes>
-      <Excludes>17997</Excludes>
     </RacialTraitOption>
     <RacialTraitOption>
       <!-- Huge Homeworld -->
@@ -310,17 +348,21 @@
       <Cost>3</Cost>
       <Description>89</Description>
       <HomeworldSizeMod>0.25</HomeworldSizeMod>
-      <Excludes>90</Excludes>
+      <Excludes>
+		<string>Small Homeworld</string>
+	  </Excludes>
     </RacialTraitOption>
     <RacialTraitOption>
       <!-- Small homeworld -->
-	  <TraitName>Small homeworld</TraitName>
+	  <TraitName>Small Homeworld</TraitName>
       <TraitIndex>90</TraitIndex>
       <Category>Special</Category>
       <Cost>-3</Cost>
       <Description>91</Description>
       <HomeworldSizeMod>-0.15</HomeworldSizeMod>
-      <Excludes>88</Excludes>
+      <Excludes>
+		<string>Huge Homeworld</string>
+	  </Excludes>
     </RacialTraitOption>
     <RacialTraitOption>
       <!-- Prototype Flagship -->
@@ -330,7 +372,6 @@
       <Cost>1</Cost>
       <Description>93</Description>
       <Prototype>1</Prototype>
-      <Excludes>94</Excludes>
     </RacialTraitOption>
     <RacialTraitOption>
       <!-- Manifest Destiny -->
@@ -349,7 +390,9 @@
       <Cost>2</Cost>
       <Description>1437</Description>
       <SpyMultiplier>10</SpyMultiplier>
-      <Excludes>1438</Excludes>
+      <Excludes>
+		<string>Honest</string>
+	  </Excludes>
     </RacialTraitOption>
     <RacialTraitOption>
       <!-- Honest -->
@@ -358,7 +401,9 @@
       <Category>Special</Category>
       <Cost>-2</Cost>
       <Description>1439</Description>
-      <Excludes>1436</Excludes>
+      <Excludes>
+		  <string>Duplicitous</string>		
+	  </Excludes>
       <SpyMultiplier>-10</SpyMultiplier>
     </RacialTraitOption>
     <RacialTraitOption>

--- a/game/Content/RacialTraits/RacialTraits.xml
+++ b/game/Content/RacialTraits/RacialTraits.xml
@@ -129,7 +129,7 @@
     <Category>Physical</Category>
     <Cost>2</Cost>
     <Description>53</Description>
-    <EnergyDamageMod>0.2</EnergyDamageMod>
+    <TargetingModifier>0.2</TargetingModifier>
     <Excludes>
 		<string>Blind</string>
 	</Excludes>
@@ -141,7 +141,7 @@
     <Category>Physical</Category>
     <Cost>-2</Cost>
     <Description>55</Description>
-    <EnergyDamageMod>-0.2</EnergyDamageMod>
+    <TargetingModifier>-0.2</TargetingModifier>
     <Excludes>
 		<string>Eagle Eyed</string>
 	</Excludes>
@@ -423,6 +423,7 @@
       <Cost>2</Cost>
       <Description>4987</Description>
 	  <Aquatic>1</Aquatic> <!-- This only changes the race description -->
+	  <PreferredEnv>Oceanic</PreferredEnv>  
 	  <EnvTerranMultiplier>1.5</EnvTerranMultiplier>
    	  <EnvOceanicMultiplier>2</EnvOceanicMultiplier>
 	  <EnvSteppeMultiplier>1</EnvSteppeMultiplier>
@@ -431,6 +432,16 @@
 	  <EnvDesertMultiplier>0.5</EnvDesertMultiplier>
 	  <EnvIceMultiplier>0.75</EnvIceMultiplier>
     </RacialTraitOption>	
+    <RacialTraitOption>
+      <!-- Explorers -->
+	  <TraitName>Explorers</TraitName>
+      <TraitIndex>4984</TraitIndex>
+      <Category>Sociological</Category>
+      <Cost>1</Cost>
+      <Description>4985</Description>
+	  <ExploreDistanceMultiplier>2</ExploreDistanceMultiplier>
+    </RacialTraitOption>
+
 	
     <!-- Adventure Mode Traits
     <RacialTraitOption>

--- a/game/Content/RacialTraits/RacialTraits.xml
+++ b/game/Content/RacialTraits/RacialTraits.xml
@@ -174,7 +174,7 @@
     <!-- Cybernetic -->
 	<TraitName>Cybernetic</TraitName>
     <TraitIndex>60</TraitIndex>
-    <Category>Special</Category>
+    <Category>HistoryAndTradition</Category>
     <Cost>7</Cost>
     <Description>61</Description>
     <Cybernetic>1</Cybernetic>
@@ -184,7 +184,7 @@
     <!--Industrious -->
 	<TraitName>Industrious</TraitName>
     <TraitIndex>62</TraitIndex>
-    <Category>Industry</Category>
+    <Category>Sociological</Category>
     <Cost>3</Cost>
     <Description>63</Description>
     <ProductionMod>0.25</ProductionMod>
@@ -196,7 +196,7 @@
     <!--Lazy -->
 	<TraitName>Lazy</TraitName>
     <TraitIndex>64</TraitIndex>
-    <Category>Industry</Category>
+    <Category>Sociological</Category>
     <Cost>-2</Cost>
     <Description>65</Description>
     <ProductionMod>-0.15</ProductionMod>
@@ -208,7 +208,7 @@
     <!--Mercantile-->
 	<TraitName>Mercantile</TraitName>
     <TraitIndex>66</TraitIndex>
-    <Category>Industry</Category>
+    <Category>Sociological</Category>
     <Cost>2</Cost>
     <Description>67</Description>
     <Mercantile>0.5</Mercantile>
@@ -217,7 +217,7 @@
     <!-- Efficient-->
 	<TraitName>Efficient</TraitName>
     <TraitIndex>70</TraitIndex>
-    <Category>Industry</Category>
+    <Category>Sociological</Category>
     <Cost>4</Cost>
     <Description>71</Description>
     <MaintMod>-0.25</MaintMod>
@@ -229,7 +229,7 @@
     <!-- Wasteful -->
 	<TraitName>Wasteful</TraitName>
     <TraitIndex>68</TraitIndex>
-    <Category>Industry</Category>
+    <Category>Sociological</Category>
     <Cost>-4</Cost>
     <Description>69</Description>
     <MaintMod>0.25</MaintMod>
@@ -241,7 +241,7 @@
     <!-- Meticulous -->
 	<TraitName>Meticulous</TraitName>
     <TraitIndex>74</TraitIndex>
-    <Category>Industry</Category>
+    <Category>Sociological</Category>
     <Cost>1</Cost>
     <Description>75</Description>
     <TaxMod>0.25</TaxMod>
@@ -253,7 +253,7 @@
     <!-- Corrupt -->
 	<TraitName>Corrupt</TraitName>
     <TraitIndex>72</TraitIndex>
-    <Category>Industry</Category>
+    <Category>Sociological</Category>
     <Cost>-1</Cost>
     <Description>73</Description>
     <TaxMod>-0.25</TaxMod>
@@ -265,7 +265,7 @@
     <!-- Skilled Engineers -->
 	<TraitName>Skilled Engineers</TraitName>
     <TraitIndex>76</TraitIndex>
-    <Category>Industry</Category>
+    <Category>Sociological</Category>
     <Cost>2</Cost>
     <Description>77</Description>
     <ModHpModifier>0.2</ModHpModifier>
@@ -277,7 +277,7 @@
     <!-- Haphazard Engineers -->
 	<TraitName>Haphazard Engineers</TraitName>
     <TraitIndex>78</TraitIndex>
-    <Category>Industry</Category>
+    <Category>Sociological</Category>
     <Cost>-2</Cost>
     <Description>79</Description>
     <ModHpModifier>-0.2</ModHpModifier>
@@ -289,7 +289,7 @@
       <!-- Astronomers -->
 	  <TraitName>Astronomers</TraitName>
       <TraitIndex>80</TraitIndex>
-      <Category>Special</Category>
+      <Category>HistoryAndTradition</Category>
       <Cost>2</Cost>
       <Description>81</Description>
       <BonusExplored>15</BonusExplored>
@@ -298,7 +298,7 @@
       <!-- Naval Tradition-->
 	  <TraitName>Naval Tradition</TraitName>
       <TraitIndex>82</TraitIndex>
-      <Category>Special</Category>
+      <Category>HistoryAndTradition</Category>
       <Cost>2</Cost>
       <Description>83</Description>
       <ShipCostMod>-0.2</ShipCostMod>
@@ -307,7 +307,7 @@
       <!-- Militaristic -->
 	  <TraitName>Militaristic</TraitName>
       <TraitIndex>84</TraitIndex>
-      <Category>Special</Category>
+      <Category>HistoryAndTradition</Category>
       <Cost>2</Cost>
       <Description>85</Description>
       <Militaristic>1</Militaristic>
@@ -316,7 +316,7 @@
       <!-- Pack -->
 	  <TraitName>Pack</TraitName>
       <TraitIndex>2243</TraitIndex>
-      <Category>Special</Category>
+      <Category>HistoryAndTradition</Category>
       <Cost>2</Cost>
       <Description>2244</Description>
       <Pack>1</Pack>
@@ -325,7 +325,7 @@
       <!-- Polluted Homeworld -->
 	  <TraitName>Polluted Homeworld</TraitName>
       <TraitIndex>86</TraitIndex>
-      <Category>Special</Category>
+      <Category>Environment</Category>
       <Cost>-2</Cost>
       <Description>87</Description>
       <HomeworldFertMod>-0.5</HomeworldFertMod>
@@ -334,7 +334,7 @@
       <!-- Industrialized Homeworld -->
 	  <TraitName>Industrialized Homeworld</TraitName>
       <TraitIndex>5081</TraitIndex>
-      <Category>Special</Category>
+      <Category>Environment</Category>
       <Cost>2</Cost>
       <Description>5082</Description>
       <HomeworldFertMod>-1.0</HomeworldFertMod>
@@ -344,7 +344,7 @@
       <!-- Huge Homeworld -->
 	  <TraitName>Huge Homeworld</TraitName>
       <TraitIndex>88</TraitIndex>
-      <Category>Special</Category>
+      <Category>Environment</Category>
       <Cost>3</Cost>
       <Description>89</Description>
       <HomeworldSizeMod>0.25</HomeworldSizeMod>
@@ -356,7 +356,7 @@
       <!-- Small homeworld -->
 	  <TraitName>Small Homeworld</TraitName>
       <TraitIndex>90</TraitIndex>
-      <Category>Special</Category>
+      <Category>Environment</Category>
       <Cost>-3</Cost>
       <Description>91</Description>
       <HomeworldSizeMod>-0.15</HomeworldSizeMod>
@@ -368,7 +368,7 @@
       <!-- Prototype Flagship -->
 	  <TraitName>Prototype Flagship</TraitName>
       <TraitIndex>92</TraitIndex>
-      <Category>Special</Category>
+      <Category>HistoryAndTradition</Category>
       <Cost>1</Cost>
       <Description>93</Description>
       <Prototype>1</Prototype>
@@ -377,7 +377,7 @@
       <!-- Manifest Destiny -->
 	  <TraitName>Manifest Destiny</TraitName>
       <TraitIndex>96</TraitIndex>
-      <Category>Special</Category>
+      <Category>HistoryAndTradition</Category>
       <Cost>1</Cost>
       <Description>97</Description>
       <PassengerBonus>2</PassengerBonus>
@@ -386,7 +386,7 @@
       <!-- Duplicitous -->
 	  <TraitName>Duplicitous</TraitName>
       <TraitIndex>1436</TraitIndex>
-      <Category>Special</Category>
+      <Category>HistoryAndTradition</Category>
       <Cost>2</Cost>
       <Description>1437</Description>
       <SpyMultiplier>10</SpyMultiplier>
@@ -398,7 +398,7 @@
       <!-- Honest -->
 	  <TraitName>Honest</TraitName>
       <TraitIndex>1438</TraitIndex>
-      <Category>Special</Category>
+      <Category>HistoryAndTradition</Category>
       <Cost>-2</Cost>
       <Description>1439</Description>
       <Excludes>
@@ -410,11 +410,27 @@
       <!-- Spiritual -->
 	  <TraitName>Spiritual</TraitName>
       <TraitIndex>1440</TraitIndex>
-      <Category>Special</Category>
+      <Category>HistoryAndTradition</Category>
       <Cost>1</Cost>
       <Description>1441</Description>
       <Spiritual>0.5</Spiritual>
     </RacialTraitOption>
+    <RacialTraitOption>
+      <!-- Aquatic -->
+	  <TraitName>Environment</TraitName>
+      <TraitIndex>4986</TraitIndex>
+      <Category>Environment</Category>
+      <Cost>2</Cost>
+      <Description>4987</Description>
+	  <Aquatic>1</Aquatic>
+	  <EnvTerranMultiplier>1.5</EnvTerranMultiplier>
+   	  <EnvOceanicMultiplier>2</EnvOceanicMultiplier>
+	  <EnvSteppeMultiplier>1</EnvSteppeMultiplier>
+	  <EnvTundraMultiplier>1</EnvTundraMultiplier>
+	  <EnvSwampMultiplier>1.75</EnvSwampMultiplier>
+	  <EnvDesertMultiplier>0.5</EnvDesertMultiplier>
+	  <EnvIceMultiplier>0.75</EnvIceMultiplier>
+    </RacialTraitOption>	
 	
     <!-- Adventure Mode Traits
     <RacialTraitOption>

--- a/game/Content/RacialTraits/RacialTraits.xml
+++ b/game/Content/RacialTraits/RacialTraits.xml
@@ -1,503 +1,425 @@
 ﻿<RacialTraits>
-  <!-- The "TraitName" is an index for the localization file. It grabs the correct description for the selected language from there-->
+  <!-- The "TraitIndex" is an index for the localization file. It grabs the correct description for the selected language from there-->
   <!-- The "Description" is an index for the localization file. It grabs the correct description for the selected language from there-->
   <TraitList>
-  <RacialTrait>
+  <RacialTraitOption>
     <!-- Efficient Metabolism -->
-    <TraitName>32</TraitName>
+	<TraitName>Efficient Metabolism</TraitName>
+    <TraitIndex>32</TraitIndex>
     <Category>Physical</Category>
     <Cost>3</Cost>
     <Description>33</Description>
     <ConsumptionModifier>-0.15</ConsumptionModifier>
     <Excludes>34</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!--Gluttonous-->
-    <TraitName>34</TraitName>
+	<TraitName>Gluttonous</TraitName>
+    <TraitIndex>34</TraitIndex>
     <Category>Physical</Category>
     <Cost>-2</Cost>
     <Description>35</Description>
     <ConsumptionModifier>0.1</ConsumptionModifier>
     <Excludes>32</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Fertile -->
-    <TraitName>36</TraitName>
+	<TraitName>Fertile</TraitName>
+    <TraitIndex>36</TraitIndex>
     <Category>Physical</Category>
     <Cost>2</Cost>
     <Description>37</Description>
     <PopGrowthMin>0.005</PopGrowthMin>
     <Excludes>38</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Less Fertile -->
-    <TraitName>38</TraitName>
+	<TraitName>Less Fertile</TraitName>
+    <TraitIndex>38</TraitIndex>
     <Category>Physical</Category>
     <Cost>-3</Cost>
     <Description>39</Description>
     <PopGrowthMax>0.015</PopGrowthMax>
     <Excludes>36</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Savage -->
-    <TraitName>40</TraitName>
+	<TraitName>Savage</TraitName>
+    <TraitIndex>40</TraitIndex>
     <Category>Physical</Category>
     <Cost>2</Cost>
     <Description>41</Description>
     <GroundCombatModifier>0.3</GroundCombatModifier>
     <Excludes>42</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Timid -->
-    <TraitName>42</TraitName>
+	<TraitName>Timid</TraitName>
+    <TraitIndex>42</TraitIndex>
     <Category>Physical</Category>
     <Cost>-2</Cost>
     <Description>43</Description>
     <GroundCombatModifier>-0.30</GroundCombatModifier>
     <Excludes>40</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Alluring -->
-    <TraitName>44</TraitName>
+	<TraitName>Alluring</TraitName>
+    <TraitIndex>44</TraitIndex>
     <Category>Physical</Category>
     <Cost>2</Cost>
     <Description>45</Description>
     <DiplomacyMod>0.2</DiplomacyMod>
     <Excludes>46</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Repulsive -->
-    <TraitName>46</TraitName>
+	<TraitName>Repulsive</TraitName>
+    <TraitIndex>46</TraitIndex>
     <Category>Physical</Category>
     <Cost>-2</Cost>
     <Description>47</Description>
     <DiplomacyMod>-0.2</DiplomacyMod>
     <Excludes>44</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Smart -->
-    <TraitName>48</TraitName>
+	<TraitName>Smart</TraitName>
+    <TraitIndex>48</TraitIndex>
     <Category>Physical</Category>
     <Cost>3</Cost>
     <Description>49</Description>
     <ResearchMod>0.2</ResearchMod>
     <Excludes>50</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Dumb -->
-    <TraitName>50</TraitName>
+	<TraitName>Dumb</TraitName>
+    <TraitIndex>50</TraitIndex>
     <Category>Physical</Category>
     <Cost>-2</Cost>
     <Description>51</Description>
     <ResearchMod>-0.1</ResearchMod>
     <Excludes>48</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Eagle Eyed -->
-    <TraitName>52</TraitName>
+	<TraitName>Eagle Eyed</TraitName>
+    <TraitIndex>52</TraitIndex>
     <Category>Physical</Category>
     <Cost>2</Cost>
     <Description>53</Description>
     <EnergyDamageMod>0.2</EnergyDamageMod>
     <Excludes>54</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Blind  -->
-    <TraitName>54</TraitName>
+	<TraitName>Blind</TraitName>
+    <TraitIndex>54</TraitIndex>
     <Category>Physical</Category>
     <Cost>-2</Cost>
     <Description>55</Description>
     <EnergyDamageMod>-0.2</EnergyDamageMod>
     <Excludes>52</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Reflexes -->
-    <TraitName>56</TraitName>
+	<TraitName>Reflexes</TraitName>
+    <TraitIndex>56</TraitIndex>
     <Category>Physical</Category>
     <Cost>2</Cost>
     <Description>57</Description>
     <DodgeMod>0.25</DodgeMod>
     <Excludes>58</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Ponderous -->
-    <TraitName>58</TraitName>
+	<TraitName>Ponderous</TraitName>
+    <TraitIndex>58</TraitIndex>
     <Category>Physical</Category>
     <Cost>-2</Cost>
     <Description>59</Description>
     <DodgeMod>-0.25</DodgeMod>
     <Excludes>56</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Cybernetic -->
-    <TraitName>60</TraitName>
+	<TraitName>Cybernetic</TraitName>
+    <TraitIndex>60</TraitIndex>
     <Category>Special</Category>
     <Cost>7</Cost>
     <Description>61</Description>
     <Cybernetic>1</Cybernetic>
     <RepairMod>1</RepairMod>
-    <Excludes>5091</Excludes>
     <Excludes>17997</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!--industrious -->
-    <TraitName>62</TraitName>
+	<TraitName>Industrious</TraitName>
+    <TraitIndex>62</TraitIndex>
     <Category>Industry</Category>
     <Cost>3</Cost>
     <Description>63</Description>
     <ProductionMod>0.25</ProductionMod>
     <Excludes>64</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!--Lazy -->
-    <TraitName>64</TraitName>
+	<TraitName>Lazy</TraitName>
+    <TraitIndex>64</TraitIndex>
     <Category>Industry</Category>
     <Cost>-2</Cost>
     <Description>65</Description>
     <ProductionMod>-0.15</ProductionMod>
     <Excludes>62</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!--Mercantile-->
-    <TraitName>66</TraitName>
+	<TraitName>Mercantile</TraitName>
+    <TraitIndex>66</TraitIndex>
     <Category>Industry</Category>
     <Cost>2</Cost>
     <Description>67</Description>
     <Mercantile>0.5</Mercantile>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Wasteful -->
-    <TraitName>68</TraitName>
+	<TraitName>Wasteful</TraitName>
+    <TraitIndex>68</TraitIndex>
     <Category>Industry</Category>
     <Cost>-4</Cost>
     <Description>69</Description>
     <MaintMod>0.25</MaintMod>
     <Excludes>70</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Efficient-->
-    <TraitName>70</TraitName>
+	<TraitName>Efficient</TraitName>
+    <TraitIndex>70</TraitIndex>
     <Category>Industry</Category>
     <Cost>4</Cost>
     <Description>71</Description>
     <MaintMod>-0.25</MaintMod>
     <Excludes>68</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Corrupt -->
-    <TraitName>72</TraitName>
+	<TraitName>Corrupt</TraitName>
+    <TraitIndex>72</TraitIndex>
     <Category>Industry</Category>
     <Cost>-1</Cost>
     <Description>73</Description>
     <TaxMod>-0.25</TaxMod>
     <Excludes>74</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Meticulous -->
-    <TraitName>74</TraitName>
+	<TraitName>Meticulous</TraitName>
+    <TraitIndex>74</TraitIndex>
     <Category>Industry</Category>
     <Cost>1</Cost>
     <Description>75</Description>
     <TaxMod>0.25</TaxMod>
     <Excludes>72</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Skilled Engineers -->
-    <TraitName>76</TraitName>
+	<TraitName>Skilled Engineers</TraitName>
+    <TraitIndex>76</TraitIndex>
     <Category>Industry</Category>
     <Cost>2</Cost>
     <Description>77</Description>
     <ModHpModifier>0.2</ModHpModifier>
     <Excludes>78</Excludes>
     <Excludes>5091</Excludes>
-  </RacialTrait>
-  <RacialTrait>
+  </RacialTraitOption>
+  <RacialTraitOption>
     <!-- Haphazard Engineers -->
-    <TraitName>78</TraitName>
+	<TraitName>Haphazard Engineers</TraitName>
+    <TraitIndex>78</TraitIndex>
     <Category>Industry</Category>
     <Cost>-2</Cost>
     <Description>79</Description>
     <ModHpModifier>-0.2</ModHpModifier>
     <Excludes>76</Excludes>
-    <Excludes>5091</Excludes>
-  </RacialTrait>
-    <RacialTrait>
+  </RacialTraitOption>
+    <RacialTraitOption>
       <!-- Astronomers -->
-      <TraitName>80</TraitName>
+	  <TraitName>Astronomers</TraitName>
+      <TraitIndex>80</TraitIndex>
       <Category>Special</Category>
       <Cost>2</Cost>
       <Description>81</Description>
       <BonusExplored>15</BonusExplored>
-      <Excludes>5091</Excludes>
-    </RacialTrait>
-    <RacialTrait>
+    </RacialTraitOption>
+    <RacialTraitOption>
       <!-- Naval Tradition-->
-      <TraitName>82</TraitName>
+	  <TraitName>Naval Tradition</TraitName>
+      <TraitIndex>82</TraitIndex>
       <Category>Special</Category>
       <Cost>2</Cost>
       <Description>83</Description>
       <ShipCostMod>-0.2</ShipCostMod>
-      <Excludes>5091</Excludes>
-    </RacialTrait>
-    <RacialTrait>
+    </RacialTraitOption>
+    <RacialTraitOption>
       <!-- Militaristic -->
-      <TraitName>84</TraitName>
+	  <TraitName>Militaristic</TraitName>
+      <TraitIndex>84</TraitIndex>
       <Category>Special</Category>
       <Cost>2</Cost>
       <Description>85</Description>
       <Militaristic>1</Militaristic>
-      <Excludes>5091</Excludes>
-    </RacialTrait>
-    <RacialTrait>
+    </RacialTraitOption>
+    <RacialTraitOption>
       <!-- Pack -->
-      <TraitName>2243</TraitName>
+	  <TraitName>Pack</TraitName>
+      <TraitIndex>2243</TraitIndex>
       <Category>Special</Category>
       <Cost>2</Cost>
       <Description>2244</Description>
-      <Pack>true</Pack>
-      <Excludes>5091</Excludes>
-    </RacialTrait>
-    <RacialTrait>
+      <Pack>1</Pack>
+    </RacialTraitOption>
+    <RacialTraitOption>
       <!-- Polluted Homeworld -->
-      <TraitName>86</TraitName>
+	  <TraitName>Polluted Homeworld</TraitName>
+      <TraitIndex>86</TraitIndex>
       <Category>Special</Category>
       <Cost>-2</Cost>
       <Description>87</Description>
       <HomeworldFertMod>-0.5</HomeworldFertMod>
       <Excludes>5087</Excludes>
-      <Excludes>5091</Excludes>
       <Excludes>17997</Excludes>
-    </RacialTrait>
-    <RacialTrait>
+    </RacialTraitOption>
+    <RacialTraitOption>
       <!-- Industrialized Homeworld -->
-      <TraitName>5081</TraitName>
+	  <TraitName>Industrialized Homeworld</TraitName>
+      <TraitIndex>5081</TraitIndex>
       <Category>Special</Category>
       <Cost>2</Cost>
       <Description>5082</Description>
       <HomeworldFertMod>-1.0</HomeworldFertMod>
       <HomeworldRichMod>1.0</HomeworldRichMod>
       <Excludes>5087</Excludes>
-      <Excludes>5091</Excludes>
       <Excludes>17997</Excludes>
-    </RacialTrait>
-    <RacialTrait>
+    </RacialTraitOption>
+    <RacialTraitOption>
       <!-- Huge Homeworld -->
-      <TraitName>88</TraitName>
+	  <TraitName>Huge Homeworld</TraitName>
+      <TraitIndex>88</TraitIndex>
       <Category>Special</Category>
       <Cost>3</Cost>
       <Description>89</Description>
       <HomeworldSizeMod>0.25</HomeworldSizeMod>
       <Excludes>90</Excludes>
-      <Excludes>5091</Excludes>
-    </RacialTrait>
-    <RacialTrait>
+    </RacialTraitOption>
+    <RacialTraitOption>
       <!-- Small homeworld -->
-      <TraitName>90</TraitName>
+	  <TraitName>Small homeworld</TraitName>
+      <TraitIndex>90</TraitIndex>
       <Category>Special</Category>
       <Cost>-3</Cost>
       <Description>91</Description>
       <HomeworldSizeMod>-0.15</HomeworldSizeMod>
       <Excludes>88</Excludes>
-      <Excludes>5091</Excludes>
-    </RacialTrait>
-    <RacialTrait>
+    </RacialTraitOption>
+    <RacialTraitOption>
       <!-- Prototype Flagship -->
-      <TraitName>92</TraitName>
+	  <TraitName>Prototype Flagship</TraitName>
+      <TraitIndex>92</TraitIndex>
       <Category>Special</Category>
       <Cost>1</Cost>
       <Description>93</Description>
       <Prototype>1</Prototype>
       <Excludes>94</Excludes>
-      <Excludes>5091</Excludes>
-    </RacialTrait>
-    <RacialTrait>
+    </RacialTraitOption>
+    <RacialTraitOption>
       <!-- Manifest Destiny -->
-      <TraitName>96</TraitName>
+	  <TraitName>Manifest Destiny</TraitName>
+      <TraitIndex>96</TraitIndex>
       <Category>Special</Category>
       <Cost>1</Cost>
       <Description>97</Description>
       <PassengerBonus>2</PassengerBonus>
-      <Excludes>5091</Excludes>
-    </RacialTrait>
-    <RacialTrait>
+    </RacialTraitOption>
+    <RacialTraitOption>
       <!-- Duplicitous -->
-      <TraitName>1436</TraitName>
+	  <TraitName>Duplicitous</TraitName>
+      <TraitIndex>1436</TraitIndex>
       <Category>Special</Category>
       <Cost>2</Cost>
       <Description>1437</Description>
       <SpyMultiplier>10</SpyMultiplier>
       <Excludes>1438</Excludes>
-      <Excludes>5091</Excludes>
-    </RacialTrait>
-    <RacialTrait>
+    </RacialTraitOption>
+    <RacialTraitOption>
       <!-- Honest -->
-      <TraitName>1438</TraitName>
+	  <TraitName>Honest</TraitName>
+      <TraitIndex>1438</TraitIndex>
       <Category>Special</Category>
       <Cost>-2</Cost>
       <Description>1439</Description>
       <Excludes>1436</Excludes>
-      <Excludes>5091</Excludes>
       <SpyMultiplier>-10</SpyMultiplier>
-    </RacialTrait>
-    <RacialTrait>
+    </RacialTraitOption>
+    <RacialTraitOption>
       <!-- Spiritual -->
-      <TraitName>1440</TraitName>
+	  <TraitName>Spiritual</TraitName>
+      <TraitIndex>1440</TraitIndex>
       <Category>Special</Category>
       <Cost>1</Cost>
       <Description>1441</Description>
       <Spiritual>0.5</Spiritual>
-      <Excludes>5091</Excludes>
-    </RacialTrait>
-    <!--Clean Homeworld-->
-    <!-- bugged, excludes dont work :( 
-    <RacialTrait>
-      
-      <TraitName>17997</TraitName>
-      <Category>Special</Category>
-      <Cost>2</Cost>
-      <Excludes>60</Excludes>
-      <Excludes>86</Excludes>
-      <Excludes>5081</Excludes>
-      <Excludes>5091</Excludes>
-      <Description>17998</Description>
-      <HomeworldFertMod>1</HomeworldFertMod>
-    </RacialTrait>
-     -->
-    <!-- Sorry not working :( 
-       <RacialTrait>-->
-      <!-- Space trash -->
-      <!-- <TraitName>5090</TraitName>
-      <Category>Special</Category>
-      <Cost>-100</Cost>
-      <Excludes>32</Excludes>
-      <Excludes>34</Excludes>
-      <Excludes>36</Excludes>
-      <Excludes>38</Excludes>
-      <Excludes>40</Excludes>
-      <Excludes>42</Excludes>
-      <Excludes>44</Excludes>
-      <Excludes>46</Excludes>
-      <Excludes>48</Excludes>
-      <Excludes>50</Excludes>
-      <Excludes>52</Excludes>
-      <Excludes>54</Excludes>
-      <Excludes>56</Excludes>
-      <Excludes>58</Excludes>
-      <Excludes>60</Excludes>
-      <Excludes>62</Excludes>
-      <Excludes>64</Excludes>
-      <Excludes>66</Excludes>
-      <Excludes>68</Excludes>
-      <Excludes>70</Excludes>
-      <Excludes>72</Excludes>
-      <Excludes>74</Excludes>
-      <Excludes>76</Excludes>
-      <Excludes>78</Excludes>
-      <Excludes>80</Excludes>
-      <Excludes>82</Excludes>
-      <Excludes>84</Excludes>
-      <Excludes>86</Excludes>
-      <Excludes>88</Excludes>
-      <Excludes>90</Excludes>
-      <Excludes>92</Excludes>
-      <Excludes>96</Excludes>
-      <Excludes>2243</Excludes>
-      <Excludes>5081</Excludes>
-      <Excludes>1436</Excludes>
-      <Excludes>1438</Excludes>
-      <Excludes>1440</Excludes>
-      <Excludes>5087</Excludes>
-      <Description>5091</Description>
-      <HomeworldFertMod>-.5</HomeworldFertMod>
-      <HomeworldRichMod>-.5</HomeworldRichMod>
-      <ConsumptionModifier>.30</ConsumptionModifier>
-      <SpyMultiplier>-20</SpyMultiplier>
-      <HomeworldSizeMod>-.50</HomeworldSizeMod>
-      <ModHpModifier>-.80</ModHpModifier>
-      <TaxMod>-.50</TaxMod>
-      <MaintMod>.40</MaintMod>
-      <DodgeMod>-.40</DodgeMod>
-      <GroundCombatModifier>-.50</GroundCombatModifier>
-      <EnergyDamageMod>-.40</EnergyDamageMod>
-      <PopGrowthMax>.05</PopGrowthMax>
-      <DiplomacyMod>-.90</DiplomacyMod>
-      <ResearchMod>-.55</ResearchMod>
-      <ProductionMod>-.50</ProductionMod>
-    </RacialTrait>-->
-
-
+    </RacialTraitOption>
+	
     <!-- Adventure Mode Traits
-    <RacialTrait>
-      <TraitName>Wealthy Parents</TraitName>
+    <RacialTraitOption>
+      <TraitIndex>Wealthy Parents</TraitIndex>
       <Category>Adventure</Category>
       <Cost>3</Cost>
       <Description>Your parents left you a sizeable inheritance, and as a result begin your adventure with 5000 extra credits. </Description>
       <PassengerModifier>2</PassengerModifier>
-    </RacialTrait>
-    <RacialTrait>
-      <TraitName>Shrewd Negotiator</TraitName>
+    </RacialTraitOption>
+    <RacialTraitOption>
+      <TraitIndex>Shrewd Negotiator</TraitIndex>
       <Category>Adventure</Category>
       <Cost>3</Cost>
       <Description>Your father was a shrwed negotiator, and as a result you know how to drive a hard bargain.  Gain +10% to buy and sell prices for trade goods. </Description>
       <PassengerModifier>2</PassengerModifier>
-    </RacialTrait>
-    <RacialTrait>
-      <TraitName>Chief Engineer</TraitName>
+    </RacialTraitOption>
+    <RacialTraitOption>
+      <TraitIndex>Chief Engineer</TraitIndex>
       <Category>Adventure</Category>
       <Cost>3</Cost>
       <Description>You were the chief engineer on a naval vessel and as a result you're an expert at deep-space repairs.  Doubles your out-of-combat repair rate. </Description>
       <PassengerModifier>2</PassengerModifier>
-    </RacialTrait>
-    <RacialTrait>
-      <TraitName>Hold Together, Baby</TraitName>
+    </RacialTraitOption>
+    <RacialTraitOption>
+      <TraitIndex>Hold Together, Baby</TraitIndex>
       <Category>Adventure</Category>
       <Cost>3</Cost>
       <Description>Most ships that are reduced to 35% overall hull integrity will fail; not yours.  Your baby will hold together until 25% hull integrity. </Description>
       <PassengerModifier>2</PassengerModifier>
-    </RacialTrait>
-    <RacialTrait>
-      <TraitName>Eagle-Eye</TraitName>
+    </RacialTraitOption>
+    <RacialTraitOption>
+      <TraitIndex>Eagle-Eye</TraitIndex>
       <Category>Adventure</Category>
       <Cost>3</Cost>
       <Description>You could shoot a credit off of a sensor mast at 1000 clicks.  Gain a +15% damage bonus with all weapons. </Description>
       <PassengerModifier>2</PassengerModifier>
-    </RacialTrait>
-    <RacialTrait>
-      <TraitName>Charming</TraitName>
+    </RacialTraitOption>
+    <RacialTraitOption>
+      <TraitIndex>Charming</TraitIndex>
       <Category>Adventure</Category>
       <Cost>2</Cost>
       <Description>Your good looks and charming personality gives you an edge when dealing with factions, earning a starting bonus of +20. </Description>
       <PassengerModifier>2</PassengerModifier>
-    </RacialTrait>
-    <RacialTrait>
-      <TraitName>Rogue</TraitName>
+    </RacialTraitOption>
+    <RacialTraitOption>
+      <TraitIndex>Rogue</TraitIndex>
       <Category>Adventure</Category>
       <Cost>2</Cost>
       <Description>You would swindle an old lady out of her last credit, and in fact have done so on two separate occasions.  +20% credits gain from looting. </Description>
       <PassengerModifier>2</PassengerModifier>
-    </RacialTrait>
-    -->
-
+    </RacialTraitOption>    -->
 </TraitList>
 </RacialTraits>

--- a/game/Content/RacialTraits/RacialTraits.xml
+++ b/game/Content/RacialTraits/RacialTraits.xml
@@ -431,6 +431,16 @@
 	  <EnvSwampMultiplier>1.75</EnvSwampMultiplier>
 	  <EnvDesertMultiplier>0.5</EnvDesertMultiplier>
 	  <EnvIceMultiplier>0.75</EnvIceMultiplier>
+	  <Excludes>
+		<string>Terran Homeworld</string>
+		<string>Oceanic Homeworld</string>
+		<string>Steppe Homeworld</string>
+		<string>Tundra Homeworld</string>
+		<string>Swamp Homeworld</string>
+		<string>Desert Homeworld</string>
+		<string>Ice Homeworld</string>
+		<string>Terran Homeworld</string>
+	  </Excludes>
     </RacialTraitOption>	
     <RacialTraitOption>
       <!-- Explorers -->
@@ -441,6 +451,139 @@
       <Description>4985</Description>
 	  <ExploreDistanceMultiplier>2</ExploreDistanceMultiplier>
     </RacialTraitOption>
+    <RacialTraitOption>
+	  <!-- Terran Homeworld -->
+	  <TraitName>Terran Homeworld</TraitName>
+	  <TraitIndex>4970</TraitIndex>
+	  <Category>Environment</Category>
+	  <Cost>2</Cost>
+	  <Description>4971</Description>
+	  <PreferredEnv>Terran</PreferredEnv>  
+	  <EnvTerranMultiplier>1.25</EnvTerranMultiplier>
+	  <Excludes>
+		<string>Oceanic Homeworld</string>
+		<string>Steppe Homeworld</string>
+		<string>Tundra Homeworld</string>
+		<string>Swamp Homeworld</string>
+		<string>Desert Homeworld</string>
+		<string>Ice Homeworld</string>
+		<string>Aquatic</string>
+	  </Excludes>
+	</RacialTraitOption>  	  	
+    <RacialTraitOption>
+	  <!-- Oceanic Homeworld -->
+	  <TraitName>Oceanic Homeworld</TraitName>
+	  <TraitIndex>4972</TraitIndex>
+	  <Category>Environment</Category>
+	  <Cost>2</Cost>
+	  <Description>4973</Description>
+	  <PreferredEnv>Oceanic</PreferredEnv>  
+	  <EnvOceanicMultiplier>1.25</EnvOceanicMultiplier>
+	  <Excludes>
+		<string>Terran Homeworld</string>
+		<string>Steppe Homeworld</string>
+		<string>Tundra Homeworld</string>
+		<string>Swamp Homeworld</string>
+		<string>Desert Homeworld</string>
+		<string>Ice Homeworld</string>
+		<string>Aquatic</string>	  
+	  </Excludes>
+	</RacialTraitOption>  	  		
+    <RacialTraitOption>
+	  <!-- Steppe Homeworld -->
+	  <TraitName>Steppe Homeworld</TraitName>
+	  <TraitIndex>4974</TraitIndex>
+	  <Category>Environment</Category>
+	  <Cost>2</Cost>
+	  <Description>4975</Description>
+	  <PreferredEnv>Steppe</PreferredEnv>  
+	  <EnvSteppeMultiplier>1.25</EnvSteppeMultiplier>
+	  <Excludes>
+		<string>Terran Homeworld</string>
+		<string>Oceanic Homeworld</string>
+		<string>Tundra Homeworld</string>
+		<string>Swamp Homeworld</string>
+		<string>Desert Homeworld</string>
+		<string>Ice Homeworld</string>
+		<string>Aquatic</string>	  
+	  </Excludes>
+	</RacialTraitOption>  		
+    <RacialTraitOption>
+	  <!-- Tundra Homeworld -->
+	  <TraitName>Tundra Homeworld</TraitName>
+	  <TraitIndex>4976</TraitIndex>
+	  <Category>Environment</Category>
+	  <Cost>2</Cost>
+	  <Description>4977</Description>
+	  <PreferredEnv>Tundra</PreferredEnv>  
+	  <EnvTundraMultiplier>1.25</EnvTundraMultiplier>
+	  <Excludes>
+		<string>Terran Homeworld</string>
+		<string>Oceanic Homeworld</string>
+		<string>Steppe Homeworld</string>
+		<string>Swamp Homeworld</string>
+		<string>Desert Homeworld</string>
+		<string>Ice Homeworld</string>
+		<string>Aquatic</string>	  
+	  </Excludes>
+	</RacialTraitOption>  			
+    <RacialTraitOption>
+	  <!-- Swamp Homeworld -->
+	  <TraitName>Swamp Homeworld</TraitName>
+	  <TraitIndex>4978</TraitIndex>
+	  <Category>Environment</Category>
+	  <Cost>2</Cost>
+	  <Description>4979</Description>
+	  <PreferredEnv>Swamp</PreferredEnv>  
+	  <EnvSwampMultiplier>1.25</EnvSwampMultiplier>
+	  <Excludes>
+		<string>Terran Homeworld</string>
+		<string>Oceanic Homeworld</string>
+		<string>Steppe Homeworld</string>
+		<string>Tundra Homeworld</string>
+		<string>Desert Homeworld</string>
+		<string>Ice Homeworld</string>
+		<string>Aquatic</string>	  
+	  </Excludes>
+	</RacialTraitOption> 	
+    <RacialTraitOption>
+	  <!-- Desert Homeworld -->
+	  <TraitName>Desert Homeworld</TraitName>
+	  <TraitIndex>4980</TraitIndex>
+	  <Category>Environment</Category>
+	  <Cost>2</Cost>
+	  <Description>4981</Description>
+	  <PreferredEnv>Desert</PreferredEnv>  
+	  <EnvDesertMultiplier>1.25</EnvDesertMultiplier>
+	  <Excludes>
+		<string>Terran Homeworld</string>
+		<string>Oceanic Homeworld</string>
+		<string>Steppe Homeworld</string>
+		<string>Tundra Homeworld</string>
+		<string>Swamp Homeworld</string>
+		<string>Ice Homeworld</string>
+		<string>Aquatic</string>	  
+	  </Excludes>
+	</RacialTraitOption> 		
+    <RacialTraitOption>
+	  <!-- Ice Homeworld -->
+	  <TraitName>Ice Homeworld</TraitName>
+	  <TraitIndex>4982</TraitIndex>
+	  <Category>Environment</Category>
+	  <Cost>2</Cost>
+	  <Description>4983</Description>
+	  <PreferredEnv>Ice</PreferredEnv>  
+	  <EnvIceMultiplier>1.25</EnvIceMultiplier>
+	  <Excludes>
+		<string>Terran Homeworld</string>
+		<string>Oceanic Homeworld</string>
+		<string>Steppe Homeworld</string>
+		<string>Tundra Homeworld</string>
+		<string>Swamp Homeworld</string>
+		<string>Desert Homeworld</string>
+		<string>Aquatic</string>	  
+	  </Excludes>
+	</RacialTraitOption> 		
 
 	
     <!-- Adventure Mode Traits

--- a/game/Content/RacialTraits/RacialTraits.xml
+++ b/game/Content/RacialTraits/RacialTraits.xml
@@ -417,12 +417,12 @@
     </RacialTraitOption>
     <RacialTraitOption>
       <!-- Aquatic -->
-	  <TraitName>Environment</TraitName>
+	  <TraitName>Aquatic</TraitName>
       <TraitIndex>4986</TraitIndex>
       <Category>Environment</Category>
       <Cost>2</Cost>
       <Description>4987</Description>
-	  <Aquatic>1</Aquatic>
+	  <Aquatic>1</Aquatic> <!-- This only changes the race description -->
 	  <EnvTerranMultiplier>1.5</EnvTerranMultiplier>
    	  <EnvOceanicMultiplier>2</EnvOceanicMultiplier>
 	  <EnvSteppeMultiplier>1</EnvSteppeMultiplier>

--- a/game/Content/RacialTraits/RacialTraits.xml
+++ b/game/Content/RacialTraits/RacialTraits.xml
@@ -47,7 +47,7 @@
     <Description>39</Description>
     <PopGrowthMax>0.015</PopGrowthMax>
     <Excludes>
-		<string>Less Fertile</string>
+		<string>Fertile</string>
 	</Excludes>
   </RacialTraitOption>
   <RacialTraitOption>

--- a/game/Content/RacialTraits/RacialTraits.xml
+++ b/game/Content/RacialTraits/RacialTraits.xml
@@ -584,6 +584,30 @@
 		<string>Aquatic</string>	  
 	  </Excludes>
 	</RacialTraitOption> 		
+    <RacialTraitOption>
+	  <!-- Salvagers -->
+	  <TraitName>Salvagers</TraitName>
+	  <TraitIndex>4966</TraitIndex>
+	  <Category>HistoryAndTradition</Category>
+	  <Cost>1</Cost>
+	  <Description>4967</Description>
+	  <CreditsPerKilledSlot>0.05</CreditsPerKilledSlot>
+	  <Excludes>
+		<string>Compensation Plan</string>
+	  </Excludes>
+	</RacialTraitOption> 			
+    <RacialTraitOption>
+	  <!-- Battle Casualty Compensation Plan -->
+	  <TraitName>Compensation Plan</TraitName>
+	  <TraitIndex>4968</TraitIndex>
+	  <Category>HistoryAndTradition</Category>
+	  <Cost>-1</Cost>
+	  <Description>4969</Description>
+	  <PenaltyPerKilledSlot>0.05</PenaltyPerKilledSlot>
+	  <Excludes>
+		<string>Salvagers</string>
+	  </Excludes>
+	</RacialTraitOption>			
 
 	
     <!-- Adventure Mode Traits

--- a/game/Mods/ExampleMod/Globals.yaml
+++ b/game/Mods/ExampleMod/Globals.yaml
@@ -57,6 +57,7 @@ Globals:
   Mod:
     Name: "ExampleMod" # this is the unique name id of this mod, don't change it after releasing the mod
     Version: "0.1"
+    FormatVersion: 1
     SupportedBlackBoxVersions: "develop,mars-1.41"
     IconPath: mod_icon.png
     Description: "Example Mod Setup"


### PR DESCRIPTION
Refactor the Racial Trait system.
Added new traits.
Trait description now show why you cannot select them.
Allow creating traits which change environment preferences of race.
Allow multiple trait exclusions.
Use text trait names  defined by the modder for trait exclusions, instead of index numbers.
Battle Reflexes trait now affect all weapons and not just cannons.
Homeworlds are created based on env preferences of the race traits and overrides data in custom systems
Save/Load race now should work.
Do not show non compatible race saves in the load list (based on save game version spin)
Block incompatible mod load based also on data format
Add personality and economic trait selection as weights instead of excluded (for modders).