### PR TITLE
Qol research screen interaction

### DIFF
--- a/Ship_Game/EmpireResearch.cs
+++ b/Ship_Game/EmpireResearch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using SDGraphics;
 using SDUtils;
 using Ship_Game.Data.Serialization;
@@ -197,6 +196,26 @@ namespace Ship_Game
             }
 
             RemoveLeadsToRecursive(techUid);
+        }
+        
+        
+        /// <summary>
+        /// Adds the given tech to the queue, and all of its PreReqs.
+        /// It checks if the tech (and PreReqs) have been discovered and not finished yet and not already enqueued.
+        /// </summary>
+        public void AddTechToQueue(string techUid)
+        {
+            var technology = ResourceManager.Tech(techUid);
+            var predecessorTechs = technology.PredecessorTechs();
+            foreach (Technology predecessor in predecessorTechs)
+            {
+                var techEntry = Empire.GetTechEntry(predecessor.UID);
+                if (techEntry.Discovered && !techEntry.Unlocked && !IsQueued(predecessor.UID))
+                {
+                    AddToQueue(predecessor.UID);
+                }
+            }
+            AddToQueue(techUid);
         }
         
         

--- a/Ship_Game/EmpireResearch.cs
+++ b/Ship_Game/EmpireResearch.cs
@@ -280,7 +280,7 @@ namespace Ship_Game
             int skipped = 0;
             while (ResearchCanMoveUp(index))
             {
-                SwapQueueItems(index - 1, index);
+                MoveUp(index);
                 index--;
                 skipped++;
             }

--- a/Ship_Game/EmpireResearch.cs
+++ b/Ship_Game/EmpireResearch.cs
@@ -182,5 +182,17 @@ namespace Ship_Game
         {
             Queue.Reorder(oldIndex, newIndex);
         }
+        
+        public void RemoveTechFromQueue(string techUid)
+        {
+            void RemoveLeadsToRecursive(string tech)
+            {
+                Queue.Remove(tech);
+                foreach (Technology.LeadsToTech dependent in ResourceManager.Tech(tech).LeadsTo)
+                    RemoveLeadsToRecursive(dependent.UID);
+            }
+
+            RemoveLeadsToRecursive(techUid);
+        }
     }
 }

--- a/Ship_Game/EmpireResearch.cs
+++ b/Ship_Game/EmpireResearch.cs
@@ -182,7 +182,6 @@ namespace Ship_Game
             Queue.Reorder(oldIndex, newIndex);
         }
         
-        
         /// <summary>
         /// Removes the given tech from the queue, and all techs that depend on it.
         /// </summary>
@@ -198,7 +197,6 @@ namespace Ship_Game
             RemoveLeadsToRecursive(techUid);
         }
         
-        
         /// <summary>
         /// Adds the given tech to the queue, and all of its PreReqs.
         /// It checks if the tech (and PreReqs) have been discovered and not finished yet and not already enqueued.
@@ -211,13 +209,10 @@ namespace Ship_Game
             {
                 var techEntry = Empire.GetTechEntry(predecessor.UID);
                 if (techEntry.Discovered && !techEntry.Unlocked && !IsQueued(predecessor.UID))
-                {
                     AddToQueue(predecessor.UID);
-                }
             }
             AddToQueue(techUid);
         }
-        
         
         string ResearchUidAt(int index) => Queue[index];
         Technology ResearchTechnologyAt(int index) => ResourceManager.Tech(ResearchUidAt(index));
@@ -247,26 +242,22 @@ namespace Ship_Game
         
         public void MoveUp(int index)
         {
-            if (ResearchCanMoveUp(index))
-            {
+            if (CanMoveUp(index))
                 SwapQueueItems(index - 1, index);
-            }
         }
         
         public void MoveDown(int index)
         {
-            if (ResearchCanMoveDown(index))
-            {
+            if (CanMoveDown(index))
                 SwapQueueItems(index + 1, index);
-            }
         }
         
-        public bool ResearchCanMoveUp(int index)
+        public bool CanMoveUp(int index)
         {
             return index != -1 && index >= 1 && !AboveIsPreReq(index);
         }
         
-        public bool ResearchCanMoveDown(int index)
+        public bool CanMoveDown(int index)
         {
             return index != -1 && index != Queue.Count - 1 && !IsPreReqOfBellow(index);
         }
@@ -278,7 +269,7 @@ namespace Ship_Game
         public int MoveToTopOrPreReq(int index)
         {
             int skipped = 0;
-            while (ResearchCanMoveUp(index))
+            while (CanMoveUp(index))
             {
                 MoveUp(index);
                 index--;

--- a/Ship_Game/EmpireResearch.cs
+++ b/Ship_Game/EmpireResearch.cs
@@ -274,20 +274,27 @@ namespace Ship_Game
         /// <summary>
         /// This will move the item at the given index to the top of the queue, or until it hits a PreReq.
         /// </summary>
-        public void MoveToTopOrPreReq(int index)
+        /// <returns>The amount of research that was skipped over.</returns>
+        public int MoveToTopOrPreReq(int index)
         {
+            int skipped = 0;
             while (ResearchCanMoveUp(index))
             {
                 SwapQueueItems(index - 1, index);
                 index--;
+                skipped++;
             }
+            return skipped;
         }
         
         /// <summary>
         /// If the item at the given index has any enqueued PreReqs, they will be moved to the top of the queue.
         /// </summary>
-        public void MovePreReqsToTop(int index)
+        /// <returns>The amount of research that has moved in the queue.</returns>
+        public int MovePreReqsToTop(int index)
         {
+            int preReqsThatMovedUp = 0;
+            
             Technology current = ResearchTechnologyAt(index);
             
             foreach (string researchUid in Queue)
@@ -300,16 +307,32 @@ namespace Ship_Game
                 {
                     if (descendant.UID == current.UID)
                     {
-                        MoveToTopOrPreReq(indexOfResearch);
+                        int movedPositions = MoveToTopOrPreReq(indexOfResearch);
+                        if (movedPositions > 0)
+                            preReqsThatMovedUp++;
                     }
                 }
             }
+            
+            return preReqsThatMovedUp;
         }
         
-        public void MoveToTopWithPreReqs(int index)
+        /// <summary>
+        /// Moves the item at the given index to the top of the queue, and all of its PreReqs as well.
+        /// </summary>
+        /// <returns>How many items in total have moved in the queue</returns>
+        public int MoveToTopWithPreReqs(int index)
         {
-            MovePreReqsToTop(index);
-            MoveToTopOrPreReq(index);
+            int movedResearchItems = 0;
+            
+            int movedPreReqs = MovePreReqsToTop(index);
+            movedResearchItems = movedPreReqs;
+            
+            int movedPositions = MoveToTopOrPreReq(index);
+            if (movedPositions > 0)
+                movedResearchItems++;
+            
+            return movedResearchItems;
         }
     }
 }

--- a/Ship_Game/GameScreens/Universe/ResearchScreenNew.cs
+++ b/Ship_Game/GameScreens/Universe/ResearchScreenNew.cs
@@ -367,7 +367,11 @@ namespace Ship_Game
             if(GameBase.ScreenManager.input != null && GameBase.ScreenManager.input.IsCtrlKeyDown)
             {
                 int index = Player.Research.IndexInQueue(tech.UID);
-                Player.Research.MoveToTopWithPreReqs(index);
+                int moved = Player.Research.MoveToTopWithPreReqs(index);
+                if (moved == 0)
+                {
+                    GameAudio.NegativeClick();
+                }
             }
             
             // if CTRL was not held down, and tech is in queue (but not added right now), remove it

--- a/Ship_Game/GameScreens/Universe/ResearchScreenNew.cs
+++ b/Ship_Game/GameScreens/Universe/ResearchScreenNew.cs
@@ -351,24 +351,36 @@ namespace Ship_Game
             {
                 // this tech cannot be researched
                 GameAudio.NegativeClick();
+                return;
             }
-            else if (tech.HasPreReq(Player))
+            
+            
+            if(Player.Research.IsQueued(tech.UID))
             {
-                // we already have all pre-requisites, so add it directly to queue
-                Queue.AddToResearchQueue(tech);
-                GameAudio.ResearchSelect();
+                Log.Warning($"QueuedItems already contains {tech.UID}");
+                Player.Research.RemoveTechFromQueue(tech.UID);
+                Queue.ReloadResearchQueue();
             }
             else
             {
-                // we need to research required techs before doing this one
-                GameAudio.ResearchSelect();
-
-                // figure out the list of techs to add
-                var techsToAdd = GetRequiredTechEntriesToResearch(tech);
-                foreach (TechEntry toAdd in techsToAdd)
+                if (tech.HasPreReq(Player))
                 {
-                    if (toAdd.Discovered)
-                        Queue.AddToResearchQueue(toAdd);
+                    // we already have all pre-requisites, so add it directly to queue
+                    Queue.AddToResearchQueue(tech);
+                    GameAudio.ResearchSelect();
+                }
+                else
+                {
+                    // we need to research required techs before doing this one
+                    GameAudio.ResearchSelect();
+
+                    // figure out the list of techs to add
+                    var techsToAdd = GetRequiredTechEntriesToResearch(tech);
+                    foreach (TechEntry toAdd in techsToAdd)
+                    {
+                        if (toAdd.Discovered)
+                            Queue.AddToResearchQueue(toAdd);
+                    }
                 }
             }
         }

--- a/Ship_Game/ResearchQItem.cs
+++ b/Ship_Game/ResearchQItem.cs
@@ -26,8 +26,8 @@ namespace Ship_Game
             Pos = pos;
             BtnUp     = Button(ButtonStyle.ResearchQueueUp, OnBtnUpPressed);
             BtnDown   = Button(ButtonStyle.ResearchQueueDown, OnBtnDownPressed);
-            BtnCancel = Button(ButtonStyle.ResearchQueueCancel, OnBtnCancelPressed);
             BtnToTop  = Button(ButtonStyle.ResearchQueueToTop, OnBtnToTopPressed);
+            BtnCancel = Button(ButtonStyle.ResearchQueueCancel, OnBtnCancelPressed);
             Node = new TreeNode(Pos + new Vector2(100f, 20f), Tech, Screen);
             PerformLayout();
         }
@@ -38,8 +38,8 @@ namespace Ship_Game
             Node.SetPos(Pos + new Vector2(100f, 20f));
             BtnUp.Rect     = new RectF(X + 15, CenterY - 33, 30, 30);
             BtnDown.Rect   = new RectF(X + 15, CenterY + 3, 30, 30);
-            BtnCancel.Rect = new RectF(X + 57, CenterY - 16 + 30, 30, 30);
-            BtnToTop.Rect  = new RectF(X + 57, CenterY - 22, 30, 30);
+            BtnToTop.Rect  = new RectF(X + 57, CenterY -33, 30, 30);
+            BtnCancel.Rect = new RectF(X + 57, CenterY + 3, 30, 30);
             base.PerformLayout();
         }
 

--- a/Ship_Game/ResearchQItem.cs
+++ b/Ship_Game/ResearchQItem.cs
@@ -188,14 +188,7 @@ namespace Ship_Game
 
         void RemoveTech(string uid)
         {
-            void RemoveLeadsToRecursive(string tech)
-            {
-                Screen.Player.Research.RemoveFromQueue(tech);
-                foreach (Technology.LeadsToTech dependent in ResourceManager.Tech(tech).LeadsTo)
-                    RemoveLeadsToRecursive(dependent.UID);
-            }
-
-            RemoveLeadsToRecursive(uid);
+            Screen.Player.Research.RemoveTechFromQueue(uid);
             Screen.Queue.ReloadResearchQueue();
         }
     }

--- a/Ship_Game/ResearchQItem.cs
+++ b/Ship_Game/ResearchQItem.cs
@@ -36,8 +36,8 @@ namespace Ship_Game
             Node.SetPos(Pos + new Vector2(100f, 20f));
             BtnUp.Rect = new RectF(X + 15, CenterY - 33, 30, 30);
             BtnDown.Rect = new RectF(X + 15, CenterY + 3, 30, 30);
-            BtnCancel.Rect = new RectF(X + 57, CenterY - 15 - 7, 30, 30);
-            BtnToTop.Rect = new RectF(X + 57, CenterY - 15 - 7 + 30 + 6, 30, 30);
+            BtnCancel.Rect = new RectF(X + 57, CenterY - 16 + 30, 30, 30);
+            BtnToTop.Rect = new RectF(X + 57, CenterY - 22, 30, 30);
             base.PerformLayout();
         }
 

--- a/Ship_Game/ResearchQItem.cs
+++ b/Ship_Game/ResearchQItem.cs
@@ -108,7 +108,12 @@ namespace Ship_Game
                 return;
             }
             
-            Research.MoveToTopWithPreReqs(index);
+            int moved = Research.MoveToTopWithPreReqs(index);
+            if (moved == 0)
+            {
+                GameAudio.NegativeClick();
+                return;
+            }
 
             Screen.Queue.ReloadResearchQueue();
         }

--- a/Ship_Game/ResearchQItem.cs
+++ b/Ship_Game/ResearchQItem.cs
@@ -58,9 +58,9 @@ namespace Ship_Game
 
         void SwapQueueItems(int first, int second)
         {
-            string tmp = Screen.Player.data.ResearchQueue[first];
-            Screen.Player.data.ResearchQueue[first] = Tech.UID;
-            Screen.Player.data.ResearchQueue[second] = tmp;
+            (Screen.Player.data.ResearchQueue[first], Screen.Player.data.ResearchQueue[second])
+            = 
+            (Screen.Player.data.ResearchQueue[second], Screen.Player.data.ResearchQueue[first]);
         }
 
         private bool CanMoveUp(int index)

--- a/Ship_Game/ResearchQItem.cs
+++ b/Ship_Game/ResearchQItem.cs
@@ -60,7 +60,7 @@ namespace Ship_Game
         void OnBtnUpPressed(UIButton up)
         {
             int index = Research.IndexInQueue(Tech.UID);
-            if (!Research.ResearchCanMoveUp(index))
+            if (!Research.CanMoveUp(index))
             {
                 GameAudio.NegativeClick();
                 return;
@@ -81,7 +81,7 @@ namespace Ship_Game
         void OnBtnDownPressed(UIButton down)
         {
             int index = Screen.Player.Research.IndexInQueue(Tech.UID);
-            if (!Research.ResearchCanMoveDown(index))
+            if (!Research.CanMoveDown(index))
             {
                 GameAudio.NegativeClick();
                 return;

--- a/Ship_Game/ResearchQItem.cs
+++ b/Ship_Game/ResearchQItem.cs
@@ -169,8 +169,9 @@ namespace Ship_Game
 
         bool AboveIsPreReq(int indexOfThis)
         {
+            var thisTech = PlayerResearchAt(indexOfThis);
             foreach (Technology.LeadsToTech dependent in PlayerResearchAt(indexOfThis - 1).LeadsTo)
-                if (dependent.UID == Tech.UID)
+                if (dependent.UID == thisTech.UID)
                     return true;
             return false;
         }

--- a/Ship_Game/ResearchQItem.cs
+++ b/Ship_Game/ResearchQItem.cs
@@ -13,6 +13,7 @@ namespace Ship_Game
         readonly UIButton BtnUp;
         readonly UIButton BtnDown;
         readonly UIButton BtnCancel;
+        readonly UIButton BtnToTop;
 
         public override string ToString() => $"ResearchQItem \"{Tech.UID}\" {ElementDescr}";
 
@@ -21,9 +22,10 @@ namespace Ship_Game
             Screen = screen;
             Tech = tech;
             Pos = pos;
-            BtnUp     = Button(ButtonStyle.ResearchQueueUp, OnBtnUpPressed);
-            BtnDown   = Button(ButtonStyle.ResearchQueueDown, OnBtnDownPressed);
+            BtnUp = Button(ButtonStyle.ResearchQueueUp, OnBtnUpPressed);
+            BtnDown = Button(ButtonStyle.ResearchQueueDown, OnBtnDownPressed);
             BtnCancel = Button(ButtonStyle.ResearchQueueCancel, OnBtnCancelPressed);
+            BtnToTop = Button(ButtonStyle.ResearchQueueToTop, OnBtnToTopPressed);
             Node = new TreeNode(Pos + new Vector2(100f, 20f), Tech, Screen);
             PerformLayout();
         }
@@ -32,9 +34,10 @@ namespace Ship_Game
         {
             Size = new Vector2(320, 110);
             Node.SetPos(Pos + new Vector2(100f, 20f));
-            BtnUp.Rect     = new RectF(X+15, CenterY - 33, 30, 30);
-            BtnDown.Rect   = new RectF(X+15, CenterY +  3, 30, 30);
-            BtnCancel.Rect = new RectF(X+57, CenterY - 15, 30, 30);
+            BtnUp.Rect = new RectF(X + 15, CenterY - 33, 30, 30);
+            BtnDown.Rect = new RectF(X + 15, CenterY + 3, 30, 30);
+            BtnCancel.Rect = new RectF(X + 57, CenterY - 15 - 7, 30, 30);
+            BtnToTop.Rect = new RectF(X + 57, CenterY - 15 - 7 + 30 + 6, 30, 30);
             base.PerformLayout();
         }
 
@@ -59,15 +62,19 @@ namespace Ship_Game
             Screen.Player.data.ResearchQueue[second] = tmp;
         }
 
+        private bool CanMoveUp(int index)
+        {
+            return index != -1 && index >= 1 && !AboveIsPreReq(index);
+        }
+
         void OnBtnUpPressed(UIButton up)
         {
             int index = Screen.Player.Research.IndexInQueue(Tech.UID);
-            if (index == -1 || index < 1 || AboveIsPreReq(index))
+            if (!CanMoveUp(index))
             {
                 GameAudio.NegativeClick();
                 return;
             }
-
             SwapQueueItems(index - 1, index);
             Screen.Queue.ReloadResearchQueue();
         }
@@ -88,6 +95,24 @@ namespace Ship_Game
         void OnBtnCancelPressed(UIButton cancel)
         {
             RemoveTech(Tech.UID);
+        }
+
+        void OnBtnToTopPressed(UIButton toTop)
+        {
+            int index = Screen.Player.Research.IndexInQueue(Tech.UID);
+            if (!CanMoveUp(index))
+            {
+                GameAudio.NegativeClick();
+                return;
+            }
+
+            while (CanMoveUp(index))
+            {
+                SwapQueueItems(index - 1, index);
+                index--;
+            }
+
+            Screen.Queue.ReloadResearchQueue();
         }
 
         string ResearchUidAt(int index) => Screen.Player.data.ResearchQueue[index];

--- a/Ship_Game/ResearchQItem.cs
+++ b/Ship_Game/ResearchQItem.cs
@@ -1,6 +1,5 @@
 using Microsoft.Xna.Framework.Graphics;
 using SDGraphics;
-using SDUtils;
 using Ship_Game.Audio;
 using Vector2 = SDGraphics.Vector2;
 
@@ -16,7 +15,7 @@ namespace Ship_Game
         readonly UIButton BtnCancel;
         readonly UIButton BtnToTop;
 
-        private EmpireResearch Research => Screen.Player.Research;
+        EmpireResearch Research => Screen.Player.Research;
 
         public override string ToString() => $"ResearchQItem \"{Tech.UID}\" {ElementDescr}";
 
@@ -25,10 +24,10 @@ namespace Ship_Game
             Screen = screen;
             Tech = tech;
             Pos = pos;
-            BtnUp = Button(ButtonStyle.ResearchQueueUp, OnBtnUpPressed);
-            BtnDown = Button(ButtonStyle.ResearchQueueDown, OnBtnDownPressed);
+            BtnUp     = Button(ButtonStyle.ResearchQueueUp, OnBtnUpPressed);
+            BtnDown   = Button(ButtonStyle.ResearchQueueDown, OnBtnDownPressed);
             BtnCancel = Button(ButtonStyle.ResearchQueueCancel, OnBtnCancelPressed);
-            BtnToTop = Button(ButtonStyle.ResearchQueueToTop, OnBtnToTopPressed);
+            BtnToTop  = Button(ButtonStyle.ResearchQueueToTop, OnBtnToTopPressed);
             Node = new TreeNode(Pos + new Vector2(100f, 20f), Tech, Screen);
             PerformLayout();
         }
@@ -37,10 +36,10 @@ namespace Ship_Game
         {
             Size = new Vector2(320, 110);
             Node.SetPos(Pos + new Vector2(100f, 20f));
-            BtnUp.Rect = new RectF(X + 15, CenterY - 33, 30, 30);
-            BtnDown.Rect = new RectF(X + 15, CenterY + 3, 30, 30);
+            BtnUp.Rect     = new RectF(X + 15, CenterY - 33, 30, 30);
+            BtnDown.Rect   = new RectF(X + 15, CenterY + 3, 30, 30);
             BtnCancel.Rect = new RectF(X + 57, CenterY - 16 + 30, 30, 30);
-            BtnToTop.Rect = new RectF(X + 57, CenterY - 22, 30, 30);
+            BtnToTop.Rect  = new RectF(X + 57, CenterY - 22, 30, 30);
             base.PerformLayout();
         }
 

--- a/Ship_Game/ResearchQItem.cs
+++ b/Ship_Game/ResearchQItem.cs
@@ -66,6 +66,19 @@ namespace Ship_Game
         {
             return index != -1 && index >= 1 && !AboveIsPreReq(index);
         }
+        
+        /// <summary>
+        /// This will move the item at given starting index to the top of the queue, or until it hits a PreReq.
+        /// </summary>
+        private void MoveToTopOrPreReq(int index)
+        {
+            while (CanMoveUp(index))
+            {
+                SwapQueueItems(index - 1, index);
+                index--;
+            }
+        }
+        
 
         void OnBtnUpPressed(UIButton up)
         {
@@ -75,7 +88,16 @@ namespace Ship_Game
                 GameAudio.NegativeClick();
                 return;
             }
-            SwapQueueItems(index - 1, index);
+            
+            InputState input = GameBase.ScreenManager.input;
+            if (input.IsCtrlKeyDown)
+            {
+                MoveToTopOrPreReq(index);
+            }
+            else
+            {
+                SwapQueueItems(index - 1, index);
+            }
             Screen.Queue.ReloadResearchQueue();
         }
 
@@ -105,12 +127,8 @@ namespace Ship_Game
                 GameAudio.NegativeClick();
                 return;
             }
-
-            while (CanMoveUp(index))
-            {
-                SwapQueueItems(index - 1, index);
-                index--;
-            }
+            
+            MoveToTopOrPreReq(index);
 
             Screen.Queue.ReloadResearchQueue();
         }

--- a/Ship_Game/Ships/LaunchShip.cs
+++ b/Ship_Game/Ships/LaunchShip.cs
@@ -160,7 +160,7 @@ namespace Ship_Game.Ships
             {
                 Owner = ship;
                 RotationDegZ = rotation;
-                DoBarrelRoll = false; //ShouldBarrelRoll();
+                DoBarrelRoll = ShouldBarrelRoll();
                 Progress = InitialProgress;
                 TotalDuration = (InitialRotationDegX / ship.RotationRadsPerSecond.ToDegrees()).Clamped(2, 5);
                 RelativeDegForBarrel = 3.6f / (1 - Progress);

--- a/Ship_Game/Ships/LaunchShip.cs
+++ b/Ship_Game/Ships/LaunchShip.cs
@@ -160,7 +160,7 @@ namespace Ship_Game.Ships
             {
                 Owner = ship;
                 RotationDegZ = rotation;
-                DoBarrelRoll = ShouldBarrelRoll();
+                DoBarrelRoll = false; //ShouldBarrelRoll();
                 Progress = InitialProgress;
                 TotalDuration = (InitialRotationDegX / ship.RotationRadsPerSecond.ToDegrees()).Clamped(2, 5);
                 RelativeDegForBarrel = 3.6f / (1 - Progress);

--- a/Ship_Game/Technology.cs
+++ b/Ship_Game/Technology.cs
@@ -138,6 +138,17 @@ namespace Ship_Game
             public string Type;
         }
         
+        public Array<Technology> DescendantTechs()
+        {
+            var descendants = new Array<Technology>();
+            foreach (Technology child in Children)
+            {
+                descendants.Add(child);
+                descendants.AddRange(child.DescendantTechs());
+            }
+            return descendants;
+        }
+        
         public float ActualCost(UniverseState universeState)
         {
             UniverseState us = universeState ?? throw new NullReferenceException(nameof(universeState));

--- a/Ship_Game/Technology.cs
+++ b/Ship_Game/Technology.cs
@@ -171,10 +171,8 @@ namespace Ship_Game
             }
             
             // reverse the order so that the technologies are in order from root to this
-            var reversed = new Array<Technology>(predecessors.Count);
-            for (int i = predecessors.Count - 1; i >= 0; --i)
-                reversed.Add(predecessors[i]);
-            return reversed;
+            predecessors.Reverse();
+            return predecessors;
         }
         
         public float ActualCost(UniverseState universeState)

--- a/Ship_Game/Technology.cs
+++ b/Ship_Game/Technology.cs
@@ -47,7 +47,9 @@ namespace Ship_Game
             return $"Tech {UID} Name={Name.Text} Root={IsRootNode} Cost={Cost} Parents={Parents.Length}";
         }
 
+        /// LeadsTo is array of only direct children
         public Array<LeadsToTech> LeadsTo                = new();
+        
         public Array<LeadsToTech> ComesFrom              = new();
         public Array<UnlockedMod> ModulesUnlocked        = new();
         public Array<UnlockedBuilding> BuildingsUnlocked = new();

--- a/Ship_Game/Technology.cs
+++ b/Ship_Game/Technology.cs
@@ -138,6 +138,13 @@ namespace Ship_Game
             public string Type;
         }
         
+        // NOTE: technically the research 'tree' isn't a tree because node can have multiple parents
+        //       but this will work anyway
+        /// <summary>
+        /// Performs a depth-first search of the tech 'tree' graph, starting at this tech
+        /// and continuing to 'leafs'.
+        /// </summary>
+        /// <returns>Array of all Technologies that are descendants of this one</returns>
         public Array<Technology> DescendantTechs()
         {
             var descendants = new Array<Technology>();
@@ -147,6 +154,27 @@ namespace Ship_Game
                 descendants.AddRange(child.DescendantTechs());
             }
             return descendants;
+        }
+        
+        /// <summary>
+        /// Performs a depth-first search of the tech 'tree' graph, starting at this tech
+        /// and continuing to 'root'.
+        /// </summary>
+        /// <returns>Array of all Technologies that lead from root to this one</returns>
+        public Array<Technology> PredecessorTechs()
+        {
+            var predecessors = new Array<Technology>();
+            foreach (Technology parent in Parents)
+            {
+                predecessors.Add(parent);
+                predecessors.AddRange(parent.PredecessorTechs());
+            }
+            
+            // reverse the order so that the technologies are in order from root to this
+            var reversed = new Array<Technology>(predecessors.Count);
+            for (int i = predecessors.Count - 1; i >= 0; --i)
+                reversed.Add(predecessors[i]);
+            return reversed;
         }
         
         public float ActualCost(UniverseState universeState)

--- a/Ship_Game/TreeNode.cs
+++ b/Ship_Game/TreeNode.cs
@@ -274,7 +274,7 @@ namespace Ship_Game
             }
             else
             {
-                string text = $"Right Click to Expand \n\n{Entry.Tech.Description.Text}";
+                string text = $"Right Click to Expand\nCtrl Left Click to move or insert at topmost possible place in queue.\n\n{Entry.Tech.Description.Text}";
                 if (Complete && !Entry.MultiLevelComplete && !Screen.Player.Research.IsQueued(Entry.UID))
                     text = $"Left Click to research level {Entry.Level+1} of this tech.\n\n{text}";
 

--- a/Ship_Game/UI/UIButton_Style.cs
+++ b/Ship_Game/UI/UIButton_Style.cs
@@ -37,13 +37,13 @@ namespace Ship_Game
 
             // Text Colors
             public Color DefaultTextColor = new Color(255, 240, 189);
-            public Color HoverTextColor = new Color(255, 240, 189);
-            public Color PressTextColor = new Color(255, 240, 189);
+            public Color HoverTextColor   = new Color(255, 240, 189);
+            public Color PressTextColor   = new Color(255, 240, 189);
 
             // Fallback background colors if texture is null
             public Color DefaultColor = new Color(96, 81, 49);
-            public Color HoverColor = new Color(106, 91, 59);
-            public Color PressColor = new Color(86, 71, 39);
+            public Color HoverColor   = new Color(106, 91, 59);
+            public Color PressColor   = new Color(86, 71, 39);
 
             public bool DrawBackground = true;
 
@@ -53,15 +53,15 @@ namespace Ship_Game
 
             public StyleTextures(string normal)
             {
-                Normal = ResourceManager.Texture(normal);
-                Hover = ResourceManager.Texture(normal + "_hover");
+                Normal  = ResourceManager.Texture(normal);
+                Hover   = ResourceManager.Texture(normal + "_hover");
                 Pressed = ResourceManager.Texture(normal + "_pressed");
             }
 
             public StyleTextures(string normal, string hover)
             {
-                Normal = ResourceManager.Texture(normal);
-                Hover = ResourceManager.Texture(hover);
+                Normal  = ResourceManager.Texture(normal);
+                Hover   = ResourceManager.Texture(hover);
                 Pressed = Hover;
             }
 
@@ -84,13 +84,13 @@ namespace Ship_Game
                         break;
                     case ButtonStyle.DanButtonBlue:
                         DefaultTextColor = new Color(205, 229, 255);
-                        HoverTextColor = new Color(174, 202, 255);
-                        PressTextColor = new Color(174, 202, 255);
+                        HoverTextColor   = new Color(174, 202, 255);
+                        PressTextColor   = new Color(174, 202, 255);
                         break;
                     case ButtonStyle.DanButtonRed:
                         DefaultTextColor = Color.Red;
-                        HoverTextColor = Color.White;
-                        PressTextColor = Color.Green;
+                        HoverTextColor   = Color.White;
+                        PressTextColor   = Color.Green;
                         break;
                 }
             }
@@ -126,7 +126,7 @@ namespace Ship_Game
                 new StyleTextures("UI/btn_event_confirm_big"),
                 new StyleTextures() { DrawBackground = false },
             };
-            return Styling[(int)style];
+            return Styling[(int) style];
         }
 
         void SetStyle(ButtonStyle style)
@@ -158,13 +158,13 @@ namespace Ship_Game
                 return Normal.SizeF;
             return new Vector2(2, 2);
         }
-
+        
         SubTexture ButtonTexture()
         {
             switch (State)
             {
-                default: return Normal;
-                case PressState.Hover: return Hover;
+                default:                 return Normal;
+                case PressState.Hover:   return Hover;
                 case PressState.Pressed: return Pressed;
             }
         }
@@ -173,8 +173,8 @@ namespace Ship_Game
         {
             switch (State)
             {
-                default: return DefaultColor;
-                case PressState.Hover: return HoverColor;
+                default:                 return DefaultColor;
+                case PressState.Hover:   return HoverColor;
                 case PressState.Pressed: return PressColor;
             }
         }
@@ -183,8 +183,8 @@ namespace Ship_Game
         {
             switch (State)
             {
-                default: return DefaultTextColor;
-                case PressState.Hover: return HoverTextColor;
+                default:                 return DefaultTextColor;
+                case PressState.Hover:   return HoverTextColor;
                 case PressState.Pressed: return PressTextColor;
             }
         }

--- a/Ship_Game/UI/UIButton_Style.cs
+++ b/Ship_Game/UI/UIButton_Style.cs
@@ -19,6 +19,7 @@ namespace Ship_Game
         ResearchQueueUp, // "ResearchMenu/button_queue_up"
         ResearchQueueDown, // "ResearchMenu/button_queue_down"
         ResearchQueueCancel, // "ResearchMenu/button_queue_cancel"
+        ResearchQueueToTop, // "ResearchMenu/button_queue_to_top"
         DanButton,     // UI/dan_button  -- wide brown button
         DanButtonBlue, // UI/dan_button_blue -- blue version of dan_button
         DanButtonRed, // UI/dan_button_red -- red version of dan_button
@@ -36,13 +37,13 @@ namespace Ship_Game
 
             // Text Colors
             public Color DefaultTextColor = new Color(255, 240, 189);
-            public Color HoverTextColor   = new Color(255, 240, 189);
-            public Color PressTextColor   = new Color(255, 240, 189);
+            public Color HoverTextColor = new Color(255, 240, 189);
+            public Color PressTextColor = new Color(255, 240, 189);
 
             // Fallback background colors if texture is null
             public Color DefaultColor = new Color(96, 81, 49);
-            public Color HoverColor   = new Color(106, 91, 59);
-            public Color PressColor   = new Color(86, 71, 39);
+            public Color HoverColor = new Color(106, 91, 59);
+            public Color PressColor = new Color(86, 71, 39);
 
             public bool DrawBackground = true;
 
@@ -52,15 +53,15 @@ namespace Ship_Game
 
             public StyleTextures(string normal)
             {
-                Normal  = ResourceManager.Texture(normal);
-                Hover   = ResourceManager.Texture(normal + "_hover");
+                Normal = ResourceManager.Texture(normal);
+                Hover = ResourceManager.Texture(normal + "_hover");
                 Pressed = ResourceManager.Texture(normal + "_pressed");
             }
 
             public StyleTextures(string normal, string hover)
             {
-                Normal  = ResourceManager.Texture(normal);
-                Hover   = ResourceManager.Texture(hover);
+                Normal = ResourceManager.Texture(normal);
+                Hover = ResourceManager.Texture(hover);
                 Pressed = Hover;
             }
 
@@ -83,13 +84,13 @@ namespace Ship_Game
                         break;
                     case ButtonStyle.DanButtonBlue:
                         DefaultTextColor = new Color(205, 229, 255);
-                        HoverTextColor   = new Color(174, 202, 255);
-                        PressTextColor   = new Color(174, 202, 255);
+                        HoverTextColor = new Color(174, 202, 255);
+                        PressTextColor = new Color(174, 202, 255);
                         break;
                     case ButtonStyle.DanButtonRed:
                         DefaultTextColor = Color.Red;
-                        HoverTextColor   = Color.White;
-                        PressTextColor   = Color.Green;
+                        HoverTextColor = Color.White;
+                        PressTextColor = Color.Green;
                         break;
                 }
             }
@@ -118,13 +119,14 @@ namespace Ship_Game
                 new StyleTextures("ResearchMenu/button_queue_up", "ResearchMenu/button_queue_up_hover"),
                 new StyleTextures("ResearchMenu/button_queue_down", "ResearchMenu/button_queue_down_hover"),
                 new StyleTextures("ResearchMenu/button_queue_cancel", "ResearchMenu/button_queue_cancel_hover"),
+                new StyleTextures("ResearchMenu/button_queue_to_top", "ResearchMenu/button_queue_to_top_hover"),
                 new StyleTextures("UI/dan_button", ButtonStyle.DanButton),
                 new StyleTextures("UI/dan_button_blue", ButtonStyle.DanButtonBlue),
                 new StyleTextures("UI/dan_button_red", ButtonStyle.DanButtonRed),
                 new StyleTextures("UI/btn_event_confirm_big"),
                 new StyleTextures() { DrawBackground = false },
             };
-            return Styling[(int) style];
+            return Styling[(int)style];
         }
 
         void SetStyle(ButtonStyle style)
@@ -156,13 +158,13 @@ namespace Ship_Game
                 return Normal.SizeF;
             return new Vector2(2, 2);
         }
-        
+
         SubTexture ButtonTexture()
         {
             switch (State)
             {
-                default:                 return Normal;
-                case PressState.Hover:   return Hover;
+                default: return Normal;
+                case PressState.Hover: return Hover;
                 case PressState.Pressed: return Pressed;
             }
         }
@@ -171,8 +173,8 @@ namespace Ship_Game
         {
             switch (State)
             {
-                default:                 return DefaultColor;
-                case PressState.Hover:   return HoverColor;
+                default: return DefaultColor;
+                case PressState.Hover: return HoverColor;
                 case PressState.Pressed: return PressColor;
             }
         }
@@ -181,8 +183,8 @@ namespace Ship_Game
         {
             switch (State)
             {
-                default:                 return DefaultTextColor;
-                case PressState.Hover:   return HoverTextColor;
+                default: return DefaultTextColor;
+                case PressState.Hover: return HoverTextColor;
                 case PressState.Pressed: return PressTextColor;
             }
         }

--- a/game/Content/Textures/ResearchMenu/button_queue_cancel_hover.png
+++ b/game/Content/Textures/ResearchMenu/button_queue_cancel_hover.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0b4fa3dae2cdf805cafc1b90012da91c315c61cc41a4e15523900d7477852742
-size 1961
+oid sha256:0b1658860c9af3548893ed9a1a68341823b356ac18dc0ed48933d531c341fd9e
+size 2104

--- a/game/Content/Textures/ResearchMenu/button_queue_to_top.png
+++ b/game/Content/Textures/ResearchMenu/button_queue_to_top.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e17d881e3ff3c974f06b82f5dc976842ebefa241965ac2c4b9f2548e1eb23a2
+size 895

--- a/game/Content/Textures/ResearchMenu/button_queue_to_top_hover.png
+++ b/game/Content/Textures/ResearchMenu/button_queue_to_top_hover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4258ca15dbb255a54388733c369995db96e581207cd4baa0f3ff64493e561d6
+size 1739

--- a/game/Content/Textures/ResearchMenu/button_queue_to_top_press.png
+++ b/game/Content/Textures/ResearchMenu/button_queue_to_top_press.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72cf95ecdf52db8938586a584d3f03a4d61e66d9fba0bd0e792b7d824c1f45fe
+size 1574


### PR DESCRIPTION
### Changes from player perspective:

**Research Queue**
- when clicking on the normal Up button with Ctrl, the selected research in the queue will move to top or to a position in the queue where it is blocked by its prerequisite
- added new ToTop button, when clicked it will bring the selected research to the top and if any prerequisites are enqueued as well, they will also be brought to the top of the queue
- changed color of cancel_on_hover to red because it is destructive action

**Research Tree**
- when clicking on a research node that is already enqueued, it will be dequeued and all the subsequent research will also be dequeued
- when Ctrl clicking on a research node (doesn't matter if already enqueued or not), the research will be moved to the top with all prerequisites as well.

### Changes to code:
- **EmpireResearch** now provides methods for checking if research can move up and can move down,
to move it up or down, to move it up to the next prerequisite, and to move it up with all prerequisites as well.
Also has methods for enqueuing research that will enqueue all predecessor research if necessary, and dequeuing tech from queue with all subsequent enqueued research.
- **ResearchScreenNew** added dequeuing and ToTopWithPreReqs functionality to the _OnTechNodeClicked_ , also slightly rewritten the original enqueuing using the new methods from EmpireResearch
- **ResearchQItem** added new ToTop button with the ToTopWithPreReqs functionality,
added to the Up button when Ctrl is held down then ToTopOrPreReq
- **Technology** technology instances have methods DescendantTechs that return all research technologies subsequent to this one,
and PredecessorTechs that return all research technologies that need to be research before this one
- **UIButton_Style** just added btnToTop enum value and path to the new ToTop button textures