### PR TITLE
Patches 1.41 - Bug fixes

### DIFF
--- a/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
@@ -407,7 +407,7 @@ namespace Ship_Game.AI
             float value = (10000f * dps) / (tgt.Health + tgt.ShieldPower).LowerBound(1);
             value *= 1f + tgt.Carrier.AllFighterHangars.Length*0.75f;
             value *= 1 + tgt.TroopCapacity*0.5f;
-            value *= 1 + (tgt.HasBombs ? tgt.BombBays.Count*2 : tgt.BombBays.Count*0.5f);
+            value *= 1 + (tgt.HasBombs ? tgt.BombBays.Count : tgt.BombBays.Count*0.25f);
 
             bool debug = EnableTargetPriorityDebug && (Owner.Loyalty.isPlayer);
             void Debug(string s) => Log.Write(

--- a/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
@@ -279,7 +279,7 @@ namespace Ship_Game.AI
                 orbital.TetherToPlanet(planetToTether);
                 orbital.TetherOffset = bg.TetherOffset;
                 UpdateResearchStationGoal(orbital, bg.TetherPlanet);
-                UpdateMiningOpsGoal(orbital, bg.TetherPlanet);
+                UpdateMiningOpsGoal(orbital, bg.TetherPlanet, goal.OldShip);
                 planetToTether.OrbitalStations.Add(orbital);
                 if (planetToTether.IsOverOrbitalsLimit(orbital.ShipData))
                     planetToTether.TryRemoveExcessOrbital(orbital);
@@ -345,7 +345,7 @@ namespace Ship_Game.AI
                 }
 
                 UpdateResearchStationGoal(orbital, target);
-                UpdateMiningOpsGoal(orbital, target);
+                UpdateMiningOpsGoal(orbital, target, goal.OldShip);
             }
         }
 
@@ -362,12 +362,15 @@ namespace Ship_Game.AI
             }
         }
 
-        void UpdateMiningOpsGoal(Ship orbital, Planet planet)
+        void UpdateMiningOpsGoal(Ship orbital, Planet planet, Ship oldShipToRefit)
         {
             if (!orbital.IsMiningStation)
                 return;
 
-            Goal goal = Owner.Loyalty.AI.FindGoal(g => g.IsMiningOpsGoal(planet) && g.StepName == "WaitForConstructor");
+            Goal goal = Owner.Loyalty.AI.FindGoal(g => g.IsMiningOpsGoal(planet) 
+                                                  && (oldShipToRefit == null ? g.StepName == "WaitForConstructor"
+                                                                             : g.TargetShip == oldShipToRefit));
+
             if (goal != null)
                 goal.TargetShip = orbital;
 

--- a/Ship_Game/EmpireDifficultyModifers.cs
+++ b/Ship_Game/EmpireDifficultyModifers.cs
@@ -150,12 +150,11 @@
                     if (!empire.isPlayer)
                     {
                         FlatMoneyBonus = 10;
-                        ProductionMod  = 0.3f;
+                        ProductionMod  = 0.25f;
                         ResearchMod    = 0.5f;
                         TaxMod         = 0.5f;
                         ShipCostMod    = -0.2f;
                         TroopCostMod   = -0.2f;
-                        ResearchTaxMultiplier  = 0.7f;
                         PlayerWarPriorityLimit = 5;
                     }
 
@@ -202,7 +201,7 @@
                         ShipCostMod    = -0.4f;
                         ModHpModifier  = 0.1f;
                         TroopCostMod   = -0.4f;
-                        ResearchTaxMultiplier  = 0.5f;
+                        ResearchTaxMultiplier  = 0.75f;
                         PlayerWarPriorityLimit = 3;
                     }
 

--- a/Ship_Game/Pirates.cs
+++ b/Ship_Game/Pirates.cs
@@ -545,7 +545,7 @@ namespace Ship_Game
 
         public void ProcessShip(Ship ship, Ship pirateBase)
         {
-            if (SpawnedShips.Contains(ship.Id))
+            if (ship.IsDefaultAssaultShuttle || SpawnedShips.Contains(ship.Id))
             {
                 // We cannot salvage ships that we spawned
                 // remove it with no benefits

--- a/Ship_Game/Remnants.cs
+++ b/Ship_Game/Remnants.cs
@@ -217,8 +217,20 @@ namespace Ship_Game
             }
         }
 
-        int TurnsLevelUp                  => Owner.DifficultyModifiers.RemnantTurnsLevelUp;
-        int ExtraLevelUpEffort            => (int)((Level-1) * Universe.RemnantPaceModifier + NeededHibernationTurns);
+        int TurnsLevelUp
+        {
+            get
+            {
+                int numturns = Owner.DifficultyModifiers.RemnantTurnsLevelUp;
+                switch (Universe.P.ExtraRemnant)
+                {
+                    case ExtraRemnantPresence.VeryRare: return numturns / 2;
+                    case ExtraRemnantPresence.Rare:     return (int)(numturns / 1.5f);
+                    default:                            return numturns;
+                }
+            }
+        }
+        int ExtraLevelUpEffort => (int)((Level-1)*Universe.RemnantPaceModifier + NeededHibernationTurns);
         public int NeededHibernationTurns => TurnsLevelUp / ((int)Universe.P.Difficulty + 2);
 
         void SetInitialLevelUpDate()
@@ -615,16 +627,16 @@ namespace Ship_Game
         {
             numBombers = (int)(Level * Owner.DifficultyModifiers.RemnantNumBombers);
 
-            if (Level <= 6)
+            if (Level <= 5)
             {
-                numBombers *= 2;
+                numBombers *= (Level-1).LowerBound(1);
                 return RemnantShipType.BomberLight;
             }
 
-            if (Level <= 11)
+            if (Level <= 9)
                 return RemnantShipType.BomberMedium;
 
-            // Level 12 and above
+            // Level 10 and above
             numBombers /= 2;
             return RemnantShipType.Bomber;
         }

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -1791,7 +1791,6 @@ namespace Ship_Game.Ships
                     if (m.IsTroopBay || m.IsSupplyBay || m.MaximumHangarShipSize > 0)
                         hangarArea += m.Area;
 
-                    offense += m.CalculateModuleOffense();
                     defense += m.CalculateModuleOffenseDefense(SurfaceArea);
                 }
             }

--- a/Ship_Game/Ships/ShipResupply.cs
+++ b/Ship_Game/Ships/ShipResupply.cs
@@ -37,7 +37,7 @@ namespace Ship_Game.Ships
             IncomingOrdnance = 0;
         }
 
-        public bool InTradeBlockade => Ship.IsResearchStation && Ship.HealthPercent < DamageThreshold(ShipCategory.Civilian);
+        public bool InTradeBlockade => (Ship.IsResearchStation || Ship.IsMiningStation) && Ship.HealthPercent < DamageThreshold(ShipCategory.Civilian);
         public static bool HasGoodTotalSupplyForResearch(IShipDesign ship)
         {
             if (!ship.IsResearchStation) 


### PR DESCRIPTION
Fix: Mining Station goal is removed when refit is completed. 
Fix: InTradeBlockade for mining stations as well.
Fix: pirate assault ships are not removed as they should, near pirate bases.
Fix: STR calculated twice.
Balance: AI Hard difficulty (slightly nerfed). 
Balance: Bomber targeting priority balance
Balance: Increase remnant pace speed if galaxy has lower remnants (as all empires advance quicker)

