### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/Commands/Goals/RemnantDefendPortal.cs
+++ b/Ship_Game/Commands/Goals/RemnantDefendPortal.cs
@@ -51,7 +51,7 @@ namespace Ship_Game.Commands.Goals
                 {
                     var task = MilitaryTask.CreateRemnantDefendPortal(Owner, Portal);
                     Owner.AI.AddPendingTask(task);
-                    task.CreateRemnantFleet(Owner, ship, $"Ancient Fleet", out Fleet);
+                    task.CreateRemnantFleet(Owner, ship, $"Ancient Defense Fleet", out Fleet);
                     continue;
                 }
 
@@ -72,7 +72,7 @@ namespace Ship_Game.Commands.Goals
         }
         GoalStep ManageCombat()
         {
-            if (Fleet.Ships.Count == 0)
+            if (Fleet == null || Fleet.Ships.Count == 0 || Remnants.NoPortals)
                 return GoalStep.GoalFailed; // fleet is dead
 
 

--- a/Ship_Game/Commands/Goals/RemnantEngageEmpire.cs
+++ b/Ship_Game/Commands/Goals/RemnantEngageEmpire.cs
@@ -124,7 +124,7 @@ namespace Ship_Game.Commands.Goals
             if (Remnants.RerouteGoalPortals(out Ship newPortal))
                 Portal = newPortal;
 
-            return Portal != null;
+            return Portal != null && Portal.Active;
         }
 
         GoalStep SelectFirstTargetPlanet()

--- a/Ship_Game/Commands/Goals/RemnantEngagements.cs
+++ b/Ship_Game/Commands/Goals/RemnantEngagements.cs
@@ -56,7 +56,7 @@ namespace Ship_Game.Commands.Goals
         {
             if (!Remnants.GetPortals(out Ship[] portals))
             {
-                Owner.Universe.Notifications.AddEmpireDiedNotification(Owner);
+                Owner.Universe.Notifications.AddEmpireDiedNotification(Owner, IsRemnant: true);
                 return GoalStep.GoalFailed;
             }
 

--- a/Ship_Game/Commands/Goals/RemnantEngagements.cs
+++ b/Ship_Game/Commands/Goals/RemnantEngagements.cs
@@ -56,7 +56,6 @@ namespace Ship_Game.Commands.Goals
         {
             if (!Remnants.GetPortals(out Ship[] portals))
             {
-                Owner.SetAsDefeated();
                 Owner.Universe.Notifications.AddEmpireDiedNotification(Owner);
                 return GoalStep.GoalFailed;
             }

--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -4662,6 +4662,8 @@ namespace Ship_Game
         ResearchMultiLevelTech = 4517,
         /// <summary>This Technology unlocks more than 4 items</summary>
         ResearchUnlocksMoreThanFourItems = 4518,
+        /// <summary>However, remaining Remnant fleets in this sector</summary>
+        RemnantsDefeatedFleetsMayAttack = 4519,
 
 
 

--- a/Ship_Game/Debug/Page/RemnantsDebug.cs
+++ b/Ship_Game/Debug/Page/RemnantsDebug.cs
@@ -20,6 +20,7 @@ public class RemnantsDebug : DebugPage
 
         Empire e = Universe.Remnants;
         Text.SetCursor(Parent.Win.X + 10 + 255, Parent.Win.Y + 250, e.EmpireColor);
+        Text.String($"Difficulty: {e.Universe.P.Difficulty}");
         Text.String($"Remnant Story: {e.Remnants.Story}");
         Text.String(!e.Remnants.Activated
             ? $"Trigger Progress: {e.Remnants.StoryTriggerKillsXp}/{e.Remnants.ActivationXpNeeded.String()}"

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -1806,7 +1806,9 @@ namespace Ship_Game
                     if (allEmpiresDead)
                     {
                         Empire remnants = Universe.Remnants;
-                        if (remnants.Remnants.Story == Remnants.RemnantStory.None || remnants.IsDefeated || !remnants.Remnants.Activated)
+                        if (remnants.Remnants.Story == Remnants.RemnantStory.None 
+                            || remnants.Remnants.NoPortals 
+                            || !remnants.Remnants.Activated)
                         {
                             Universe.Screen.OnPlayerWon();
                         }

--- a/Ship_Game/GameScreens/ScreenManager.cs
+++ b/Ship_Game/GameScreens/ScreenManager.cs
@@ -658,6 +658,7 @@ namespace Ship_Game
         {
             if (CurrentMusic != musicName || Music.IsStopped)
             {
+                GameAudio.ConfigureAudioSettings(GlobalStats.MusicVolume, GlobalStats.EffectsVolume);
                 StopMusic();
                 CurrentMusic = musicName;
                 Music = GameAudio.PlayMusic(musicName);

--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignScreen.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignScreen.cs
@@ -314,7 +314,6 @@ namespace Ship_Game
                 return;
 
             RemoveVisibleMesh();
-
             ShipDesign cloned = shipDesignTemplate.GetClone(shipDesignTemplate.Name);
             ModuleGrid = new DesignModuleGrid(this, cloned);
             CurrentDesign = cloned;

--- a/Ship_Game/Ships/Ship_Update.cs
+++ b/Ship_Game/Ships/Ship_Update.cs
@@ -151,7 +151,7 @@ namespace Ship_Game.Ships
                 if (LaunchShip.Done)
                 {
                     LaunchShip = null;
-                    if (IsHangarShip && !Mothership.InCombat)
+                    if (IsHangarShip && !Mothership.InCombat && AI.State != AIState.AssaultPlanet )
                         AI.BackToCarrier();
                 }
             }

--- a/Ship_Game/StoryAndEvents/NotificationManager.cs
+++ b/Ship_Game/StoryAndEvents/NotificationManager.cs
@@ -259,12 +259,16 @@ namespace Ship_Game
             }, "sd_ui_notification_warning");
         }
 
-        public void AddEmpireDiedNotification(Empire thatDied)
+        public void AddEmpireDiedNotification(Empire thatDied, bool IsRemnant = false)
         {
+            string message = $"{thatDied.data.Traits.Name} {Localizer.Token(GameText.HasBeenDefeated)}";
+            if (IsRemnant)
+                message += $"\n{Localizer.Token(GameText.RemnantsDefeatedFleetsMayAttack)}";
+
             AddNotification(new Notification
             {
                 RelevantEmpire  = thatDied,
-                Message         = $"{thatDied.data.Traits.Name} {Localizer.Token(GameText.HasBeenDefeated)}",
+                Message         = message,
                 IconPath        = "NewUI/icon_planet_terran_01_mid",
                 ClickRect       = DefaultClickRect,
                 DestinationRect = DefaultNotificationRect

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -10666,6 +10666,9 @@ ResearchMultiLevelTech:
 ResearchUnlocksMoreThanFourItems:
  Id: 4518
  ENG: "This Technology unlocks more than 4 items. Right Click on the title to Expand"
+RemnantsDefeatedFleetsMayAttack:
+ Id: 4519
+ ENG: "However, remaining Remnant fleets in this sector might still\npose an active threat until destroyed." 
 BB_MiningSpeedTech:
  Id: 4924
  ENG: "Mining Ships Speed"


### PR DESCRIPTION
Fix: Finetune Remnant Defeat code. 
Fix: Assault shuttles return to hangar without launching troops after launch completion if Mothership is not in combat.
Fix: Sound-loudness-on-menu-start-fix
Remnants: Deal with Remnant fleets remaining after all portals are destroyed.
Remnants: Balance of warmongers story end event.
Remnants: Add better message for player when remnants are defeated.

@gkapulis  @SmischenkoB 