### PR TITLE
Patch 1.41 - Shared Research

### DIFF
--- a/Ship_Game/Data/RacialTrait.cs
+++ b/Ship_Game/Data/RacialTrait.cs
@@ -86,6 +86,7 @@ namespace Ship_Game
         [StarData] public float ConstructionRateMultiplier = 1; // for constructors
         [StarData] public float BuilderShipConstructionMultiplier = 1; // for builder ships
         [StarData] public int ExtraStartingScouts;
+        [StarData] public float ResearchBenefitFromAlliance;
 
         // FB - Environment
         [StarData] public PlanetCategory PreferredEnv = PlanetCategory.Terran;
@@ -209,7 +210,8 @@ namespace Ship_Game
                 Aquatic += trait.Aquatic;
                 CreditsPerKilledSlot += trait.CreditsPerKilledSlot;
                 PenaltyPerKilledSlot += trait.PenaltyPerKilledSlot;
-                ExtraStartingScouts += trait.ExtraStartingScouts; 
+                ExtraStartingScouts += trait.ExtraStartingScouts;
+                ResearchBenefitFromAlliance += trait.ResearchBenefitFromAlliance;
 
                 ExploreDistanceMultiplier *= trait.ExploreDistanceMultiplier;
                 ConstructionRateMultiplier *= trait.ConstructionRateMultiplier;

--- a/Ship_Game/Data/RacialTraitOption.cs
+++ b/Ship_Game/Data/RacialTraitOption.cs
@@ -61,6 +61,7 @@ namespace Ship_Game.Data
         public float ConstructionRateMultiplier = 1; // for constructors
         public float BuilderShipConstructionMultiplier = 1; // for builder ships
         public int ExtraStartingScouts;
+        public float ResearchBenefitFromAlliance;
 
         // FB - Environment
         public PlanetCategory PreferredEnv = PlanetCategory.Terran;

--- a/Ship_Game/EmpireDifficultyModifers.cs
+++ b/Ship_Game/EmpireDifficultyModifers.cs
@@ -73,8 +73,8 @@
             TaxMod                 = 0;
             ShipCostMod            = 0;
             TroopCostMod           = 0;
-            ResearchTaxMultiplier  = 0;
             ModHpModifier          = 0;
+            ResearchTaxMultiplier  = 1;
             PlayerWarPriorityLimit = 10;
             switch (difficulty)
             {
@@ -196,6 +196,7 @@
                         ResearchMod    = 1.2f;
                         TaxMod         = 1f;
                         ShipCostMod    = -0.4f;
+                        ModHpModifier  = 0.1f;
                         TroopCostMod   = -0.4f;
                         ResearchTaxMultiplier  = 0.5f;
                         PlayerWarPriorityLimit = 3;
@@ -242,6 +243,7 @@
                         TaxMod                 = 1.5f;
                         ShipCostMod            = -0.6f;
                         TroopCostMod           = -0.6f;
+                        ModHpModifier          = 0.25f;
                         ResearchTaxMultiplier  = 0.3f;
                         PlayerWarPriorityLimit = 2;
                     }

--- a/Ship_Game/EmpireResearch.cs
+++ b/Ship_Game/EmpireResearch.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using SDGraphics;
 using SDUtils;
 using Ship_Game.Data.Serialization;
 
@@ -87,6 +88,25 @@ namespace Ship_Game
                 NetResearch          += planet.Res.NetIncome;
                 MaxResearchPotential += planet.Res.GrossMaxPotential;
             }
+
+            float ResearchFromAlliances = 0;
+            foreach (Empire ally in Empire.Universe.GetAllies(Empire))
+            {
+                if (Empire.isPlayer && ally.DifficultyModifiers.ResearchMod.NotZero())
+                {
+                    float grossResearch = ally.Research.NetResearch / ally.DifficultyModifiers.ResearchMod;
+                    float netMultiplier = ally.data.Traits.ResearchMod / ally.DifficultyModifiers.ResearchMod;
+                    ResearchFromAlliances += grossResearch * netMultiplier;
+                }
+                else
+                {
+                    ResearchFromAlliances += ally.Research.NetResearch;
+                }
+            }
+
+            ResearchFromAlliances *= GlobalStats.Defaults.ResearchBenefitFromAlliance + Empire.data.Traits.ResearchBenefitFromAlliance;
+            NetResearch += ResearchFromAlliances;
+            MaxResearchPotential += ResearchFromAlliances;
         }
 
         public void AddResearchStationResearchPerTurn(float value)

--- a/Ship_Game/GamePlayGlobals.cs
+++ b/Ship_Game/GamePlayGlobals.cs
@@ -68,6 +68,8 @@ public class GamePlayGlobals
     [StarData] public int ConstructionModuleBuildRate = 100;
     // How much construction Builder ships add when they reach the contructor
     [StarData] public int BuilderShipConstructionAdded = 100;
+    // How much extra research the empire gets from allies
+    [StarData] public float ResearchBenefitFromAlliance = 0.1f;
 
     // feature flags
     [StarData] public bool UseHullBonuses;

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen_RaceDescription.cs
@@ -276,6 +276,7 @@ namespace Ship_Game
                 RaceSummary.CreditsPerKilledSlot   += trait.CreditsPerKilledSlot;
                 RaceSummary.PenaltyPerKilledSlot   += trait.PenaltyPerKilledSlot;
                 RaceSummary.ExtraStartingScouts    += trait.ExtraStartingScouts;
+                RaceSummary.ResearchBenefitFromAlliance += trait.ResearchBenefitFromAlliance;
 
                 RaceSummary.ExploreDistanceMultiplier *= trait.ExploreDistanceMultiplier;
                 RaceSummary.ConstructionRateMultiplier *= trait.ConstructionRateMultiplier;

--- a/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
+++ b/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
@@ -213,13 +213,18 @@ namespace Ship_Game.GameScreens.NewGame
             {
                 Empire e = UState.CreateEmpire(readOnlyData, isPlayer: false, difficulty: Difficulty);
                 RacialTrait t = e.data.Traits;
-
                 e.data.FlatMoneyBonus += e.DifficultyModifiers.FlatMoneyBonus;
-                t.ProductionMod += e.DifficultyModifiers.ProductionMod;
-                t.ResearchMod += e.DifficultyModifiers.ResearchMod;
-                t.TaxMod += e.DifficultyModifiers.TaxMod;
-                t.ModHpModifier += e.DifficultyModifiers.ModHpModifier;
                 t.ShipCostMod += e.DifficultyModifiers.ShipCostMod;
+
+                if (e.DifficultyModifiers.ProductionMod.NotZero())
+                    t.ProductionMod = (1 + t.ProductionMod) * e.DifficultyModifiers.ProductionMod;
+                if (e.DifficultyModifiers.ResearchMod.NotZero())
+                    t.ResearchMod = (1 + t.ResearchMod) * e.DifficultyModifiers.ResearchMod;
+                if (e.DifficultyModifiers.TaxMod.NotZero())
+                    t.TaxMod = (1 + t.TaxMod) * e.DifficultyModifiers.TaxMod;
+
+                t.ModHpModifier += e.DifficultyModifiers.ModHpModifier;
+
                 t.ResearchTaxMultiplier = e.DifficultyModifiers.ResearchTaxMultiplier; // the "=" here is intended
 
                 step.Advance();

--- a/Ship_Game/Universe/SolarBodies/SolarSystemBody.cs
+++ b/Ship_Game/Universe/SolarBodies/SolarSystemBody.cs
@@ -562,11 +562,21 @@ namespace Ship_Game
                     GetTraitMax(newOwner.data.Traits.EnemyPlanetInhibitionPercentCounter, ownerTraits.EnemyPlanetInhibitionPercentCounter);
 
                 // Do not add AI difficulty modifiers for the below
-                float realProductionMod = ownerTraits.ProductionMod - oldOwner.DifficultyModifiers.ProductionMod;
-                float realResearchMod   = ownerTraits.ResearchMod - oldOwner.DifficultyModifiers.ResearchMod;
-                float realShipCostMod   = ownerTraits.ShipCostMod - oldOwner.DifficultyModifiers.ShipCostMod;
-                float realModHpModifer  = ownerTraits.ModHpModifier - oldOwner.DifficultyModifiers.ModHpModifier;
-                float realTaxMod        = ownerTraits.TaxMod - oldOwner.DifficultyModifiers.TaxMod;
+                float realProductionMod = Owner.isPlayer && oldOwner.DifficultyModifiers.ProductionMod.NotZero()
+                    ? ownerTraits.ProductionMod/oldOwner.DifficultyModifiers.ProductionMod - 1
+                    : ownerTraits.ProductionMod;
+
+                float realResearchMod = newOwner.isPlayer && oldOwner.DifficultyModifiers.ResearchMod.NotZero()
+                    ? ownerTraits.ResearchMod/oldOwner.DifficultyModifiers.ResearchMod - 1
+                    : ownerTraits.ResearchMod;
+
+                float realTaxMod = newOwner.isPlayer && oldOwner.DifficultyModifiers.TaxMod.NotZero()
+                    ? ownerTraits.TaxMod/oldOwner.DifficultyModifiers.TaxMod - 1 
+                    : ownerTraits.TaxMod;
+
+                float realShipCostMod   = newOwner.isPlayer ? ownerTraits.ShipCostMod - oldOwner.DifficultyModifiers.ShipCostMod : ownerTraits.ShipCostMod;
+                float realModHpModifer  = newOwner.isPlayer ? ownerTraits.ModHpModifier - oldOwner.DifficultyModifiers.ModHpModifier : ownerTraits.ModHpModifier;
+
 
                 newOwner.data.Traits.ShipCostMod   = GetTraitMin(newOwner.data.Traits.ShipCostMod, realShipCostMod); // min
                 newOwner.data.Traits.ProductionMod = GetTraitMax(newOwner.data.Traits.ProductionMod, realProductionMod);

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -10458,6 +10458,18 @@ DesignIssueConstructorCostProblem:
 DesignIssueConstructorCostRemidiation:
  Id: 4448
  ENG: "You my want to lower the cost of this constructor. Excess production cost added to any orbital production cost when this constructor is selected:"     
+Trait_Research_Collaborators_Name: 
+ Id: 4957
+ ENG: "Research Collaborators"     
+Trait_Research_Collaborators_Desc: 
+ Id: 4958
+ ENG: "Your Scientists are known for their desire to collaborate and share Research. 15% Research Benefit from each Alliance instead of the normal 10%."       
+Trait_Research_Adversaries_Name: 
+ Id: 4959
+ ENG: "Research Adversaries"     
+Trait_Research_Adversaries_Desc: 
+ Id: 4960
+ ENG: "Your Scientists are known for their ego when collaborating with allies, which disrupts alliance research benefits. 5% Research Benefit from each Alliance instead of the normal 10%."      
 Tech_BuilderShipEfficiency:
  Id: 4961
  ENG: "Better construction tools alow Builder ships to increase its build rate by 50%"     

--- a/game/Content/Globals.yaml
+++ b/game/Content/Globals.yaml
@@ -36,6 +36,7 @@ Globals:
   ConstructionShipOrbitalDiscount: 100 # When building orbitals, constructor ship cost over this threshold will be added to the gross orbital cost
   ConstructionModuleBuildRate: 100 # How much consturction the construction module can process per turn   
   BuilderShipConstructionAdded: 100 # How much consturction Builder ships add when they reach the contructor
+  ResearchBenefitFromAlliance: 0.1 # Hoe much research each alliance is giving you (from other party research)  
 
   # feature flags
   DisableShipPicker: true

--- a/game/Content/Globals.yaml
+++ b/game/Content/Globals.yaml
@@ -36,7 +36,7 @@ Globals:
   ConstructionShipOrbitalDiscount: 100 # When building orbitals, constructor ship cost over this threshold will be added to the gross orbital cost
   ConstructionModuleBuildRate: 100 # How much consturction the construction module can process per turn   
   BuilderShipConstructionAdded: 100 # How much consturction Builder ships add when they reach the contructor
-  ResearchBenefitFromAlliance: 0.1 # Hoe much research each alliance is giving you (from other party research)  
+  ResearchBenefitFromAlliance: 0.1 # How much research each alliance is giving you (from other party research)  
 
   # feature flags
   DisableShipPicker: true

--- a/game/Content/RacialTraits/RacialTraits.xml
+++ b/game/Content/RacialTraits/RacialTraits.xml
@@ -609,7 +609,6 @@
 		<string>Salvagers</string>
 	  </Excludes>
 	</RacialTraitOption>
-	
     <RacialTraitOption>
 	  <!-- Orbital Constructors -->
   	  <TraitName>Orbital Constructors</TraitName>
@@ -634,6 +633,30 @@
 	  	  <string>Orbital Constructors</string>
 	  </Excludes>
     </RacialTraitOption>		
+	  <RacialTraitOption>
+		<!-- Research Collaborators -->
+		<TraitName>Research Collaborators</TraitName>
+		<TraitIndex>4957</TraitIndex>
+		<Category>Sociological</Category>
+		<Cost>2</Cost>
+		<Description>4958</Description>
+		<ResearchBenefitFromAlliance>0.05</ResearchBenefitFromAlliance>
+		<Excludes>
+			<string>Research Adversaries</string>
+		</Excludes>
+	  </RacialTraitOption>	
+	  <RacialTraitOption>
+		<!-- Research Adversaries -->
+		<TraitName>Research Adversaries</TraitName>
+		<TraitIndex>4959</TraitIndex>
+		<Category>Sociological</Category>
+		<Cost>-2</Cost>
+		<Description>4960</Description>
+		<ResearchBenefitFromAlliance>-0.05</ResearchBenefitFromAlliance>
+		<Excludes>
+			<string>Research Collaborators</string>
+		</Excludes>
+	  </RacialTraitOption>		
 
 	
     <!-- Adventure Mode Traits


### PR DESCRIPTION
Feature: Shared Research from Alliance. - Each alliance give its allies a percentage of the ally's research capacity. The percentage is a var in globals.yaml (default is 0.1) .
Feature: Added traits which increase or decrease research benefits from Alliances.
Fix: Research Tax multiplier was 0 for normal difficulty, making the AI stronger by mistake.
Balance: AI -  Added some module hp mod for brutal and insane difficulty levels.
Balance: AI - traits which nerf or buff modifiers are now calculated as a multiplier of the bonuses of the AI, if any, so they will be more pronounced.