### PR TITLE
Patches 1.41

### DIFF
--- a/Ship_Game/AI/StrategyAI/FleetShips.cs
+++ b/Ship_Game/AI/StrategyAI/FleetShips.cs
@@ -310,7 +310,7 @@ namespace Ship_Game.AI
             if (task.NeededTroopStrength > 0)
             {
                 if (InvasionTroopStrength < task.NeededTroopStrength)
-                    LaunchTroopsAndAddToShipList(task.NeededTroopStrength, planetTroops);
+                    LaunchTroopsAndAddToShipList(planetTroops);
                 GetTroops(ships, task.NeededTroopStrength);
             }
 
@@ -329,25 +329,10 @@ namespace Ship_Game.AI
             });
         }
 
-        private void LaunchTroopsAndAddToShipList(int wantedTroopStrength, Array<Troop> planetTroops)
+        private void LaunchTroopsAndAddToShipList(Array<Troop> launchablePlanetTroops)
         {
-            foreach (Troop troop in planetTroops.Filter(delegate(Troop t)
+            foreach (Troop troop in launchablePlanetTroops)
             {
-                if (t.HostPlanet != null
-                    && t.Loyalty != null
-                    && t.CanLaunch // save some iterations to find tiles for irrelevant troops
-                    && !t.HostPlanet.RecentCombat
-                    && !t.HostPlanet.System.DangerousForcesPresent(t.Loyalty))
-                {
-                    return true;
-                }
-
-                return false;
-            }))
-            {
-                if (InvasionTroopStrength > wantedTroopStrength)
-                    break;
-
                 Ship launched = troop.Launch();
                 if (launched != null)
                     AddShip(launched);

--- a/Ship_Game/AI/Tasks/MilitaryTask_Requistions.cs
+++ b/Ship_Game/AI/Tasks/MilitaryTask_Requistions.cs
@@ -57,25 +57,21 @@ namespace Ship_Game.AI.Tasks
                 for (int i = 0; i < system.PlanetList.Count; i++)
                 {
                     Planet planet = system.PlanetList[i];
-                    if (planet.Owner != Owner || planet.RecentCombat) 
+                    if (planet.Owner != Owner || planet.RecentCombat || planet.SpaceCombatNearPlanet) 
                         continue;
 
                     float planetMinStr                 = sysCom.PlanetTroopMin(planet);
                     float planetDefendingTroopStrength = planet.GetDefendingTroopCount();
-                    float maxCanTake                   = troopPriorityHigh && !planet.RecentCombat && !planet.System.HostileForcesPresent(Owner)
+                    float maxCanTake                   = troopPriorityHigh && !planet.System.HostileForcesPresent(Owner)
                         ? 5 
                         : (planetDefendingTroopStrength - (planetMinStr - 3)).LowerBound(0);
 
                     if (maxCanTake > 0)
                     {
                         potentialTroops.AddRange(planet.GetEmpireTroops(Owner, (int)maxCanTake));
-
                         totalStrength = potentialTroops.Sum(t => t.ActualStrengthMax);
-
                         if (strengthNeeded <= totalStrength)
-                        {
                             break;
-                        }
                     }
                 }
 

--- a/Ship_Game/Commands/Goals/DeployFleetProjector.cs
+++ b/Ship_Game/Commands/Goals/DeployFleetProjector.cs
@@ -39,7 +39,19 @@ namespace Ship_Game.Commands.Goals
 
             float distanceToDeploy = Owner.GetProjectorRadius() * 0.8f;
             Vector2 dir = TargetPlanet.Position.DirectionToTarget(Fleet.AveragePosition());
-            BuildGoal = new(TargetPlanet.Position + dir * distanceToDeploy, "Subspace Projector", Owner, rush: true);
+            Vector2 deployPos = TargetPlanet.Position + dir * distanceToDeploy;
+
+            var projecors = Owner.OwnedProjectors;
+            foreach (Ship projector in projecors)
+            {
+                if (projector.Position.InRadius(deployPos, 100))
+                {
+                    Log.Info($"Build pos of fleet projector is near {deployPos}");
+                    return GoalStep.GoalComplete;
+                }
+            }
+
+            BuildGoal = new(deployPos, "Subspace Projector", Owner, rush: true);
             Owner.AI.AddGoalAndEvaluate(BuildGoal);
             return GoalStep.GoToNextStep;
         }

--- a/Ship_Game/EmpireExoticBonuses.cs
+++ b/Ship_Game/EmpireExoticBonuses.cs
@@ -44,11 +44,6 @@ namespace Ship_Game
         void RemoveFromStorage(float amount)
         {
             CurrentStorage = (CurrentStorage - amount).Clamped(0, MaxStorage);
-            if (float.IsNaN(CurrentStorage)) 
-            {
-                Log.Error($"Current storage was nan for {Owner.Name}!");
-                CurrentStorage = 0;
-            }
         }
 
         public void Update()
@@ -75,6 +70,12 @@ namespace Ship_Game
                 case ExoticBonusType.WarpSpeed:       consumption = Owner.TotalShipWarpThrustK;         break;
                 case ExoticBonusType.None:
                 default: break;
+            }
+
+            if (float.IsNaN(consumption))
+            {
+                Log.Error($"consumption was nan for {Owner.Name}, {Good.ExoticBonusType}!");
+                return;
             }
 
             Consumption = consumption * Good.ConsumptionMultiplier;

--- a/Ship_Game/EmpireExoticBonuses.cs
+++ b/Ship_Game/EmpireExoticBonuses.cs
@@ -44,6 +44,11 @@ namespace Ship_Game
         void RemoveFromStorage(float amount)
         {
             CurrentStorage = (CurrentStorage - amount).Clamped(0, MaxStorage);
+            if (float.IsNaN(CurrentStorage)) 
+            {
+                Log.Error($"Current storage was nan for {Owner.Name}!");
+                CurrentStorage = 0;
+            }
         }
 
         public void Update()

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -1134,7 +1134,7 @@ namespace Ship_Game.Fleets
 
                     break;
                 case 8:
-                    if (StillInvasionEffective(task))
+                    if (StillInvasionEffective(task) && task.TargetPlanet.Owner != null && task.TargetPlanet.Owner != Owner)
                     {
                         OrderShipsToInvade(Ships, task, false);
                         break;

--- a/Ship_Game/Remnants.cs
+++ b/Ship_Game/Remnants.cs
@@ -224,8 +224,8 @@ namespace Ship_Game
                 int numturns = Owner.DifficultyModifiers.RemnantTurnsLevelUp;
                 switch (Universe.P.ExtraRemnant)
                 {
-                    case ExtraRemnantPresence.VeryRare: return numturns / 2;
-                    case ExtraRemnantPresence.Rare:     return (int)(numturns / 1.5f);
+                    case ExtraRemnantPresence.VeryRare: return (int)(numturns * 0.66f);
+                    case ExtraRemnantPresence.Rare:     return (int)(numturns * 0.8f);
                     default:                            return numturns;
                 }
             }

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -880,7 +880,7 @@ namespace Ship_Game.Ships
             AI.OrderExplore();
         }
 
-        public void DoColonize(Planet p, Goal g)
+        public void OrderColonization(Planet p, Goal g)
         {
             AI.OrderColonization(p, g);
         }

--- a/Ship_Game/Ships/ShipEngines.cs
+++ b/Ship_Game/Ships/ShipEngines.cs
@@ -99,6 +99,9 @@ public class ShipEngines
 
     WarpStatus GetFormationWarpReadyStatus(Ship owner)
     {
+        if (owner.IsLaunching)
+            return Status(WarpStatus.WaitingOrRecalling, "Launching"); // tell everyone to plz wait
+
         if (owner.engineState == Ship.MoveState.Warp || !owner.CanTakeFleetMoveOrders())
             return Status(ReadyForWarp, "");
 

--- a/Ship_Game/Ships/Ship_Warp.cs
+++ b/Ship_Game/Ships/Ship_Warp.cs
@@ -227,9 +227,6 @@ namespace Ship_Game.Ships
         /// @return TRUE if ship can effectively warp the given distance in 1 jump
         public bool IsWarpRangeGood(float neededRange)
         {
-            if (IsLaunching) 
-                return false;
-
             if (neededRange <= 0f) return true;
             float powerDuration = NetPower.PowerDuration(MoveState.Warp, PowerCurrent);
             return ShipStats.IsWarpRangeGood(neededRange, powerDuration, MaxFTLSpeed);


### PR DESCRIPTION
Fix: Fleet take troops doing double checks. 
Fix: Fleet take troops now counted for TotalTroopStr  because of new launch code
Fix: wait for launching ships before fleet warp
Fix: claim fleets stuck in invesion phase.
Fix: several issues in MarkForColonization for the AI
Fix: Added trace and WA for NaN in mining Ops consumption.
Refactor: Slight refactor for MarkForColonization
Balance: Remnant Pace for Rare and VeryRare presence.