### PR TITLE
Mars 1.41 patch - mining ops and empire absorb fixes

### DIFF
--- a/Ship_Game/Universe/SolarBodies/Planet/Mineable.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Mineable.cs
@@ -46,7 +46,7 @@ namespace Ship_Game
             return P.OrbitalStations.Any(o => o.IsMiningStation);
         }
 
-        void ChangeOwner(Empire empire)
+        public void ChangeOwner(Empire empire)
         {
             Owner = empire;
         }


### PR DESCRIPTION
- Fix: Mining Ops issues when an empire is absorbed.
- Fix: Remove single rebel ship created when there is bankruptcy. need to make several and consider research stations / mining stations
- Fix: Remove planet supply ship when empire changes