### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
@@ -596,7 +596,7 @@ namespace Ship_Game.AI
 
         public void OrderReturnHome()
         {
-            ClearOrders(priority:true);
+            ClearOrders(priority:false);
             AddShipGoal(Plan.ReturnHome, AIState.ReturnHome);
         }
 

--- a/Ship_Game/Remnants.cs
+++ b/Ship_Game/Remnants.cs
@@ -349,8 +349,8 @@ namespace Ship_Game
                 case RemnantStory.AncientBalancers:     target = FindStrongestByAveragePopAndStr(empiresList, 1.25f); break;
                 case RemnantStory.AncientExterminators: target = FindWeakestEmpire(empiresList);                      break;
                 case RemnantStory.AncientRaidersRandom: target = Owner.Random.Item(empiresList);                      break;
-                case RemnantStory.AncientPeaceKeepers:  target = FindRandomEmpireAtWar(empiresList);                  break;
-                case RemnantStory.AncientWarMongers:    target = FindRandomEmpireAtPeace(empiresList);                break;
+                case RemnantStory.AncientPeaceKeepers:  target = FindStrongestEmpireAtWar(empiresList);               break;
+                case RemnantStory.AncientWarMongers:    target = FindStrongestEmpireAtPeace(empiresList);               break;
             }
 
             return target != null;
@@ -389,22 +389,22 @@ namespace Ship_Game
             return false;
         }
 
-        Empire FindRandomEmpireAtPeace(Empire[] empiresList)
+        Empire FindStrongestEmpireAtPeace(Empire[] empiresList)
         {
             var potentialTargets = empiresList.Filter(e => !e.IsAtWarWithMajorEmpire);
             if (potentialTargets.Length == 0)
-                return null;
+                return empiresList.FindMin(e => e.OffensiveStrength); // get the weakest if everybody is at war
 
-            return Owner.Random.Item(potentialTargets); ;
+            return potentialTargets.FindMax(e => e.OffensiveStrength);
         }
 
-        Empire FindRandomEmpireAtWar(Empire[] empiresList)
+        Empire FindStrongestEmpireAtWar(Empire[] empiresList)
         {
             var potentialTargets = empiresList.Filter(e => e.IsAtWarWithMajorEmpire);
             if (potentialTargets.Length == 0)
-                return Universe.Player;
+                return null;
 
-            return Owner.Random.Item(potentialTargets); ;
+            return potentialTargets.FindMax(e => e.OffensiveStrength);
         }
 
         Empire FindStrongestByAveragePopAndStr(Empire[] empiresList, float ratioOverAverageThreshold = 1f)

--- a/Ship_Game/Remnants.cs
+++ b/Ship_Game/Remnants.cs
@@ -350,7 +350,7 @@ namespace Ship_Game
                 case RemnantStory.AncientExterminators: target = FindWeakestEmpire(empiresList);                      break;
                 case RemnantStory.AncientRaidersRandom: target = Owner.Random.Item(empiresList);                      break;
                 case RemnantStory.AncientPeaceKeepers:  target = FindStrongestEmpireAtWar(empiresList);               break;
-                case RemnantStory.AncientWarMongers:    target = FindStrongestEmpireAtPeace(empiresList);               break;
+                case RemnantStory.AncientWarMongers:    target = FindStrongestEmpireAtPeace(empiresList);             break;
             }
 
             return target != null;

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -1271,7 +1271,7 @@ namespace Ship_Game.Ships
             }
 
             // return home if it is a defense ship
-            if (!InCombat && IsHomeDefense && !HomePlanet.SpaceCombatNearPlanet && AI.State != AIState.ReturnHome)
+            if (!InCombat && IsHomeDefense && !IsLaunching && !HomePlanet.SpaceCombatNearPlanet && AI.State != AIState.ReturnHome)
                 ReturnHome();
 
             // Ship Repair

--- a/Ship_Game/Universe/EmpireSolarSystemStatus.cs
+++ b/Ship_Game/Universe/EmpireSolarSystemStatus.cs
@@ -47,7 +47,7 @@ namespace Ship_Game.Universe
                 {
                     HostileForcesPresent = true;
                     CombatTimer = Owner.isPlayer ? 5f : 1f;
-                    if (ship.BaseStrength > 0 || ship.IsDefaultTroopShip)
+                    if (ship.BaseStrength > 0 || ship.IsDefaultTroopShip || ship.IsMeteor)
                     {
                         DangerousForcesPresent = true;
                         return;

--- a/Ship_Game/Universe/SolarBodies/GeodeticManager.cs
+++ b/Ship_Game/Universe/SolarBodies/GeodeticManager.cs
@@ -146,7 +146,7 @@ namespace Ship_Game.Universe.SolarBodies // Fat Bastard - Refactored March 21, 2
                 Shield.HitShield(P, bomb, Position, P.Radius + 100f);
             }
 
-            P.ShieldStrengthCurrent = Math.Max(P.ShieldStrengthCurrent - bomb.HardDamageMax, 0);
+            P.ChangeCurrentplanetaryShield(-bomb.HardDamageMax);
         }
 
         void AssignPlanetarySupply()

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -844,16 +844,16 @@ namespace Ship_Game
             }
         }
 
-        private void RechargePlanetaryShields()
+        void RechargePlanetaryShields()
         {
-            if (ShieldStrengthMax.LessOrEqual(0) || ShieldStrengthCurrent.GreaterOrEqual(ShieldStrengthMax))
-                return; // fully recharged
+            if (ShieldStrengthMax.AlmostZero() || ShieldStrengthCurrent.AlmostEqual(ShieldStrengthMax))
+                return;
 
-            float maxRechargeRate = ShieldStrengthMax / (SpaceCombatNearPlanet ? 100 : 30);
-            float rechargeRate    = (ShieldStrengthCurrent * 100 / ShieldStrengthMax).Clamped(1, maxRechargeRate);
+            float maxRechargeRate = SpaceCombatNearPlanet ? ShieldStrengthMax * 0.005f : ShieldStrengthMax * 0.05f;
+            float rechargeRate = (ShieldStrengthCurrent * 100 / ShieldStrengthMax).Clamped(1, maxRechargeRate);
             Owner.AddExoticConsumption(ExoticBonusType.ShieldRecharge, rechargeRate);
             float rechargeExoticBonus = Owner.GetDynamicExoticBonusMuliplier(ExoticBonusType.ShieldRecharge);
-            ShieldStrengthCurrent = (ShieldStrengthCurrent + rechargeRate*rechargeExoticBonus).Clamped(0, ShieldStrengthMax);
+            ChangeCurrentplanetaryShield(rechargeRate * rechargeExoticBonus);
         }
 
         private void UpdateColonyValue() => ColonyValue = Owner != null ? ColonyBaseValue(Owner) : 0;
@@ -1232,7 +1232,7 @@ namespace Ship_Game
                     Shield.HitShield(this, ship, Position, Radius + 100f);
                 }
 
-                ShieldStrengthCurrent = (ShieldStrengthCurrent - damage).LowerBound(0);
+                ChangeCurrentplanetaryShield(-damage);
                 return true;
             }
         }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
@@ -445,10 +445,8 @@ public partial class Planet
 
         PlusFlatPopulationPerTurn = SumBuildings(bb => bb.PlusFlatPopulation);
 
-        ShieldStrengthMax = SumBuildings(bb => bb.PlanetaryShieldStrengthAdded);
-        ShieldStrengthMax *= 1 + (Owner?.data.ShieldPowerMod ?? 0);
-        ShieldStrengthCurrent = ShieldStrengthCurrent.Clamped(0, ShieldStrengthMax);
-
+        SetShieldStrengthMax(SumBuildings(bb => bb.PlanetaryShieldStrengthAdded) * (1 + (Owner?.data.ShieldPowerMod ?? 0)));
+        ChangeCurrentplanetaryShield(0); // done for clamping the shields
         TotalRepair = SumBuildings(bb => bb.ShipRepair).LowerBound(0);
     }
 }

--- a/Ship_Game/Universe/SolarBodies/SolarSystemBody.cs
+++ b/Ship_Game/Universe/SolarBodies/SolarSystemBody.cs
@@ -216,8 +216,8 @@ namespace Ship_Game
         public int NumBuildings => BuildingList.Count;
         public ReadOnlySpan<Building> Buildings => BuildingList.AsReadOnlySpan();
 
-        [StarData] public float ShieldStrengthCurrent;
-        public float ShieldStrengthMax;        
+        [StarData] public float ShieldStrengthCurrent { get; private set; }
+        public float ShieldStrengthMax { get; private set; }
         float PosUpdateTimer = 1f;
         float ZrotateAmount  = 0.03f;
         [StarData] public float TerraformPoints { get; protected set; } // FB - terraform process from 0 to 1. 
@@ -663,6 +663,16 @@ namespace Ship_Game
                     System.MoonList.Add(moon);
                 }
             }
+        }
+
+        public void SetShieldStrengthMax(float value)
+        {
+            ShieldStrengthMax = value;
+        }
+
+        public void ChangeCurrentplanetaryShield(float value)
+        {
+            ShieldStrengthCurrent = (ShieldStrengthCurrent + value).Clamped(0, ShieldStrengthMax);
         }
 
         // Used only for Unit tests!

--- a/game/Content/Exploration Events/scripted/RemnantPeaceKeepers04.xml
+++ b/game/Content/Exploration Events/scripted/RemnantPeaceKeepers04.xml
@@ -7,7 +7,7 @@
       <Chance>100</Chance>
       <Image>Encounters/remnstory4.png</Image>      
       <TitleText>Remnant Protocols</TitleText>
-      <DescriptionText>After gaining some more access to Remnant broken computers, we believe we have uncovered some of their protocols. To our understanding, they believe that agressors should be kepy at bay. They have left guardians which triggered the portal creation once enough sentient activity was detected by them. Their protocols require to engage any civilization that wages war on others. We think that the destruction of the Remnant portal will end their involvement in this part of the galaxy. It also seems that the portal is absorbing a rather lethal radiation from the stars they orbit and the bad news is that they are getting stronger as the years pass by.</DescriptionText>
+      <DescriptionText>After gaining some more access to Remnant broken computers, we believe we have uncovered some of their protocols. To our understanding, they believe that agressors should be kept at bay. They have left guardians which triggered the portal creation once enough sentient activity was detected by them. Their protocols require to engage the strongest civilization that wages war on others. We think that the destruction of the Remnant portal will end their involvement in this part of the galaxy. It also seems that the portal is absorbing a rather lethal radiation from the stars they orbit and the bad news is that they are getting stronger as the years pass by.</DescriptionText>
     </Outcome>
   </PotentialOutcomes>
 </ExplorationEvent>

--- a/game/Content/Exploration Events/scripted/RemnantWarMongers04.xml
+++ b/game/Content/Exploration Events/scripted/RemnantWarMongers04.xml
@@ -7,7 +7,7 @@
       <Chance>100</Chance>
       <Image>Encounters/remnstory4.png</Image>      
       <TitleText>Remnant Protocols</TitleText>
-      <DescriptionText>After gaining some more access to Remnant broken computers, we believe we have uncovered some of their protocols. To our understanding, they like to pit sentient empires at each other and enjoy the show. They have left guardians which triggered the portal creation once enough sentient activity was detected by them. In their search for entertainment, they will engage empires which are not at war with another, preferring stronger empires. We think that the destruction of the Remnant portal will end their involvement in this part of the galaxy. It also seems that the portal is absorbing a rather lethal radiation from the stars they orbit and the bad news is that they are getting stronger as the years pass by.</DescriptionText>
+      <DescriptionText>After gaining some more access to Remnant broken computers, we believe we have uncovered some of their protocols. To our understanding, they like to pit sentient empires at each other and enjoy the show. They have left guardians which triggered the portal creation once enough sentient activity was detected by them. In their search for entertainment, they will engage empires which are not at war with another, preferring stronger empires. If all empires are at war, we believe they will focus on the weakset empire. We think that the destruction of the Remnant portal will end their involvement in this part of the galaxy. It also seems that the portal is absorbing a rather lethal radiation from the stars they orbit and the bad news is that they are getting stronger as the years pass by.</DescriptionText>
     </Outcome>
   </PotentialOutcomes>
 </ExplorationEvent>


### PR DESCRIPTION
Fix: Text typos in Remnant stories. 
Fix: Remnant  Warmongers/peacemakers targeting logic.
Fix: Allow planet defenses and home defense ships to attack meteors
Fix: Planetary shields recharge was too fast during combat.