### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
@@ -212,7 +212,7 @@ namespace Ship_Game.AI
                 return;
             }
 
-            if (goal.BuildPosition.OutsideRadius(Owner.Position, Owner.CurrentVelocity*2))
+            if (goal.BuildPosition.OutsideRadius(Owner.Position, (Owner.CurrentVelocity *2).UpperBound(500)))
             {
                 ThrustOrWarpToPos(goal.BuildPosition, timeStep);
                 return;
@@ -277,7 +277,7 @@ namespace Ship_Game.AI
                 return;
             }
 
-            if (goal.BuildPosition.OutsideRadius(Owner.Position, Owner.CurrentVelocity*2))
+            if (goal.BuildPosition.OutsideRadius(Owner.Position, (Owner.CurrentVelocity * 2).UpperBound(500)))
             {
                 ThrustOrWarpToPos(goal.BuildPosition, timeStep);
                 return;

--- a/Ship_Game/Gameplay/Projectile.cs
+++ b/Ship_Game/Gameplay/Projectile.cs
@@ -952,7 +952,9 @@ namespace Ship_Game.Gameplay
         void ArmorPiercingTouch(ShipModule victim, Ship parent, Vector2 hitPos)
         {
             // for visual consistency we want to show Projectile at hitPos
-            Position = hitPos;
+            // if the radius is big - adjust the pos accordingly, since if the explosion radius is smaller than
+            // the projectile radius - it will explode with no affect
+            Position = Radius <= 8 ? hitPos : hitPos + hitPos.DirectionToTarget(victim.Position)*Radius;
             Universe.DebugWin?.DrawGameObject(DebugModes.Targeting, this, Color.LightCyan, lifeTime:0.25f);
 
             if (!TryPhaseThroughModule(victim) && Damage(victim))

--- a/Ship_Game/Ships/LaunchShip.cs
+++ b/Ship_Game/Ships/LaunchShip.cs
@@ -39,6 +39,10 @@ namespace Ship_Game.Ships
         public static Vector3 FlashPos(Ship ship, float scale, float posZ)
             => new Vector2(-ship.Direction * ship.Radius * scale * 0.5f + ship.Position).ToVec3(posZ + 20);
 
+        public static Vector2 StartingVelocity(Ship ship, float rotationDegZ, float randomModifier) 
+            => rotationDegZ.AngleToDirection() * (ship.MaxSTLSpeed * randomModifier).UpperBound(500);
+
+
         public void Update(bool visibleToPlayer, FixedSimTime timeStep)
         {
             Owner.AI.IgnoreCombat = true;
@@ -107,9 +111,7 @@ namespace Ship_Game.Ships
                 SecondsHalfPosZ = (StartingPosZ / ship.MaxSTLSpeed.LowerBound(100)).Clamped(MinSecondsToHalfScale, MaxSecondsToHalfScale);
                 SecondsToZeroX = PlanetPlanRotationDegX / ship.RotationRadsPerSecond.ToDegrees().LowerBound(5);
                 TotalDuration = SecondsHalfPosZ + SecondsToZeroX;
-
-                float velRandom = ship.Universe.Random.Float(0.5f, 0.75f);
-                Velocity = RotationDegZ.AngleToDirection() * Owner.MaxSTLSpeed * velRandom;
+                Velocity = StartingVelocity(ship, RotationDegZ, ship.Universe.Random.Float(0.5f, 0.75f));
             }
 
             public void Update(FixedSimTime timeStep, bool visible, ref float posZ, out float scale)
@@ -163,9 +165,7 @@ namespace Ship_Game.Ships
                 Progress = InitialProgress;
                 TotalDuration = (InitialRotationDegX / ship.RotationRadsPerSecond.ToDegrees()).Clamped(2, 5);
                 RelativeDegForBarrel = 3.6f / (1 - Progress);
-
-                float velRandom = ship.Universe.Random.Float(1f, 2f);
-                Velocity = RotationDegZ.AngleToDirection() * Owner.MaxSTLSpeed * velRandom;
+                Velocity = StartingVelocity(ship, RotationDegZ, ship.Universe.Random.Float(1f, 1.2f));
             }
 
             bool ShouldBarrelRoll()
@@ -212,7 +212,7 @@ namespace Ship_Game.Ships
                 RotationDegZ = rotation;
                 Progress = InitialProgress;
                 float velRandom = ship.Universe.Random.Float(0.5f, 0.8f);
-                Velocity = RotationDegZ.AngleToDirection() * Owner.MaxSTLSpeed * velRandom;
+                Velocity = StartingVelocity(ship, RotationDegZ, ship.Universe.Random.Float(0.5f, 0.8f));
                 switch (ship.ShipData.HullRole)
                 {
                     case RoleName.fighter:


### PR DESCRIPTION

Fix: constructors dropping out of warp prematurely
Fix: Slow projectiles with big radius (mostly AA) and smaller explosion radius will not hit at actual module (especially at slow speed when there is no ray tracing)
Refactor: Small refacto of ship launch. 
