### PR TITLE
Patch 1.41

### DIFF
--- a/Ship_Game/Ships/Ship_Warp.cs
+++ b/Ship_Game/Ships/Ship_Warp.cs
@@ -183,7 +183,7 @@ namespace Ship_Game.Ships
                 return;
             }
 
-            if (JumpTimer <= 4.0f)
+            if (JumpTimer <= 3.0f)
             {
                 if (IsVisibleToPlayer && !Universe.Paused && JumpSfx.IsStopped && JumpSfx.IsReadyToReplay)
                 {

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.HandleInput.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.HandleInput.cs
@@ -498,6 +498,12 @@ namespace Ship_Game
             return UState.Spatial.FindNearby(ref opt).FastCast<SpatialObjectBase, Ship>();
         }
 
+        public Ship[] GetVisibleEnemyShipsInScreen()
+        {
+            Ship[] Ships = GetVisibleShipsInScreenRect(new RectF(0,0, new Vector2(ScreenArea.X, ScreenArea.Y)));
+            return Ships.Filter(s => !s.IsInWarp && Player.IsEmpireAttackable(s.Loyalty, s));
+        }
+
         Ship FindClickedShip(InputState input)
         {
             const float ClickRadius = 5f;


### PR DESCRIPTION
Fix: Do not allow moving ships "on top" of enemies by issuing a move order near them. Instead, redirect the order to a safe distance from enemy ships and play a different sound to the click order. This does not affect directly clicking on an enemy ship to attack it or on a planet.
Refactor: Remove legacy CoreFleet code.