### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/AI/EmpireAI/ShipBuilder.cs
+++ b/Ship_Game/AI/EmpireAI/ShipBuilder.cs
@@ -285,9 +285,9 @@ namespace Ship_Game.AI
 
         public static IShipDesign PickFreighter(Empire empire, float fastVsBig)
         {
-            if (empire.isPlayer && empire.AutoFreighters &&
-                !empire.Universe.Player.AutoPickBestFreighter &&
-                ResourceManager.Ships.GetDesign(empire.data.CurrentAutoFreighter, out IShipDesign freighter))
+            if (empire.isPlayer 
+                && !empire.Universe.Player.AutoPickBestFreighter 
+                && ResourceManager.Ships.GetDesign(empire.data.CurrentAutoFreighter, out IShipDesign freighter))
             {
                 return freighter;
             }

--- a/Ship_Game/EmpireData.cs
+++ b/Ship_Game/EmpireData.cs
@@ -138,8 +138,7 @@ namespace Ship_Game
         [StarData] public string DiplomacyDialogPath;
         [StarData] public DTrait DiplomaticPersonality;
         [StarData] public ETrait EconomicPersonality;
-
-        float TaxRateValue = 0.25f;
+        [StarData] float TaxRateValue;
 
         // player modified tax rate
         [StarData]

--- a/Ship_Game/Empire_Trade.cs
+++ b/Ship_Game/Empire_Trade.cs
@@ -88,7 +88,7 @@ namespace Ship_Game
                 DispatchOrBuildFreighters(Goods.Food, OwnedPlanets, false);
 
             float popRatio              = TotalPopBillion / MaxPopBillion;
-            float productionFirstChance = popRatio * 100;
+            float productionFirstChance = popRatio * (NonCybernetic ? 200 : 300);
             if (Random.RollDice(productionFirstChance))
             {
                 DispatchOrBuildFreighters(Goods.Production, OwnedPlanets, false);

--- a/game/Content/ShipModules/Utility modules/Storage/BasicCargoHold.xml
+++ b/game/Content/ShipModules/Utility modules/Storage/BasicCargoHold.xml
@@ -16,8 +16,7 @@
   <Name>Small Cargo Hold</Name>
   <IconTexturePath>Modules/cargoSmall</IconTexturePath>
   <Mass>3</Mass>
-  <Health>300</Health>
-  <HealthMax>10</HealthMax>
+  <HealthMax>300</HealthMax>
   <energyreq>0</energyreq>
   
   

--- a/game/Content/ShipModules/Utility modules/Storage/LargeCargoHold.xml
+++ b/game/Content/ShipModules/Utility modules/Storage/LargeCargoHold.xml
@@ -20,8 +20,7 @@
   <Name>Small Cargo Hold</Name>
   <IconTexturePath>Modules/cargoLarge</IconTexturePath>
   <Mass>15</Mass>
-  <Health>3105</Health>
-  <HealthMax>3015</HealthMax>
+  <HealthMax>3105</HealthMax>
   <energyreq>0</energyreq>
   
   

--- a/game/Content/ShipModules/Utility modules/Storage/MediumCargoHold.xml
+++ b/game/Content/ShipModules/Utility modules/Storage/MediumCargoHold.xml
@@ -2,11 +2,10 @@
 <ShipModule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 
 
-  <Cost>8</Cost>
   <!-- Tech Level -->
   <TechLevel>1</TechLevel>
   <TechBranch>Storage</TechBranch>
-  <Cost>3</Cost>
+  <Cost>8</Cost>
   <XSize>2</XSize>
   <YSize>2</YSize>
   <!-- common traits shared by all ship modules -->


### PR DESCRIPTION
Fix: Tax reset to 25% after load if it was 0% when saved. 
Fix: Build Freighter button in freighter util was ignoring selected freighter in automation window.
Fix: BB+ basic/medium/large cargo hold xml errors
Balance: Production/Colonists trade ratio
@gkapulis 