### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/Data/RacialTrait.cs
+++ b/Ship_Game/Data/RacialTrait.cs
@@ -6,6 +6,7 @@ using Ship_Game.Data.Serialization;
 using Ship_Game.Data;
 using System;
 using SDUtils;
+using Ship_Game.Utils;
 
 namespace Ship_Game
 {
@@ -35,8 +36,8 @@ namespace Ship_Game
         [StarData] public float R;
         [StarData] public float G;
         [StarData] public float B;
-        
-            // RacialTraits.xml
+
+        // RacialTraits.xml
         [StarData] public int TraitIndex;
         [StarData] public string TraitName;
         [XmlIgnore] public LocalizedText LocalizedName => new(TraitIndex);
@@ -103,7 +104,8 @@ namespace Ship_Game
         [StarData] public bool Assimilators;
         [StarData] public float PassengerModifier = 1f;
 
-        [StarData] public Array<string> TraitOptions;
+        [StarData] public Array<TraitSet> TraitSets = new();
+        public Array<string> PlayerTraitOptions => TraitSets.Count > 0 ? TraitSets[0].TraitOptions : new Array<string>();
 
         // MISC wrappers
 
@@ -149,17 +151,21 @@ namespace Ship_Game
         }
 
         //Added by McShooterz: set old values from new bools
-        public void LoadTraitConstraints()
+        public void LoadTraitConstraints(bool isPlayer, RandomBase random)
         {
+            if (TraitSets.Count == 0)
+                return;
+
+            Array<string> traitOptions = isPlayer ? PlayerTraitOptions : random.Item(TraitSets).TraitOptions; 
             var traits = ResourceManager.RaceTraits;
             if (traits.TraitList == null)
                 return;
 
             foreach (RacialTraitOption trait in traits.TraitList)
             {
-                if (!TraitOptions.Contains(trait.TraitName))
+                if (!traitOptions.Contains(trait.TraitName))
                     continue;
-                    
+
                 DiplomacyMod += trait.DiplomacyMod;
                 TargetingModifier += trait.TargetingModifier;
                 ConsumptionModifier += trait.ConsumptionModifier;
@@ -211,5 +217,13 @@ namespace Ship_Game
         {
             if (Pack > 0) ship.UpdatePackDamageModifier();
         }
+
     }
+
+    [StarDataType]
+    public class TraitSet
+    {
+        [StarData] public Array<string> TraitOptions;
+    }
+
 }

--- a/Ship_Game/GameObject.cs
+++ b/Ship_Game/GameObject.cs
@@ -136,6 +136,11 @@ namespace Ship_Game
             return Vector2.Zero;
         }
 
+        public virtual float DodgeMultiplier()
+        {
+            return 1;
+        }
+
         public virtual void OnDamageInflicted(ShipModule victim, float damage)
         {
         }

--- a/Ship_Game/GameScreens/NewGame/EnvPreferencesPanel.cs
+++ b/Ship_Game/GameScreens/NewGame/EnvPreferencesPanel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Ship_Game.UI;
 using Microsoft.Xna.Framework.Graphics;
 using SDGraphics;
 using SDUtils;
@@ -106,6 +105,7 @@ namespace Ship_Game.GameScreens.NewGame
 
         void UpdateVisibility()
         {
+            bool wasVisibile = Visible;
             Visible = PreferredEnv != PlanetCategory.Terran
                 || EnvTerran != 1
                 || EnvOceanic != 1
@@ -116,6 +116,9 @@ namespace Ship_Game.GameScreens.NewGame
                 || EnvIce != 1
                 || EnvBarren != 1
                 || EnvVolcanic != 1;
+
+            if (!wasVisibile && Visible)
+                SlideInFromOffset(offset: new(-Width, 0), Screen.TransitionOffTime);
         }
 
         void UpdatePlanetIcon()

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
@@ -76,7 +76,12 @@ namespace Ship_Game
             t.Name      = RaceName;
             t.ShipType  = SelectedData.ShipType;
             t.VideoPath = SelectedData.VideoPath;
-            t.TraitOptions = AllTraits.FilterSelect(trait => trait.Selected, trait => trait.Trait.TraitName).ToArrayList();
+
+            Array<string> traitOptions = AllTraits.FilterSelect(trait => trait.Selected, trait => trait.Trait.TraitName).ToArrayList();
+            TraitSet traitset = new TraitSet();
+            traitset.TraitOptions = traitOptions;
+            t.TraitSets.Add(traitset);
+            t.TraitSets[0].TraitOptions = AllTraits.FilterSelect(trait => trait.Selected, trait => trait.Trait.TraitName).ToArrayList();
             return t;
         }
         

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
@@ -204,7 +204,7 @@ namespace Ship_Game
             {
                 traitEntry.Selected = false;
                 RacialTraitOption tEnt = traitEntry.Trait;
-                if (traits.TraitOptions.Contains(tEnt.TraitName))
+                if (traits.PlayerTraitOptions.Contains(tEnt.TraitName))
                 {
                     traitEntry.Selected = true;
                     TotalPointsUsed -= tEnt.Cost;

--- a/Ship_Game/Gameplay/Weapon.cs
+++ b/Ship_Game/Gameplay/Weapon.cs
@@ -312,6 +312,7 @@ namespace Ship_Game.Gameplay
             if (target != null)
             {
                 error += target.JammingError(); // if target has ECM, they can scramble their position
+                error *= target.DodgeMultiplier();
             }
             return error;
         }

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -15,7 +15,6 @@ using SDUtils;
 using Ship_Game.Data.Serialization;
 using Ship_Game.ExtensionMethods;
 using Rectangle = SDGraphics.Rectangle;
-using Ship_Game.Commands.Goals;
 
 namespace Ship_Game.Ships
 {
@@ -569,10 +568,12 @@ namespace Ship_Game.Ships
             if (ECMValue > 0)
                 error += Loyalty.Random.Vector2D(ECMValue * 80f);
 
-            if (Loyalty.data.Traits.DodgeMod > 0)
-                error += Loyalty.Random.Vector2D(Loyalty.data.Traits.DodgeMod * 80f);
-
             return error;
+        }
+
+        public override float DodgeMultiplier()
+        {
+            return 1 + Loyalty.data.Traits.DodgeMod;
         }
 
         public bool IsHangarShip   => Mothership != null;

--- a/Ship_Game/Universe/UniverseState_Empires.cs
+++ b/Ship_Game/Universe/UniverseState_Empires.cs
@@ -288,7 +288,7 @@ public partial class UniverseState
         data.EconomicPersonality = CreateEconimicTrait();
 
         // Added by McShooterz: set values for alternate race file structure
-        data.Traits.LoadTraitConstraints();
+        data.Traits.LoadTraitConstraints(isPlayer, Random);
         empire.dd = ResourceManager.GetDiplomacyDialog(data.DiplomacyDialogPath);
         data.SpyModifier = data.Traits.SpyMultiplier;
         data.Traits = data.Traits;

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -10451,43 +10451,43 @@ TraitTerranHomeworldName:
   ENG: "Terran Homeworld"   
 TraitTerranHomeworldDesc:
   Id: 4971
-  ENG: "Your empire starts in a Terran homeworld and gets +25% Fertility and Max Population for other Terran worlds."      
+  ENG: "Your empire starts in a Terran homeworld and gets +50% Fertility and Max Population for other Terran worlds."      
 TraitOceanicHomeworldName:
   Id: 4972
   ENG: "Oceanic Homeworld"   
 TraitOceanicHomeworldDesc:
   Id: 4973
-  ENG: "Your empire starts in an Oceanic homeworld and gets +25% Fertility and Max Population for other Oceanic worlds."      
+  ENG: "Your empire starts in an Oceanic homeworld and gets +50% Fertility and Max Population for other Oceanic worlds."      
 TraitSteppeHomeworldName:
   Id: 4974
   ENG: "Steppe Homeworld"   
 TraitSteppeHomeworldDesc:
   Id: 4975
-  ENG: "Your empire starts in a Steppe homeworld and gets +25% Fertility and Max Population for other Steppe worlds."      
+  ENG: "Your empire starts in a Steppe homeworld and gets +50% Fertility and Max Population for other Steppe worlds."      
 TraitTundraHomeworldName:
   Id: 4976
   ENG: "Tundra Homeworld"   
 TraitTundraHomeworldDesc:
   Id: 4977
-  ENG: "Your empire starts in a Tuntra homeworld and gets +25% Fertility and Max Population for other Tundra worlds."      
+  ENG: "Your empire starts in a Tuntra homeworld and gets +50% Fertility and Max Population for other Tundra worlds."      
 TraitSwampHomeworldName:
   Id: 4978
   ENG: "Swamp Homeworld"   
 TraitSwampHomeworldDesc:
   Id: 4979
-  ENG: "Your empire starts in a Swamp homeworld and gets +25% Fertility and Max Population for other Swamp worlds."      
+  ENG: "Your empire starts in a Swamp homeworld and gets +50% Fertility and Max Population for other Swamp worlds."      
 TraitDesertHomeworldName:
   Id: 4980
   ENG: "Desert Homeworld"   
 TraitDesertHomeworldDesc:
   Id: 4981
-  ENG: "Your empire starts in a Desert homeworld and gets +25% Fertility and Max Population for other Desert worlds."      
+  ENG: "Your empire starts in a Desert homeworld and gets +50% Fertility and Max Population for other Desert worlds."      
 TraitIceHomeworldName:
   Id: 4982
   ENG: "Ice Homeworld"   
 TraitIceHomeworldDesc:
   Id: 4983
-  ENG: "Your empire starts in an Ice homeworld and gets +25% Fertility and Max Population for other Ice worlds."      
+  ENG: "Your empire starts in an Ice homeworld and gets +50% Fertility and Max Population for other Ice worlds."      
 TraitExplorers_Name: 
  Id: 4984
  ENG: "Explorers"

--- a/game/Content/Races/Cordrazine.xml
+++ b/game/Content/Races/Cordrazine.xml
@@ -28,7 +28,6 @@
   <ThrustColor1R>34</ThrustColor1R>
   <ThrustColor1G>139</ThrustColor1G>
   <ThrustColor1B>34</ThrustColor1B>      
-
   <Traits>
     <Name>Cordrazine Collective</Name>
     <Singular>Cordrazine</Singular>
@@ -43,19 +42,20 @@
     <R>255</R>
     <G>242</G>
     <B>0</B>
-    <RaceDescription>KWAK!</RaceDescription>
-    <Cost>0</Cost>
-	<TraitOptions>
-		<string>Huge Homeworld</string>
-		<string>Alluring</string>
-		<string>Less Fertile</string>
-		<string>Efficient Metabolism</string>
-		<string>Timid</string>
-		<string>Prototype Flagship</string>
-		<string>Skilled Engineers</string>		
-		<string>Ponderous</string>
-		<string>Efficient</string>
-	</TraitOptions>	
+	<TraitSets>
+		<TraitSet>
+			<TraitOptions>
+				<string>Huge Homeworld</string>
+				<string>Alluring</string>
+				<string>Less Fertile</string>
+				<string>Efficient Metabolism</string>
+				<string>Timid</string>
+				<string>Prototype Flagship</string>
+				<string>Skilled Engineers</string>		
+				<string>Ponderous</string>
+				<string>Efficient</string>
+			</TraitOptions>	
+		</TraitSet>
+	</TraitSets>			
   </Traits>
-  <Faction>0</Faction>
 </EmpireData>

--- a/game/Content/Races/Cordrazine.xml
+++ b/game/Content/Races/Cordrazine.xml
@@ -42,7 +42,7 @@
     <R>255</R>
     <G>242</G>
     <B>0</B>
-	<TraitSets>
+	<TraitSets> <!-- The first trait set is what the player sees. Other sets are extra sets randomized for the AI -->
 		<TraitSet>
 			<TraitOptions>
 				<string>Huge Homeworld</string>

--- a/game/Content/Races/Corsairs.xml
+++ b/game/Content/Races/Corsairs.xml
@@ -24,19 +24,6 @@
   <PirateStationImproved>Corsair Station-Mk2</PirateStationImproved>
   <PirateStationAdvanced>Corsair Station-Mk3</PirateStationAdvanced>
   <PirateFlagShip>Corsair Flagship</PirateFlagShip>
-  <!-- Fertility multipliers for environments. The default is 1 in the code, but the tags are included here for reference -->
-  <EnvTerran>1</EnvTerran>
-  <EnvOceanic>1</EnvOceanic>
-  <EnvSteppe>1</EnvSteppe>
-  <EnvTundra>1</EnvTundra>
-  <EnvSwamp>1</EnvSwamp>
-  <EnvDesert>1</EnvDesert>
-  <EnvIce>1</EnvIce>
-  <EnvBarren>1</EnvBarren>
-  <EnvVolcanic>1</EnvVolcanic>
-  <PreferredEnv>Terran</PreferredEnv>
-  <!-- Terraformers will terraform a planet to this environment -->
-
   <Traits>
     <Name>Corsairs</Name>
     <Singular>Corsair</Singular>
@@ -48,8 +35,5 @@
     <R>247</R>
     <G>148</G>
     <B>29</B>
-    <RaceDescription>Mighty Pirates</RaceDescription>
-    <Cost>0</Cost>
-	<TraitOptions></TraitOptions>
   </Traits>
 </EmpireData>

--- a/game/Content/Races/Draugar.xml
+++ b/game/Content/Races/Draugar.xml
@@ -24,19 +24,6 @@
   <PirateStationImproved>Draug Station-Mk2</PirateStationImproved>
   <PirateStationAdvanced>Draug Station-Mk3</PirateStationAdvanced>
   <PirateFlagShip>Draug Flagship</PirateFlagShip>
-  <!-- Fertility multipliers for environments. The default is 1 in the code, but the tags are included here for reference -->
-  <EnvTerran>1</EnvTerran>
-  <EnvOceanic>1</EnvOceanic>
-  <EnvSteppe>1</EnvSteppe>
-  <EnvTundra>1</EnvTundra>
-  <EnvSwamp>1</EnvSwamp>
-  <EnvDesert>1</EnvDesert>
-  <EnvIce>1</EnvIce>
-  <EnvBarren>1</EnvBarren>
-  <EnvVolcanic>1</EnvVolcanic>
-  <PreferredEnv>Terran</PreferredEnv>
-  <!-- Terraformers will terraform a planet to this environment -->
-
   <Traits>
     <Name>Draugar</Name>
     <Singular>Draug</Singular>
@@ -48,8 +35,5 @@
     <R>4</R>
     <G>0</G>
     <B>253</B>
-    <RaceDescription>Deadly Pirates</RaceDescription>
-    <Cost>0</Cost>
-	<TraitOptions></TraitOptions>
   </Traits>
 </EmpireData>

--- a/game/Content/Races/Draylok.xml
+++ b/game/Content/Races/Draylok.xml
@@ -30,8 +30,6 @@
   <ThrustColor1R>245</ThrustColor1R>
   <ThrustColor1G>245</ThrustColor1G>
   <ThrustColor1B>245</ThrustColor1B>     
-
-
   <Traits>
     <Name>The Draylok Council</Name>
     <Singular>Draylok</Singular>
@@ -46,15 +44,16 @@
     <R>146</R>
     <G>39</G>
     <B>143</B>
-    <RaceDescription>Deprecated </RaceDescription>
-    <Cost>0</Cost>
-	<TraitOptions>
-		<string>Smart</string>
-		<string>Corrupt</string>
-		<string>Mercantile</string>
-		<string>Alluring</string>
-		<string>Duplicitous</string>
-	</TraitOptions>	
+	<TraitSets>
+		<TraitSet>
+			<TraitOptions>
+				<string>Smart</string>
+				<string>Corrupt</string>
+				<string>Mercantile</string>
+				<string>Alluring</string>
+				<string>Duplicitous</string>
+			</TraitOptions>			
+		</TraitSet>
+	</TraitSets>	
   </Traits>
-  <Faction>0</Faction>
 </EmpireData>

--- a/game/Content/Races/Draylok.xml
+++ b/game/Content/Races/Draylok.xml
@@ -44,7 +44,7 @@
     <R>146</R>
     <G>39</G>
     <B>143</B>
-	<TraitSets>
+	<TraitSets> <!-- The first trait set is what the player sees. Other sets are extra sets randomized for the AI -->
 		<TraitSet>
 			<TraitOptions>
 				<string>Smart</string>

--- a/game/Content/Races/Human.xml
+++ b/game/Content/Races/Human.xml
@@ -59,16 +59,18 @@
     <R>68</R>
     <G>140</G>
     <B>203</B>
-    <RaceDescription>The United Federation is an expasionist republic with a strong emphasis on scientific and military power.  Humans are somewhat xenophobic, and they can be slow to trust other empires while also being quick to make war.    </RaceDescription>
-	<TraitOptions>
-		<string>Prototype Flagship</string>
-		<string>Militaristic</string>
-		<string>Astronomers</string>
-		<string>Huge Homeworld</string>
-		<string>Polluted Homeworld</string>
-		<string>Corrupt</string>
-		<string>Industrious</string>
-	</TraitOptions>		
+	<TraitSets>
+		<TraitSet>
+			<TraitOptions>
+				<string>Prototype Flagship</string>
+				<string>Militaristic</string>
+				<string>Astronomers</string>
+				<string>Huge Homeworld</string>
+				<string>Polluted Homeworld</string>
+				<string>Corrupt</string>
+				<string>Industrious</string>
+			</TraitOptions>		
+		</TraitSet>
+	</TraitSets>	
   </Traits>
-  <Faction>0</Faction>
 </EmpireData>

--- a/game/Content/Races/Human.xml
+++ b/game/Content/Races/Human.xml
@@ -59,7 +59,7 @@
     <R>68</R>
     <G>140</G>
     <B>203</B>
-	<TraitSets>
+	<TraitSets> <!-- The first trait set is what the player sees. Other sets are extra sets randomized for the AI -->
 		<TraitSet>
 			<TraitOptions>
 				<string>Prototype Flagship</string>

--- a/game/Content/Races/Kulrathi.xml
+++ b/game/Content/Races/Kulrathi.xml
@@ -60,7 +60,7 @@
     <R>201</R>
     <G>75</G>
     <B>96</B>
-	<TraitSets>
+	<TraitSets> <!-- The first trait set is what the player sees. Other sets are extra sets randomized for the AI -->
 		<TraitSet>
 			<TraitOptions>
 				<string>Prototype Flagship</string>

--- a/game/Content/Races/Kulrathi.xml
+++ b/game/Content/Races/Kulrathi.xml
@@ -60,18 +60,18 @@
     <R>201</R>
     <G>75</G>
     <B>96</B>
-    <RaceDescription>The Kulrathi are a noble and proud race who value beauty, honor, and battle. They are fiercely territorial race and they prefer personal, hand-to-hand engagements over modern weaponry. The Kulrathi make great allies and terrible enemies. </RaceDescription>
-    <Cost>0</Cost>
-	<TraitOptions>
-		<string>Prototype Flagship</string>
-		<string>Honest</string>
-		<string>Meticulous</string>
-		<string>Militaristic</string>
-		<string>Skilled Engineers</string>
-		<string>Savage</string>
-		<string>Naval Tradition</string>
-	</TraitOptions>	
-    <ShipCostMod>-0.35</ShipCostMod>
+	<TraitSets>
+		<TraitSet>
+			<TraitOptions>
+				<string>Prototype Flagship</string>
+				<string>Honest</string>
+				<string>Meticulous</string>
+				<string>Militaristic</string>
+				<string>Skilled Engineers</string>
+				<string>Savage</string>
+				<string>Naval Tradition</string>
+			</TraitOptions>	
+			</TraitSet>
+	</TraitSets>
   </Traits>
-  <Faction>0</Faction>
 </EmpireData>

--- a/game/Content/Races/Opteris.xml
+++ b/game/Content/Races/Opteris.xml
@@ -75,23 +75,24 @@
     <R>90</R>
     <G>87</G>
     <B>51</B>
-    <RaceDescription>bzzz!</RaceDescription>
-    <Cost>0</Cost>
-	<TraitOptions>
-		<string>Efficient Metabolism</string>
-		<string>Fertile</string>
-		<string>Timid</string>
-		<string>Militaristic</string>
-		<string>Small Homeworld</string>
-		<string>Polluted Homeworld</string>
-		<string>Blind</string>
-		<string>Industrious</string>
-		<string>Corrupt</string>
-		<string>Industrialized Homeworld</string>
-		<string>Cybernetic</string>
-		<string>Prototype Flagship</string>
-		<string>Honest</string>
-	</TraitOptions>	
+	<TraitSets>
+		<TraitSet>
+			<TraitOptions>
+				<string>Efficient Metabolism</string>
+				<string>Fertile</string>
+				<string>Timid</string>
+				<string>Militaristic</string>
+				<string>Small Homeworld</string>
+				<string>Polluted Homeworld</string>
+				<string>Blind</string>
+				<string>Industrious</string>
+				<string>Corrupt</string>
+				<string>Industrialized Homeworld</string>
+				<string>Cybernetic</string>
+				<string>Prototype Flagship</string>
+				<string>Honest</string>
+			</TraitOptions>	
+		</TraitSet>
+	</TraitSets>	
   </Traits>
-  <Faction>0</Faction>
 </EmpireData>

--- a/game/Content/Races/Opteris.xml
+++ b/game/Content/Races/Opteris.xml
@@ -75,7 +75,7 @@
     <R>90</R>
     <G>87</G>
     <B>51</B>
-	<TraitSets>
+	<TraitSets> <!-- The first trait set is what the player sees. Other sets are extra sets randomized for the AI -->
 		<TraitSet>
 			<TraitOptions>
 				<string>Efficient Metabolism</string>

--- a/game/Content/Races/Pollops.xml
+++ b/game/Content/Races/Pollops.xml
@@ -77,7 +77,7 @@
     <R>0</R>
     <G>175</G>
     <B>0</B>
-	<TraitSets>
+	<TraitSets> <!-- The first trait set is what the player sees. Other sets are extra sets randomized for the AI -->
 		<TraitSet>
 			<TraitOptions>
 				<string>Manifest Destiny</string>

--- a/game/Content/Races/Pollops.xml
+++ b/game/Content/Races/Pollops.xml
@@ -77,17 +77,18 @@
     <R>0</R>
     <G>175</G>
     <B>0</B>
-    <RaceDescription>Pollops are a peculiar race of mobile plant-like organisms. Though physically weak, they grow at a rapid pace and have long lifespans. Pollops tend to be quite friendly.</RaceDescription>
-    <Cost>0</Cost>
-	<TraitOptions>
-		<string>Manifest Destiny</string>
-		<string>Timid</string>
-		<string>Efficient</string>
-		<string>Fertile</string>
-		<string>Efficient Metabolism</string>
-		<string>Reflexes</string>
-		<string>Lazy</string>
-	</TraitOptions>
+	<TraitSets>
+		<TraitSet>
+			<TraitOptions>
+				<string>Manifest Destiny</string>
+				<string>Timid</string>
+				<string>Efficient</string>
+				<string>Fertile</string>
+				<string>Efficient Metabolism</string>
+				<string>Reflexes</string>
+				<string>Lazy</string>
+			</TraitOptions>
+		</TraitSet>
+	</TraitSets>	
   </Traits>
-  <Faction>0</Faction>
 </EmpireData>

--- a/game/Content/Races/Ralyeh.xml
+++ b/game/Content/Races/Ralyeh.xml
@@ -53,19 +53,20 @@
     <R>255</R>
     <G>242</G>
     <B>253</B>
-    <RaceDescription>KWAK!</RaceDescription>
-    <Cost>0</Cost>
-	<TraitOptions>
-		<string>Gluttonous</string>
-		<string>Fertile</string>
-		<string>Huge Homeworld</string>
-		<string>Lazy</string>
-		<string>Skilled Engineers</string>
-		<string>Spiritual</string>
-		<string>Manifest Destiny</string>
-		<string>Prototype Flagship</string>
-		<string>Astronomers</string>
-	</TraitOptions>
+	<TraitSets>
+		<TraitSet>
+			<TraitOptions>
+				<string>Gluttonous</string>
+				<string>Fertile</string>
+				<string>Huge Homeworld</string>
+				<string>Lazy</string>
+				<string>Skilled Engineers</string>
+				<string>Spiritual</string>
+				<string>Manifest Destiny</string>
+				<string>Prototype Flagship</string>
+				<string>Astronomers</string>
+			</TraitOptions>
+		</TraitSet>
+	</TraitSets>	
   </Traits>
-  <Faction>0</Faction>
 </EmpireData>

--- a/game/Content/Races/Ralyeh.xml
+++ b/game/Content/Races/Ralyeh.xml
@@ -53,7 +53,7 @@
     <R>255</R>
     <G>242</G>
     <B>253</B>
-	<TraitSets>
+	<TraitSets> <!-- The first trait set is what the player sees. Other sets are extra sets randomized for the AI -->
 		<TraitSet>
 			<TraitOptions>
 				<string>Gluttonous</string>

--- a/game/Content/Races/Remnant.xml
+++ b/game/Content/Races/Remnant.xml
@@ -51,12 +51,5 @@
     <R>91</R>
     <G>195</G>
     <B>91</B>
-    <RaceDescription>The Remnant is an empire comprised of Remnant. Remnant are a race of terrestrial beings with a moderate reproductive rate and unremarkable dietary needs. Physically, Remnant have no particular strengths or weaknesses. Remnant possess an average intelligence for a starfaring race. 
- 
-Remnant government is functional but unremarkable while society at large is neither overly efficient nor wasteful. Remnant are not particularly industrious or lazy but their engineers are competent although not especially noteworthy for any strengths or shortcomings. 
- 
-The Remnant homeworld of Earth is of an average size for a terran planet. </RaceDescription>
-    <Cost>0</Cost>
-	<TraitOptions></TraitOptions>
   </Traits>
 </EmpireData>

--- a/game/Content/Races/Revoran.xml
+++ b/game/Content/Races/Revoran.xml
@@ -14,8 +14,5 @@
     <R>255</R>
     <G>242</G>
     <B>0</B>
-
-    <Cost>0</Cost>
-	<TraitOptions></TraitOptions>
   </Traits>
 </EmpireData>

--- a/game/Content/Races/Unknown.xml
+++ b/game/Content/Races/Unknown.xml
@@ -15,6 +15,5 @@
     <G>137</G>
     <B>137</B>
     <Cost>0</Cost>
-	<TraitOptions></TraitOptions>
   </Traits>
 </EmpireData>

--- a/game/Content/Races/Vulfen.xml
+++ b/game/Content/Races/Vulfen.xml
@@ -74,7 +74,7 @@
     <R>255</R>
     <G>0</G>
     <B>0</B>
-	<TraitSets>
+	<TraitSets> <!-- The first trait set is what the player sees. Other sets are extra sets randomized for the AI -->
 		<TraitSet>
 			<TraitOptions>
 				<string>Pack</string>

--- a/game/Content/Races/Vulfen.xml
+++ b/game/Content/Races/Vulfen.xml
@@ -74,21 +74,22 @@
     <R>255</R>
     <G>0</G>
     <B>0</B>
-    <RaceDescription>The Vulfen Imperium believes in the superiority of the Vulfen race. They are an aggressive an industrialist race preferring strength through numbers in their many and varied conflicts. </RaceDescription>
-    <Cost>0</Cost>
-	<TraitOptions>
-		<string>Pack</string>
-		<string>Prototype Flagship</string>
-		<string>Militaristic</string>
-    	<string>Haphazard Engineers</string>
-		<string>Naval Tradition</string>
-		<string>Efficient</string>
-		<string>Dumb</string>
-		<string>Ponderous</string>
-		<string>Repulsive</string>
-		<string>Eagle Eyed</string>
-		<string>Industrious</string>		
-	</TraitOptions>	
+	<TraitSets>
+		<TraitSet>
+			<TraitOptions>
+				<string>Pack</string>
+				<string>Prototype Flagship</string>
+				<string>Militaristic</string>
+				<string>Haphazard Engineers</string>
+				<string>Naval Tradition</string>
+				<string>Efficient</string>
+				<string>Dumb</string>
+				<string>Ponderous</string>
+				<string>Repulsive</string>
+				<string>Eagle Eyed</string>
+				<string>Industrious</string>		
+			</TraitOptions>	
+		</TraitSet>
+	</TraitSets>	
   </Traits>
-  <Faction>0</Faction>
 </EmpireData>

--- a/game/Content/RacialTraits/RacialTraits.xml
+++ b/game/Content/RacialTraits/RacialTraits.xml
@@ -459,7 +459,7 @@
 	  <Cost>2</Cost>
 	  <Description>4971</Description>
 	  <PreferredEnv>Terran</PreferredEnv>  
-	  <EnvTerranMultiplier>1.25</EnvTerranMultiplier>
+	  <EnvTerranMultiplier>1.5</EnvTerranMultiplier>
 	  <Excludes>
 		<string>Oceanic Homeworld</string>
 		<string>Steppe Homeworld</string>
@@ -478,7 +478,7 @@
 	  <Cost>2</Cost>
 	  <Description>4973</Description>
 	  <PreferredEnv>Oceanic</PreferredEnv>  
-	  <EnvOceanicMultiplier>1.25</EnvOceanicMultiplier>
+	  <EnvOceanicMultiplier>1.5</EnvOceanicMultiplier>
 	  <Excludes>
 		<string>Terran Homeworld</string>
 		<string>Steppe Homeworld</string>
@@ -497,7 +497,7 @@
 	  <Cost>2</Cost>
 	  <Description>4975</Description>
 	  <PreferredEnv>Steppe</PreferredEnv>  
-	  <EnvSteppeMultiplier>1.25</EnvSteppeMultiplier>
+	  <EnvSteppeMultiplier>1.5</EnvSteppeMultiplier>
 	  <Excludes>
 		<string>Terran Homeworld</string>
 		<string>Oceanic Homeworld</string>
@@ -516,7 +516,7 @@
 	  <Cost>2</Cost>
 	  <Description>4977</Description>
 	  <PreferredEnv>Tundra</PreferredEnv>  
-	  <EnvTundraMultiplier>1.25</EnvTundraMultiplier>
+	  <EnvTundraMultiplier>1.5</EnvTundraMultiplier>
 	  <Excludes>
 		<string>Terran Homeworld</string>
 		<string>Oceanic Homeworld</string>
@@ -535,7 +535,7 @@
 	  <Cost>2</Cost>
 	  <Description>4979</Description>
 	  <PreferredEnv>Swamp</PreferredEnv>  
-	  <EnvSwampMultiplier>1.25</EnvSwampMultiplier>
+	  <EnvSwampMultiplier>1.5</EnvSwampMultiplier>
 	  <Excludes>
 		<string>Terran Homeworld</string>
 		<string>Oceanic Homeworld</string>
@@ -554,7 +554,7 @@
 	  <Cost>2</Cost>
 	  <Description>4981</Description>
 	  <PreferredEnv>Desert</PreferredEnv>  
-	  <EnvDesertMultiplier>1.25</EnvDesertMultiplier>
+	  <EnvDesertMultiplier>1.5</EnvDesertMultiplier>
 	  <Excludes>
 		<string>Terran Homeworld</string>
 		<string>Oceanic Homeworld</string>
@@ -573,7 +573,7 @@
 	  <Cost>2</Cost>
 	  <Description>4983</Description>
 	  <PreferredEnv>Ice</PreferredEnv>  
-	  <EnvIceMultiplier>1.25</EnvIceMultiplier>
+	  <EnvIceMultiplier>1.5</EnvIceMultiplier>
 	  <Excludes>
 		<string>Terran Homeworld</string>
 		<string>Oceanic Homeworld</string>


### PR DESCRIPTION
Feature: Allow Modders to provide multiple trait set for each race, so AI empires would be more diverse.
Fix: Change dodge mod to work with both negative and positive traits by multiplying the error vector.