### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/AI/EmpireAI/EmpireAI.RunDiplomaticPlanner.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.RunDiplomaticPlanner.cs
@@ -39,8 +39,7 @@ namespace Ship_Game.AI
         {
             float ratio = OwnerEmpire.PersonalityModifiers.PopRatioBeforeMerge;
             var enemies =  OwnerEmpire.Universe.MajorEmpiresAtWarWith(OwnerEmpire)
-                .Filter(e => e.TotalPopBillion * ratio > OwnerEmpire.TotalPopBillion 
-                             || e.OffensiveStrength * ratio > OwnerEmpire.CurrentMilitaryStrength);
+                .Filter(e => e.TotalPopBillion * ratio > OwnerEmpire.TotalPopBillion);
 
             if (enemies.Length > 0)
             {

--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -4507,6 +4507,13 @@ namespace Ship_Game
         RandomGameMode = 4439,
         /// <summary>in Random game mode, you may win the</summary>
         InRandomGameMode = 4440,
+        /// <summary>Disable Alternate AI trait sets</summary>
+        DisableAlternateTraits = 4441,
+        /// <summary>Disable Alternate AI trait sets</summary>
+        DisableAlternateTraitsTip = 4442,
+
+
+
 
 
 

--- a/Ship_Game/Data/RacialTrait.cs
+++ b/Ship_Game/Data/RacialTrait.cs
@@ -151,12 +151,24 @@ namespace Ship_Game
         }
 
         //Added by McShooterz: set old values from new bools
-        public void LoadTraitConstraints(bool isPlayer, RandomBase random)
+        public void LoadTraitConstraints(bool isPlayer, RandomBase random, string raceName, bool disableAlternateTraits)
         {
             if (TraitSets.Count == 0)
                 return;
 
-            Array<string> traitOptions = isPlayer ? PlayerTraitOptions : random.Item(TraitSets).TraitOptions; 
+            Array<string> traitOptions = isPlayer || disableAlternateTraits 
+                ? PlayerTraitOptions 
+                : random.Item(TraitSets).TraitOptions; 
+
+            if (Log.HasDebugger)
+            {
+                string selectedTraits = string.Empty;
+                foreach (string trait in traitOptions)
+                    selectedTraits += $"{trait}, "; ;
+
+                Log.Info($"Selected traits for {raceName}: {selectedTraits}");
+            }
+
             var traits = ResourceManager.RaceTraits;
             if (traits.TraitList == null)
                 return;

--- a/Ship_Game/EmpireDifficultyModifers.cs
+++ b/Ship_Game/EmpireDifficultyModifers.cs
@@ -100,7 +100,7 @@
                     RemnantNumBombers    = 0.75f;
                     BaseColonyGoals      = 2;
                     ColonyGoalMultiplier = 0.5f;
-                    StandByColonyShips   = 2;
+                    StandByColonyShips   = 0;
                     TrustLostStoleColony = 5;
                     FleetStrModifier     = 0.2f;
                     NumSystemsToSniff    = 2;
@@ -111,12 +111,6 @@
                     HullTechMultiplier   = 1f;
                     RemnantPortalCreationMod = 10;
                     CombatShipGoalsPerPlanet = 3;
-                    if (!empire.isPlayer)
-                    {
-                        FlatMoneyBonus         = 3;
-                        PlayerWarPriorityLimit = 7;
-                    }
-
                     break;
                 case GameDifficulty.Hard:
                     ShipBuildStrMin      = 0.8f;

--- a/Ship_Game/GamePlayGlobals.cs
+++ b/Ship_Game/GamePlayGlobals.cs
@@ -24,7 +24,7 @@ public class GamePlayGlobals
     // How easy ships are to destroy. Ships which have active internal slots below this ratio, will Die()
     [StarData] public float ShipDestroyThreshold = 0.5f;
     // How tougher are remnant designs in the mod. This affects starting fleet multipliers and also increases with difficulty. Vanilla is 2
-    [StarData] public float RemnantDesignStrMultiplier; 
+    [StarData] public float RemnantDesignStrMultiplier;
     [StarData] public int CostBasedOnSizeThreshold = 2500;  // Allow tuning the change up/down
     [StarData] public float HangarCombatShipCostMultiplier = 1;
     [StarData] public float ResearchStationProductionPerResearch = 2f; // Production consumed per 1 Research point
@@ -135,3 +135,4 @@ public class GamePlayGlobals
         return settings;
     }
 }
+

--- a/Ship_Game/GameScreens/MainMenu/MainMenuScreen.cs
+++ b/Ship_Game/GameScreens/MainMenu/MainMenuScreen.cs
@@ -141,9 +141,29 @@ namespace Ship_Game.GameScreens.MainMenu
             }
         }
 
-        void NewGame_Clicked(UIButton button)   => ScreenManager.AddScreen(new RaceDesignScreen(this));
+        void NewGame_Clicked(UIButton button) 
+        {
+            if (GlobalStats.HasMod && !GlobalStats.Defaults.Mod.ModFormatSupported)
+            {
+                ScreenManager.AddScreen(new MessageBoxScreen(this, "Mod format version mismatch. " +
+                    "Please update Blackbox and this mod to latest vessions", MessageBoxButtons.Ok, 275));
+                return;
+            }
+
+            ScreenManager.AddScreen(new RaceDesignScreen(this)); 
+        }
         void Tutorials_Clicked(UIButton button) => ScreenManager.AddScreen(new TutorialScreen(this));
-        void LoadGame_Clicked(UIButton button)  => ScreenManager.AddScreen(new LoadSaveScreen(this));
+        void LoadGame_Clicked(UIButton button)
+        {
+            if (GlobalStats.HasMod && !GlobalStats.Defaults.Mod.ModFormatSupported)
+            {
+                ScreenManager.AddScreen(new MessageBoxScreen(this, "Mod format version mismatch. " +
+                    "Please update Blackbox and this mod to latest vessions", MessageBoxButtons.Ok, 275));
+                return;
+            }
+
+            ScreenManager.AddScreen(new LoadSaveScreen(this));
+        }
         void Options_Clicked(UIButton button)   => ScreenManager.AddScreen(new OptionsScreen(this));
         void Mods_Clicked(UIButton button)      => ScreenManager.AddScreen(new ModManager(this));
         void Info_Clicked(UIButton button)      => ScreenManager.AddScreen(new InGameWiki(this));

--- a/Ship_Game/GameScreens/NewGame/RuleOptionsScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RuleOptionsScreen.cs
@@ -67,7 +67,8 @@ public sealed class RuleOptionsScreen : GameScreen
         Checkbox(ftlRect.X + indent, ftlRect.Y + 25*2, () => P.AIUsesPlayerDesigns, title: GameText.UsePlayerDesignsTitle, tooltip: GameText.UsePlayerDesignsTip);
         Checkbox(ftlRect.X + indent, ftlRect.Y + 25*3, () => P.DisablePirates, title: GameText.DisablePirates, tooltip: GameText.DisablesAllPirateFactionsFor);
         Checkbox(ftlRect.X + indent, ftlRect.Y + 25*4, () => P.DisableRemnantStory, title: GameText.DisableRemnantStory, tooltip: GameText.IfCheckedRemnantForcesIn);
-        Checkbox(ftlRect.X + indent, ftlRect.Y + 25*5, () => P.UseUpkeepByHullSize, title: GameText.RuleOptionsUseHullUpkeepName, tooltip: GameText.RuleOptionsUseHullUpkeepTip);
+        Checkbox(ftlRect.X + indent, ftlRect.Y + 25*5, () => P.DisableAlternateAITraits, title: GameText.DisableAlternateTraits, tooltip: GameText.DisableAlternateTraitsTip);
+        Checkbox(ftlRect.X + indent, ftlRect.Y + 25*6, () => P.UseUpkeepByHullSize, title: GameText.RuleOptionsUseHullUpkeepName, tooltip: GameText.RuleOptionsUseHullUpkeepTip);
 
         var mdRect = new Rectangle(ftlRect.X + indent+2, ftlRect.Y + 230, 270, 50);
         CustomMineralDecay = SliderDecimal1(mdRect, GameText.MineralDecayRate, 0.2f, 3, P.CustomMineralDecay);

--- a/Ship_Game/GlobalStats.cs
+++ b/Ship_Game/GlobalStats.cs
@@ -388,7 +388,7 @@ public static class GlobalStats
 
     public static void SetActiveModNoSave(ModEntry me)
     {
-        if (me != null && me.CheckSupport(me.Mod.SupportedBlackBoxVersions, me.Mod.FormatVersion))
+        if (me != null)
         {
             ModName = me.Mod.Name;
             ModPath = me.Mod.Path;

--- a/Ship_Game/ModEntry.cs
+++ b/Ship_Game/ModEntry.cs
@@ -19,7 +19,7 @@ namespace Ship_Game
         public ModEntry(GamePlayGlobals settings)
         {
             Settings = settings;
-            IsSupported = CheckSupport(Mod.SupportedBlackBoxVersions, Mod.FormatVersion);
+            IsSupported = CheckSupport(Mod.SupportedBlackBoxVersions);
         }
 
         public SubTexture LoadPortrait(GameScreen screen)
@@ -48,7 +48,7 @@ namespace Ship_Game
 
             if (!IsSupported)
             {
-                batch.DrawString(Fonts.Arial12Bold, "Not supported on This BlackBox Version, try update this mod.", titlePos, Color.Red);
+                batch.DrawString(Fonts.Arial12Bold, "Not supported on This BlackBox Version, try updating this mod.", titlePos, Color.Red);
                 titlePos.Y += Fonts.Arial12Bold.LineSpacing + 1;
             }
 
@@ -68,9 +68,9 @@ namespace Ship_Game
             batch.DrawRectangle(portrait, Color.White);
         }
 
-        public bool CheckSupport(string supportedBbVers, int formatVersion)
+        static public bool CheckSupport(string supportedBbVers)
         {
-            if (supportedBbVers.IsEmpty() || formatVersion != FormatVersion)
+            if (supportedBbVers.IsEmpty())
                 return false;
 
             foreach (string version in supportedBbVers.Split(',')) 

--- a/Ship_Game/ModInformation.cs
+++ b/Ship_Game/ModInformation.cs
@@ -32,4 +32,7 @@ public sealed class ModInformation
     [StarData] public bool ClearVanillaTechs;
     [StarData] public bool ClearVanillaWeapons;
     [StarData] public bool DisableDefaultRaces;
+
+    public bool ModFormatSupported => FormatVersion == ModEntry.FormatVersion;
 }
+

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -1779,7 +1779,7 @@ namespace Ship_Game.Ships
             int offensiveArea = weaponArea + hangarArea;
             if (offensiveArea == 0
                 && (IsDefaultTroopShip || IsSupplyShuttle || DesignRole == RoleName.scout
-                    || IsSubspaceProjector || IsFreighter))
+                    || IsSubspaceProjector || IsFreighter || IsConstructor))
             {
                 return 0;
             }

--- a/Ship_Game/Universe/UniverseParams.cs
+++ b/Ship_Game/Universe/UniverseParams.cs
@@ -75,6 +75,7 @@ public class UniverseParams
     [StarData] public bool FilterOldModules;
 
     [StarData] public bool DisableRemnantStory;
+    [StarData] public bool DisableAlternateAITraits;
     [StarData] public bool DisablePirates;
     [StarData] public bool FixedPlayerCreditCharge;
 

--- a/Ship_Game/Universe/UniverseState_Empires.cs
+++ b/Ship_Game/Universe/UniverseState_Empires.cs
@@ -286,9 +286,8 @@ public partial class UniverseState
 
         data.DiplomaticPersonality = CreateDiplomaticTrait();
         data.EconomicPersonality = CreateEconimicTrait();
-
         // Added by McShooterz: set values for alternate race file structure
-        data.Traits.LoadTraitConstraints(isPlayer, Random);
+        data.Traits.LoadTraitConstraints(isPlayer, Random, data.Name, P.DisableAlternateAITraits);
         empire.dd = ResourceManager.GetDiplomacyDialog(data.DiplomacyDialogPath);
         data.SpyModifier = data.Traits.SpyMultiplier;
         data.Traits = data.Traits;

--- a/UnitTests/Serialization/BinarySerializerTests.cs
+++ b/UnitTests/Serialization/BinarySerializerTests.cs
@@ -1128,6 +1128,7 @@ namespace UnitTests.Serialization
             AssertEqual(instance.ShowAllDesigns, result.ShowAllDesigns);
             AssertEqual(instance.FilterOldModules, result.FilterOldModules);
             AssertEqual(instance.DisableRemnantStory, result.DisableRemnantStory);
+            AssertEqual(instance.DisableAlternateAITraits, result.DisableAlternateAITraits);
             AssertEqual(instance.DisablePirates, result.DisablePirates);
             AssertEqual(instance.FixedPlayerCreditCharge, result.FixedPlayerCreditCharge);
         }

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -10434,6 +10434,12 @@ InRandomGameMode:
  ENG: "Random game mode is very similar to Sandbox Game Mode but starting positions are randomized. Some empires might start very close to eachother and some may have a lot of space to expand."
  RUS: "Случайный режим игры очень похож на режим песочницы, но стартовые позиции случайны. Некоторые империи могут начинаться очень близко друг к другу, а у некоторых может быть много места для расширения."
  SPA: "El modo de juego aleatorio es muy similar al modo de juego Sandbox, pero las posiciones iniciales son aleatorias. Algunos imperios pueden comenzar muy cerca uno del otro y otros pueden tener mucho espacio para expandirse."  
+DisableAlternateTraits:
+ Id: 4441
+ ENG: "Disable Alternate AI Trait Sets"
+DisableAlternateTraitsTip:
+ Id: 4442
+ ENG: "Disable the ability to create alternate traits sets for AI empires. The AI empires will start with the traits you see when you cycle the races during in the Race Design Screen. Using alternate AI trait sets will create slightly diffrent empires each new game, increasing replayability."
 TraitSalvagersName:
   Id: 4966
   ENG: "Salvagers"   

--- a/game/Content/Globals.yaml
+++ b/game/Content/Globals.yaml
@@ -5,6 +5,7 @@ Globals:
   MaxOpponents: 7
   DefaultNumOpponents: 5
   TurnTimer: 5 # default time in seconds for a single turn
+  TraitPoints: 8 # initial number of trait points. Default is 8
   
 
   # gameplay modifiers


### PR DESCRIPTION
Feature: Add ability to disable alternate AI traits
Fix: races surrender or merge too fast. 
Fix: Calc constructors str as 0 if they have no weapon. 
Balance: Nerf AI in Normal difficulty level.
Allow mods with unsupported format to load so they could be updated, but do not allow starting or loading games until bb and the mod are updated.