### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -5326,6 +5326,10 @@ namespace Ship_Game
         GameOptionsInfluenceAlpha = 6222,
         /// <summary>Adjust the empires' border color strength</summary>
         GameOptionsInfluenceAlphaTip = 6223,
+        /// <summary>Refit In Fleed</summary>
+        RefitInFleet = 6224,
+        /// <summary>All Ships of the same type in the</summary>
+        RefitInFleetTip = 6225,
         /// <summary>Indicates the % chance of ECM disruption against incoming guided</summary>
         IndicatesTheChanceOfEcm = 7001,
         /// <summary>Indicates the resistance of this weapon's guidance against targets' ECM</summary>

--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -5322,6 +5322,10 @@ namespace Ship_Game
         LinksChain = 6220,
         /// <summary>Opens the Blueprints Screen, which allows you to create</summary>
         BlueprintsScreenTip = 6221,
+        /// <summary>Border Color Strength</summary>
+        GameOptionsInfluenceAlpha = 6222,
+        /// <summary>Adjust the empires' border color strength</summary>
+        GameOptionsInfluenceAlphaTip = 6223,
         /// <summary>Indicates the % chance of ECM disruption against incoming guided</summary>
         IndicatesTheChanceOfEcm = 7001,
         /// <summary>Indicates the resistance of this weapon's guidance against targets' ECM</summary>

--- a/Ship_Game/Empire_Fleets.cs
+++ b/Ship_Game/Empire_Fleets.cs
@@ -80,6 +80,9 @@ public sealed partial class Empire
     /// <summary>Returns only active fleets which have ships</summary>
     public FleetEnumerator ActiveFleets => new FleetEnumerator(Fleets.GetInternalArrayItems(), Fleets.Count);
 
+    /// <summary> Gets All Fleets for data nodes hnadling (refit, for isntance)</summary>
+    public IReadOnlyList<Fleet> AllFleets => Fleets;
+
     /// <summary>Check if any of the active fleets matches the predicate test</summary>
     public IEnumerable<Fleet> GetActiveFleetsTargetingEmpire(Empire empire)
     {

--- a/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_Draw.cs
+++ b/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_Draw.cs
@@ -355,7 +355,7 @@ namespace Ship_Game
                 RequisitionForces.Visible = true;
                 SaveDesign.Visible = true;
                 LoadDesign.Visible = true;
-                AutoArrange.Visible = !f.DataNodes.Any(n => n.Ship == null && n.Goal == null);
+                AutoArrange.Visible = f.Ships.Count > 0 && !f.DataNodes.Any(n => n.Ship == null && n.Goal == null);
             }
         }
     }

--- a/Ship_Game/GameScreens/MainMenu/OptionsScreen.cs
+++ b/Ship_Game/GameScreens/MainMenu/OptionsScreen.cs
@@ -111,6 +111,7 @@ namespace Ship_Game
 
         FloatSlider MusicVolumeSlider;
         FloatSlider EffectsVolumeSlider;
+        FloatSlider EffectsInfluenceNodeAlpha;
         AudioHandle EffectSound = new();
 
         FloatSlider IconSize;
@@ -249,10 +250,11 @@ namespace Ship_Game
             botLeft.AddSplit(new UILabel(GameText.SoundDevice), SoundDevices);
             MusicVolumeSlider   = botLeft.Add(new FloatSlider(SliderStyle.Percent, 240f, 50f, GameText.MusicVolume, 0f, 1f, GlobalStats.MusicVolume));
             EffectsVolumeSlider = botLeft.Add(new FloatSlider(SliderStyle.Percent, 240f, 50f, GameText.EffectsVolume, 0f, 1f, GlobalStats.EffectsVolume));
-            
+
             CurrentLanguage = new DropOptions<Language>(105, 18);
             Add(botLeft, GameText.Language, CurrentLanguage);
-
+            EffectsInfluenceNodeAlpha = botLeft.Add(new FloatSlider(SliderStyle.Percent, 240f, 50f, GameText.GameOptionsInfluenceAlpha, 0f, 1f, GlobalStats.InfluenceNodeAlpha));
+            EffectsInfluenceNodeAlpha.Tip = GameText.GameOptionsInfluenceAlphaTip;
             botLeft.ReverseZOrder(); // @todo This is a hacky workaround to zorder limitations
             
             UIList botRight = AddList(new Vector2(RightArea.X, RightArea.Y + 180), RightArea.Size());
@@ -265,6 +267,7 @@ namespace Ship_Game
             
             MusicVolumeSlider.OnChange = (s) => GlobalStats.MusicVolume = s.AbsoluteValue;
             EffectsVolumeSlider.OnChange = (s) => SetEffectsVolume(s.AbsoluteValue);
+            EffectsInfluenceNodeAlpha.OnChange = (s) => GlobalStats.InfluenceNodeAlpha = s.AbsoluteValue;
             MaxDynamicLightSources.OnChange = (s) => GlobalStats.MaxDynamicLightSources = (int)s.AbsoluteValue;
             IconSize.OnChange = (s) => GlobalStats.IconSize = (int)s.AbsoluteValue;
             AutoSaveFreq.OnChange = (s) => GlobalStats.AutoSaveFreq = (int)s.AbsoluteValue;
@@ -411,8 +414,9 @@ namespace Ship_Game
             Original = New.GetClone(); // accepted!
             GlobalStats.SaveSettings();
 
-            EffectsVolumeSlider.RelativeValue = GlobalStats.EffectsVolume;
-            MusicVolumeSlider.RelativeValue   = GlobalStats.MusicVolume;
+            EffectsVolumeSlider.RelativeValue       = GlobalStats.EffectsVolume;
+            MusicVolumeSlider.RelativeValue         = GlobalStats.MusicVolume;
+            EffectsInfluenceNodeAlpha.RelativeValue = GlobalStats.InfluenceNodeAlpha;
         }
 
         void CancelChanges()

--- a/Ship_Game/GameScreens/MainMenu/OptionsScreen.cs
+++ b/Ship_Game/GameScreens/MainMenu/OptionsScreen.cs
@@ -250,11 +250,10 @@ namespace Ship_Game
             botLeft.AddSplit(new UILabel(GameText.SoundDevice), SoundDevices);
             MusicVolumeSlider   = botLeft.Add(new FloatSlider(SliderStyle.Percent, 240f, 50f, GameText.MusicVolume, 0f, 1f, GlobalStats.MusicVolume));
             EffectsVolumeSlider = botLeft.Add(new FloatSlider(SliderStyle.Percent, 240f, 50f, GameText.EffectsVolume, 0f, 1f, GlobalStats.EffectsVolume));
-
-            CurrentLanguage = new DropOptions<Language>(105, 18);
-            Add(botLeft, GameText.Language, CurrentLanguage);
             EffectsInfluenceNodeAlpha = botLeft.Add(new FloatSlider(SliderStyle.Percent, 240f, 50f, GameText.GameOptionsInfluenceAlpha, 0f, 1f, GlobalStats.InfluenceNodeAlpha));
             EffectsInfluenceNodeAlpha.Tip = GameText.GameOptionsInfluenceAlphaTip;
+            CurrentLanguage = new DropOptions<Language>(105, 18);
+            Add(botLeft, GameText.Language, CurrentLanguage);
             botLeft.ReverseZOrder(); // @todo This is a hacky workaround to zorder limitations
             
             UIList botRight = AddList(new Vector2(RightArea.X, RightArea.Y + 180), RightArea.Size());

--- a/Ship_Game/GlobalStats.cs
+++ b/Ship_Game/GlobalStats.cs
@@ -256,6 +256,7 @@ public static class GlobalStats
     // Music, Sound & Language settings
     public static float MusicVolume   = 0.7f;
     public static float EffectsVolume = 1f;
+    public static float InfluenceNodeAlpha = 1f;
     public static string SoundDevice  = "Default"; // Use windows default device if not explicitly specified
 
     // Language options
@@ -333,6 +334,7 @@ public static class GlobalStats
 
         if (TryGetSetting(config, "MusicVolume", out int musicVol)) MusicVolume = musicVol / 100f;
         if (TryGetSetting(config, "EffectsVolume", out int fxVol)) EffectsVolume = fxVol / 100f;
+        if (TryGetSetting(config, "InfluenceNodeAlpha", out int nodeAlpha)) InfluenceNodeAlpha = nodeAlpha / 100f;
         GetSetting(config, "SoundDevice", ref SoundDevice);
         GetSetting(config, "Language", ref Language);
         GetSetting(config, "VerboseLogging", ref VerboseLogging);
@@ -494,6 +496,7 @@ public static class GlobalStats
 
         WriteSetting(config, "MusicVolume", (int)(MusicVolume * 100));
         WriteSetting(config, "EffectsVolume", (int)(EffectsVolume * 100));
+        WriteSetting(config, "InfluenceNodeAlpha", (int)(InfluenceNodeAlpha * 100));
         WriteSetting(config, "SoundDevice", SoundDevice);
         WriteSetting(config, "Language", Language);
         WriteSetting(config, "VerboseLogging", VerboseLogging);

--- a/Ship_Game/RefitToWindow.cs
+++ b/Ship_Game/RefitToWindow.cs
@@ -21,6 +21,7 @@ namespace Ship_Game
         ScrollList<RefitShipListItem> RefitShipList;
         UIButton RefitOne;
         UIButton RefitAll;
+        UIButton RefitInFleet;
         UICheckBox RushRefit;
         IShipDesign RefitTo;
         DanButton ConfirmRefit;
@@ -100,10 +101,12 @@ namespace Ship_Game
 
             ConfirmRefit = new DanButton(new Vector2(shipDesignsRect.X, (shipDesignsRect.Y + 505)), "Do Refit");
 
-            RefitOne = ButtonMedium(shipDesignsRect.X + 25, shipDesignsRect.Y + 505, text:GameText.RefitOne, click: OnRefitOneClicked);
-            RefitOne.Tooltip = Localizer.Token(GameText.RefitOnlyThisShipTo);
-            RefitAll = ButtonMedium(shipDesignsRect.X + 250, shipDesignsRect.Y + 505, text:GameText.RefitAll, click: OnRefitAllClicked);
-            RefitAll.Tooltip = Localizer.Token(GameText.RefitAllShipsOfThis);
+            RefitOne = ButtonMedium(shipDesignsRect.X + 10, shipDesignsRect.Y + 505, text:GameText.RefitOne, click: OnRefitOneClicked);
+            RefitOne.Tooltip = GameText.RefitOnlyThisShipTo;
+            RefitAll = ButtonMedium(shipDesignsRect.X + 270, shipDesignsRect.Y + 505, text:GameText.RefitAll, click: OnRefitAllClicked);
+            RefitAll.Tooltip = GameText.RefitAllShipsOfThis;
+            RefitInFleet = ButtonMedium(shipDesignsRect.X + 140, shipDesignsRect.Y + 505, text: GameText.RefitInFleet, click: OnRefitFleetClicked);
+            RefitInFleet.Tooltip = GameText.RefitInFleetTip;
             RushRefit = Add(new UICheckBox(() => Rush, Fonts.Arial12Bold,
                 title: GameText.RushRefit, tooltip: GameText.RushRefitTip));
             RushRefit.TextColor = Color.Gray;
@@ -118,14 +121,14 @@ namespace Ship_Game
             };
 
             base.LoadContent();
+            RefitOne.Visible = RefitAll.Visible = RefitInFleet.Visible = RushRefit.Visible = false;
         }
 
         void OnRefitShipItemClicked(RefitShipListItem item)
         {
             RefitTo = item.Design;
-            RefitOne.Enabled = RefitTo != null;
-            RefitAll.Enabled = RefitTo != null;
-            RushRefit.Enabled = RefitTo != null;
+            RushRefit.Visible = RefitAll.Visible = RefitOne.Visible = RefitTo != null;
+            RefitInFleet.Visible = RefitAll.Visible && ShipToRefit.Fleet != null;
         }
 
         public override void Draw(SpriteBatch batch, DrawTimes elapsed)
@@ -140,10 +143,6 @@ namespace Ship_Game
                 batch.DrawString(Fonts.Arial14Bold, text, cursor, Color.White);
             }
             batch.SafeEnd();
-
-            RefitOne.Visible = RefitTo != null;
-            RefitAll.Visible = RefitTo != null;
-            RushRefit.Visible= RefitTo != null;
         }
 
         public override void ExitScreen()
@@ -161,6 +160,16 @@ namespace Ship_Game
 
         void OnRefitAllClicked(UIButton b)
         {
+            RefitAllShips();
+            foreach (Fleet fleet in Player.AllFleets)
+                fleet.RefitNodeName(ShipToRefit.Name, RefitTo.Name);
+
+            GameAudio.EchoAffirmative();
+            ExitScreen();
+        }
+
+        void RefitAllShips()
+        {
             var ships = Player.OwnedShips;
             foreach (Ship ship in ships)
             {
@@ -170,10 +179,12 @@ namespace Ship_Game
 
             foreach (Planet planet in Player.GetPlanets())
                 planet.Construction.RefitShipsBeingBuilt(ShipToRefit, RefitTo);
+        }
 
-            foreach (Fleet fleet in Player.ActiveFleets)
-                fleet.RefitNodeName(ShipToRefit.Name, RefitTo.Name);
-
+        void OnRefitFleetClicked(UIButton b)
+        {
+            ShipToRefit.Fleet?.RefitNodeName(ShipToRefit.Name, RefitTo.Name);
+            RefitAllShips();
             GameAudio.EchoAffirmative();
             ExitScreen();
         }

--- a/Ship_Game/Universe/SolarBodies/ColonyResource.cs
+++ b/Ship_Game/Universe/SolarBodies/ColonyResource.cs
@@ -292,9 +292,9 @@ namespace Ship_Game.Universe.SolarBodies
 
         public float NetRevenueGain(Building b)
         {
-            float newPopulation = b.MaxPopIncrease/1000f;
+            float newPopulation = b.MaxPopIncrease*0.001f;
             if (b.IsBiospheres)
-                newPopulation += Planet.BasePopPerBioSphere/1000f;
+                newPopulation += Planet.PopPerBiosphere(Planet.Owner)*0.001f;
 
             float grossIncome = newPopulation * IncomePerColonist * TaxRate;
             return grossIncome - b.ActualMaintenance(Planet);

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -1507,7 +1507,9 @@ namespace Ship_Game
         public int TotalBuildings { get; private set; }
         public int  TerraformersHere { get; private set; }
         public float HabitablePercentage { get; private set; }
-        public float HabitableBuiltCoverage { get; private set; }
+        public int NumFreeBiospheres { get; private set; }
+
+        public float HabiableBuiltCoverage { get; private set; }
         public int TotalInvadeInjure { get; private set; }
         public float BuildingGeodeticOffense { get; private set; }
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
@@ -423,10 +423,12 @@ public partial class Planet
         BuildingGeodeticOffense = SumBuildings(b => b.Offense);
 
         HabitablePercentage = (float)TilesList.Count(tile => tile.Habitable) / TileArea;
-        HabitableBuiltCoverage = 1 - (float)FreeHabitableTiles/TotalHabitableTiles;
 
         FreeHabitableTiles = TilesList.Count(tile => tile.Habitable && tile.NoBuildingOnTile);
         TotalHabitableTiles = TilesList.Count(tile => tile.Habitable);
+        HabiableBuiltCoverage = 1 - (float)FreeHabitableTiles / TotalHabitableTiles;
+        NumFreeBiospheres = TilesList.Count(t => t.Biosphere && !t.BuildingOnTile);
+
         TotalMoneyBuildings = TilesList.Count(tile => tile.BuildingOnTile &&  tile.Building.IsMoneyBuilding);
         MoneyBuildingRatio = (float)TotalMoneyBuildings / TotalBuildings;
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
@@ -482,7 +482,8 @@ namespace Ship_Game
                 || b.IsMilitary
                 || !b.Scrappable
                 || b.IsSpacePort && Owner.GetPlanets().Count == 1 // Dont scrap our last spaceport
-                || b.BuildOnlyOnce)
+                || b.BuildOnlyOnce
+                || b.PlusTerraformPoints > 0) // using this instead of IsTerraformer since some event building might also terraform without the terraformer building ID
             {
                 return false;
             }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
@@ -762,9 +762,7 @@ namespace Ship_Game
         bool TryBuildBiospheres(float budget, out bool shouldScrapBioSpheres)
         {
             shouldScrapBioSpheres = false;
-
             if (!Owner.IsBuildingUnlocked(Building.BiospheresId)
-                || PopulationRatio < 0.99f && HabitableBuiltCoverage.Less(1)
                 || BiosphereInTheWorks
                 || IsStarving
                 || HabitablePercentage.AlmostEqual(1)) // all tiles are habitable
@@ -776,15 +774,30 @@ namespace Ship_Game
             if (bio == null || bio.ActualMaintenance(this) > budget)
                 return false; // not within budget or not profitable and more than 5
 
-            if  (!BioSphereProfitable(bio))
+            if (!BioSphereProfitable(bio))
             {
-                int numBio = CountBuildings(b => b.IsBiospheres);
-                if (numBio > 5)
-                    shouldScrapBioSpheres = true;
-
-                if (numBio >= 5)
+                int numBuildingsWeCanBuild = GetBuildingsListToChooseFrom(BuildingsCanBuild).Count;
+                if (NumFreeBiospheres > 0)
+                {
+                    // We do not need more than 1 free biospheres if not profitable.
+                    // We need only 1 free biosphere if we have anything to built at all
+                    shouldScrapBioSpheres = NumFreeBiospheres > 1 || numBuildingsWeCanBuild == 0;
                     return false;
+                }
+                else if (numBuildingsWeCanBuild == 0 || HabiableBuiltCoverage.Less(1))
+                {
+                    // no need to build unprofitable biospheres if we have nothing to build here
+                    return false;
+                }
             }
+            else if (PopulationRatio < 0.95f 
+                     && (NumFreeBiospheres > 0 || HabiableBuiltCoverage.Less(1)))
+            {
+                // dont build even if profitable, if pop is not big enough.
+                // but ensure there is at least 1 free biospheres if there are no free tiles
+                return false;
+            }
+
 
             if (IsPlanetExtraDebugTarget())
                 Log.Info(ConsoleColor.Green, $"{Owner.PortraitName} BUILT {bio.Name} on planet {Name}");
@@ -799,7 +812,7 @@ namespace Ship_Game
 
         bool BioSphereProfitable(Building bio)
         {
-            return Money.NetRevenueGain(bio).GreaterOrEqual(0);
+            return Money.NetRevenueGain(bio) >= 0;
         }
 
         // FB - For unit tests only!

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -15071,6 +15071,12 @@ GameOptionsInfluenceAlpha:
 GameOptionsInfluenceAlphaTip:
  Id: 6223
  ENG: "Adjusts the empires' border color strength in the Universe Screen. You can change it if the border colors get too bright for you, especially late game."   
+RefitInFleet:
+ Id: 6224
+ ENG: "Refit In Fleet"   
+RefitInFleetTip:
+ Id: 6225
+ ENG: "All Ships of the same type in the selected ship's fleet will be refitted."    
 IndicatesTheChanceOfEcm:
  Id: 7001
  ENG: "Indicates the % chance of ECM disruption against incoming guided weapons, before the weapon's ECM resistance is deducted. Successful ECM disruption jams targeting and prevents the munition from hitting."

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -15065,6 +15065,12 @@ LinksChain:
 BlueprintsScreenTip:
  Id: 6221
  ENG: "Opens the Blueprints Screen, which allows you to create, delete and edit Blueprints for colonies." 
+GameOptionsInfluenceAlpha:
+ Id: 6222
+ ENG: "Border Color Strength"  
+GameOptionsInfluenceAlphaTip:
+ Id: 6223
+ ENG: "Adjusts the empires' border color strength in the Universe Screen. You can change it if the border colors get too bright for you, especially late game."   
 IndicatesTheChanceOfEcm:
  Id: 7001
  ENG: "Indicates the % chance of ECM disruption against incoming guided weapons, before the weapon's ECM resistance is deducted. Successful ECM disruption jams targeting and prevents the munition from hitting."


### PR DESCRIPTION
Feature: Added button to refit ship only within its fleet, if it has one.
Feature: Game option to allow adjustments of border color strength in Universe Screen
Fix: Dont let normal governor logic scrap Terraformers. They are handled in terraforming logic.
Fix: Small alteration of biosphere build logic.
Fix: Refit window edge cases where ships in the fleet would not be refitted besides the selected one.
Fix: crash in ship design when loading a fleet and clicking auto arrange
