### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/AI/EmpireAI/EmpireAI.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.cs
@@ -137,12 +137,11 @@ namespace Ship_Game.AI
                 if (ResearchStationsAI == null)
                     ResearchStationsAI = new(OwnerEmpire);
 
-                ResearchStationsAI?.RunResearchStationPlanner(); // the null check here is for save competability
-
                 if (MiningOpsAI == null)
                     MiningOpsAI = new(OwnerEmpire);
 
-                MiningOpsAI.RunMiningOpsPlanner(); // the null check here is for save competability
+                ResearchStationsAI.RunResearchStationPlanner();
+                MiningOpsAI.RunMiningOpsPlanner();
                 SpaceRoadsManager.Update();
                 RunDiplomaticPlanner();
                 RunResearchPlanner();

--- a/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
@@ -640,11 +640,7 @@ namespace Ship_Game.AI
         {
             ClearOrders();
             IgnoreCombat = true;
-            float distance = targetPlanet.Random.Float(targetPlanet.Mining.MinMiningRadius,
-                                                       targetPlanet.Mining.MaxMiningRadius);
-
-            Vector2 pos = targetPlanet.Position.GenerateRandomPointOnCircle(distance, targetPlanet.Random);
-            AddShipGoal(Plan.MinePlanet, AIState.Mining, pos, targetPlanet, true);
+            AddShipGoal(Plan.MinePlanet, AIState.Mining, targetPlanet.Mining.GetMinePos(), targetPlanet, true);
         }
 
         public void OrderSystemDefense(SolarSystem system)

--- a/Ship_Game/Commands/Goals/MiningOps.cs
+++ b/Ship_Game/Commands/Goals/MiningOps.cs
@@ -162,7 +162,7 @@ namespace Ship_Game.Commands.Goals
 
             float numRawResources = MiningStation.GetOtherCargo(ResourceCargoName);
             float numRefiningNeeded = Owner.GetRefiningNeeded(ExoticBonusType);
-            MiningStation.Carrier.MiningBays.ProcessMiningBays(numRawResources);
+            MiningStation.Carrier.MiningBays.ProcessMiningBays(numRawResources, TargetPlanet);
             MiningStation.Carrier.MiningBays.UpdateIsRefining(0);
 
             if (numRefiningNeeded <= 0 || numRawResources <= 0 || MiningStation.Loyalty != TargetPlanet.Mining.Owner)

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -520,7 +520,7 @@ namespace Ship_Game
         public bool CanTerraformPlanetTiles => IsBuildingUnlocked(Building.TerraformerId) && data.Traits.TerraformingLevel >= 2;
         public bool CanFullTerraformPlanets => IsBuildingUnlocked(Building.TerraformerId) && data.Traits.TerraformingLevel >= 3;
 
-        public float AverageSystemsSqdistFromCenter => OwnedSolarSystems.Average(s => s.Position.SqDist(WeightedCenter));
+        public float AverageSystemsSqdistFromCenter => OwnedSolarSystems.Count > 0 ? OwnedSolarSystems.Average(s => s.Position.SqDist(WeightedCenter)) : 0;
 
         public bool IsModuleUnlocked(string moduleUID) => UnlockedModulesDict.TryGetValue(moduleUID, out bool found) && found;
 

--- a/Ship_Game/Ships/CarrierBays.cs
+++ b/Ship_Game/Ships/CarrierBays.cs
@@ -134,6 +134,19 @@ namespace Ship_Game.Ships
             MiningBays     = null;
         }
 
+        public void DisposeHangarShip(Ship hangarShip)
+        {
+            for (int i = 0; i < AllHangars.Length; i++)
+            {
+                ShipModule hangar = AllHangars[i];
+                if (hangar.HangarShip == hangarShip)
+                {
+                    hangar.SetHangarShip(null);
+                    return;
+                }
+            }
+        }
+
         // aggressive dispose looks to cause a crash here. 
         public ShipModule[] AllActiveHangars   => AllHangars?.Filter(module => module.Active);
         public bool HasActiveHangars           => AllHangars.Any(module => module.Active); // FB: this changes dynamically
@@ -604,7 +617,7 @@ namespace Ship_Game.Ships
             if (Owner == null || empire.Id == -1)
                 return false;
 
-            if (hangar.TryGetHangarShip(out _))
+            if (hangar.TryGetHangarShipActive(out _))
                 return false;
 
             if (hangar.IsSupplyBay)

--- a/Ship_Game/Ships/MiningBays.cs
+++ b/Ship_Game/Ships/MiningBays.cs
@@ -25,7 +25,7 @@ namespace Ship_Game.Ships
             Owner = null;
         }
 
-        public void ProcessMiningBays(float rawResourcesStored)
+        public void ProcessMiningBays(float rawResourcesStored, Planet planet)
         {
             if (Owner == null
                 || !HasOrdnanceToLaunch()
@@ -37,16 +37,16 @@ namespace Ship_Game.Ships
             float resourcesNeeded = RefiningOutput > 0 ? Owner.MiningStationCargoSpaceMax 
                                                        : Owner.MiningStationCargoSpaceMax - rawResourcesStored;
 
-            if (TryGetCandidateBayAndReturnExceesMiners(resourcesNeeded, out ShipModule candidateBay)
+            if (TryGetCandidateBayAndReturnExcessMiners(resourcesNeeded, out ShipModule candidateBay)
                 && CreateMiningShip(candidateBay, out Ship miningShip)) 
             {
                 candidateBay.HangarTimer = candidateBay.HangarTimerConstant;
-                miningShip.AI.OrderMinePlanet(Owner.GetTether());
+                miningShip.AI.OrderMinePlanet(planet);
                 return;
             }
         }
 
-        bool TryGetCandidateBayAndReturnExceesMiners(float resourcesNeeded, out ShipModule candidateBay)
+        bool TryGetCandidateBayAndReturnExcessMiners(float resourcesNeeded, out ShipModule candidateBay)
         {
             candidateBay = null;
             float miningShipsCapacityAlreadyMining = 0;

--- a/Ship_Game/Ships/ShipModule.cs
+++ b/Ship_Game/Ships/ShipModule.cs
@@ -77,7 +77,7 @@ namespace Ship_Game.Ships
         public Restrictions Restrictions;
         public Shield Shield { get; private set; }
         public string HangarShipUID;
-        [StarData] public Ship HangarShip;
+        [StarData] public Ship HangarShip { get; private set; }
         [StarData] public float HangarTimer;
         public bool IsWeapon;
         public Weapon InstalledWeapon;

--- a/Ship_Game/Ships/Ship_Events.cs
+++ b/Ship_Game/Ships/Ship_Events.cs
@@ -76,6 +76,7 @@ namespace Ship_Game.Ships
         {
             Carrier.AddToOrdnanceInSpace(-ship.ShipOrdLaunchCost);
             UpdateOrdnancePercentage();
+            Carrier.DisposeHangarShip(ship);
         }
 
         // EVT: when a ShipModule installs a new weapon

--- a/Ship_Game/Ships/Ship_Initialize.cs
+++ b/Ship_Game/Ships/Ship_Initialize.cs
@@ -356,10 +356,10 @@ namespace Ship_Game.Ships
 
             if (ship == null)
             {
-                Log.Warning($"Could not create ship from hangar, UID = {hangar.HangarShipUID}");
+                Log.Warning($"Carrier {parent.Name} ({parent.Id}): Could not create ship from hangar, UID = {hangar.HangarShipUID}");
                 return null;
             }
-
+            
             ship.Mothership = parent;
             if (ship.IsMiningShip)
                 ship.InitLaunch(LaunchPlan.Mining);

--- a/Ship_Game/StoryAndEvents/NotificationManager.cs
+++ b/Ship_Game/StoryAndEvents/NotificationManager.cs
@@ -705,12 +705,12 @@ namespace Ship_Game
             }, "sd_ui_notification_encounter");
         }
 
-        public void AddScrapUnlockNotification(string message, string iconPath, string action)
+        public void AddScrapUnlockNotification(string message, string iconPath)
         {
             AddNotification(new Notification
             {
                 Message  = message,
-                Action   = action,
+                Action   = "ShipDesign",
                 IconPath = iconPath ?? "ResearchMenu/icon_event_science_bad"
             }, "sd_ui_notification_encounter");
         }
@@ -801,18 +801,18 @@ namespace Ship_Game
             }, "sd_ui_notification_encounter");
         }
 
-        public void AddScrapProgressNotification(string message, string iconPath, string action, string techName)
+        public void AddScrapProgressNotification(string message, string iconPath, string techName)
         {
             AddNotification(new Notification
             {
                 Message = message,
-                Action = action,
+                Action = "ResearchScreen",
                 ReferencedItem1 = techName,
                 IconPath = iconPath ?? "ResearchMenu/icon_event_science_bad"
             }, "sd_ui_notification_encounter");
         }
 
-        public void AddRebellionNotification(Planet beingInvaded, Empire invader)
+        public void AddRebellionNotification(Planet beingInvaded)
         {
             string message = "Rebellion on " + beingInvaded.Name + "!";
             if (IsNotificationPresent(message))

--- a/Ship_Game/TechEntry.cs
+++ b/Ship_Game/TechEntry.cs
@@ -513,9 +513,8 @@ namespace Ship_Game
         {
             DoRevealedTechs(us);
             if (bonusUnlock)
-            {
                 UnlockBonus(us);
-            }
+
             UnlockModules(us, them);
             UnlockTroops(us, them);
             UnLockHulls(us, them);
@@ -524,6 +523,11 @@ namespace Ship_Game
             // Finally, remove this tech from our ResearchQueue
             if (removeFromQueue)
                 us.Research.RemoveFromQueue(UID);
+        }
+
+        void UnlockHullReverseEngineer(Empire us, string hullname)
+        {
+            us.UnlockEmpireHull(hullname, UID);
         }
 
         public bool UnlockFromSpy(Empire us, Empire them)
@@ -553,7 +557,7 @@ namespace Ship_Game
             return false;
         }
 
-        public bool UnlockFromScrap(Empire us, Empire them)
+        public bool UnlockFromScrap(Empire us, Empire them, string hullname)
         {
             if (Locked)
             {
@@ -567,7 +571,7 @@ namespace Ship_Game
 
             if (WasAcquiredFrom.AddUnique(them.data.Traits.ShipType))
             {
-                UnlockTechContentOnly(us, them);
+                us.UnlockEmpireHull(hullname, UID);
                 return true;
             }
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Mineable.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Mineable.cs
@@ -1,5 +1,6 @@
 ﻿using SDGraphics;
 using SDUtils;
+using Ship_Game.ExtensionMethods;
 using Ship_Game.Data.Serialization;
 using Ship_Game.Universe;
 
@@ -27,7 +28,7 @@ namespace Ship_Game
         public float RefiningRatio => ResourceType.RefiningRatio; // How much of the resource is processed per turn
         public ExoticBonusType ExoticBonusType => ResourceType.ExoticBonusType;
 
-        public float MinMiningRadius => P.Radius * 0.5f;
+        float MinMiningRadius => P.Radius * 0.5f;
         public float MaxMiningRadius => P.Radius * 0.7f;
 
 
@@ -35,6 +36,11 @@ namespace Ship_Game
         public bool MiningOpsExistFor(Empire empire) => Owner == empire && MiningOpsSize > 0;
         int MiningOpsSize => HasOpsOwner ? Owner.AI.CountGoals(g => g.IsMiningOpsGoal(P)) : 0;
 
+        public Vector2 GetMinePos()
+        {
+            float distance = P.Random.Float(MinMiningRadius, MaxMiningRadius);
+            return P.Position.GenerateRandomPointOnCircle(distance, P.Random);
+        }
 
         public bool AreMiningOpsPresentBy(Empire empire)
         {

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -6055,8 +6055,8 @@ ConstructionModule:
  RUS: "Этот модуль строительства предоставляет инфраструктуру, необходимую для строительства платформ и станций на орбите или в глубоком космосе. Когда строительный корабль достигает позиции сборки, он начинает передавать продукцию, необходимую для строительства конструкции, добавляя строительство за ход. Несколько строительных массивов увеличат темпы строительства."
 ReverseEngineered:
  Id: 1932
- ENG: " was reverse engineered during the scrap process.\nThis hull can now be used to build our own ships!"
- RUS: " был реконструирован в процессе утилизации.\nТеперь этот корпус можно использовать для постройки собственных кораблей!"
+ ENG: " hull was reverse engineered during the scrap process.\nThis hull can now be used to build our own ships!"
+ RUS: " Корпус был реконструирован во время процесса утилизации.\nТеперь этот корпус можно использовать для постройки наших собственных кораблей!"
 HullScrappedAdvancingResearch:
  Id: 1933
  ENG: " was scrapped, helping us advance in our own research\ntoward this hull type."


### PR DESCRIPTION
Fix: false positive of not finding hangar ship name to launch 
Fix: dispose dead hangar ship from Module.HangarShip
Fix: When unlocking from scrap, unlock hulls only and not the full possible content of the hull tech.
Fix: Revered engineered hulls now unlock only the specific hull and not all hulls in the relevant tech.
Refactor: Encapsulation for GetMiningPos
Refactor: Slight refactor of notification manager
@gkapulis 