### PR TITLE
Remnant Fixes

### DIFF
--- a/Ship_Game/Commands/Goals/RemnantEngageEmpire.cs
+++ b/Ship_Game/Commands/Goals/RemnantEngageEmpire.cs
@@ -146,8 +146,7 @@ namespace Ship_Game.Commands.Goals
             if (Portal.InCombat && Portal.AI.Target?.System == Portal.System && Portal.HealthPercent > 0.75f)
                 return GoalStep.TryAgain;
 
-            bool checkOnlyDefeated = Remnants.Story == Remnants.RemnantStory.AncientRaidersRandom;
-            if (!Remnants.TargetEmpireStillValid(TargetEmpire, Portal, checkOnlyDefeated))
+            if (!Remnants.TargetEmpireStillValid(TargetEmpire, Portal))
                 return Remnants.Hibernating ? GoalStep.TryAgain : Remnants.ReleaseFleet(Fleet, GoalStep.GoalComplete);
 
             int numBombersInFleet = Remnants.NumBombersInFleet(Fleet);

--- a/Ship_Game/Commands/Goals/RemnantEngagements.cs
+++ b/Ship_Game/Commands/Goals/RemnantEngagements.cs
@@ -37,7 +37,7 @@ namespace Ship_Game.Commands.Goals
 
         GoalStep CreateFirstPortal()
         {
-            if (!Remnants.CreatePortal())
+            if (!Remnants.TryCreatePortal())
             {
                 Log.Warning($"Could not create a portal for {Owner.data.Name}, they will not be activated!");
                 return GoalStep.GoalFailed;
@@ -60,13 +60,8 @@ namespace Ship_Game.Commands.Goals
                 return GoalStep.GoalFailed;
             }
 
-            if (Remnants.TryLevelUpByDate(out int newLevel) 
-                && newLevel % Owner.DifficultyModifiers.RemnantPortalCreationMod == 0
-                && Remnants.CreatePortal())
-            {
-                Owner.Universe.Notifications.AddRemnantsNewPortal(Owner);
-            }
-
+            Remnants.TryLevelUpByDate();
+            Remnants.CheckHibernation();
             EngageEmpire(portals);
             return GoalStep.TryAgain;
         }

--- a/Ship_Game/Commands/Goals/RemnantPortal.cs
+++ b/Ship_Game/Commands/Goals/RemnantPortal.cs
@@ -135,7 +135,7 @@ namespace Ship_Game.Commands.Goals
 
                 production *= Owner.DifficultyModifiers.RemnantResourceMod;
                 production *= (int)(UState.P.GalaxySize + 1) * 2 * UState.P.StarsModifier / UState.MajorEmpires.Length;
-                Remnants.TryGenerateProduction(production);
+                Remnants.GenerateProduction(production);
             }
 
             return GoalStep.TryAgain;


### PR DESCRIPTION
Fix: Remnants over level 20 created portal every time they leveled up (though level remained 20).
Fix: Multiple Portals reduce hibernation time.
Fix: Remnant Warmongers and Peacekeepers bug constantly switching targets when checking valid targets, preventing them from attacking.
Refactor: Remnant code.