### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/AI/EmpireAI/EmpireAI.RunEconomicPlanner.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.RunEconomicPlanner.cs
@@ -43,9 +43,10 @@ namespace Ship_Game.AI
         /// This is a quick set check to see if we are financially able to rush production
         /// </summary>
         public bool SafeToRush => CreditRating > 0.8f;
+        public bool SafeToRushColonyShips => OwnerEmpire.IsExpansionists ? CreditRating > 0.5f : CreditRating > 0.6f;
 
         // Empire spaceDefensive Reserves high enough to support fractional build budgets
-        public bool EmpireCanSupportSpcDefense => DefenseBudget > OwnerEmpire.TotalOrbitalMaintenance && CreditRating > 0.90f;
+        public bool EmpireCanSupportSpcDefense => DefenseBudget > OwnerEmpire.TotalOrbitalMaintenance && CreditRating > 0.9f;
 
         /// <summary>
         /// This is the budgeted amount of money that will be available to empire looking over 20 years.
@@ -53,18 +54,16 @@ namespace Ship_Game.AI
         public float ProjectedMoney { get; private set; } = 0;
 
         /// <summary>
-        /// This a ratio of projectedMoney and the normalized money then multiplied by 2 then add 1 - taxrate
-        /// then the whole thing divided by 3. This puts a large emphasis on money goal to money ratio
+        /// This a ratio of projectedMoney and the normalized money then multiplied by 3 then add 1 - taxrate
+        /// then the whole thing divided by 4. This puts a large emphasis on money goal to money ratio
         /// but a high tax will greatly effect the result.
         /// </summary>
         public float CreditRating
         {
             get
             {
-                float normalMoney = OwnerEmpire.Money;
-                float goalRatio = normalMoney / ProjectedMoney;
-
-                return (goalRatio.UpperBound(1) * 3 + (1 - OwnerEmpire.data.TaxRate)) / 4f;
+                float goalRatio = OwnerEmpire.Money / ProjectedMoney;
+                return (goalRatio.UpperBound(1)*3 + (1-OwnerEmpire.data.TaxRate)) * 0.25f;
             }
         }
 

--- a/Ship_Game/AI/EmpireAI/ShipBuilder.cs
+++ b/Ship_Game/AI/EmpireAI/ShipBuilder.cs
@@ -285,9 +285,9 @@ namespace Ship_Game.AI
 
         public static IShipDesign PickFreighter(Empire empire, float fastVsBig)
         {
-            if (empire.isPlayer && empire.AutoFreighters &&
-                !empire.Universe.Player.AutoPickBestFreighter &&
-                ResourceManager.Ships.GetDesign(empire.data.CurrentAutoFreighter, out IShipDesign freighter))
+            if (empire.isPlayer 
+                && !empire.Universe.Player.AutoPickBestFreighter 
+                && ResourceManager.Ships.GetDesign(empire.data.CurrentAutoFreighter, out IShipDesign freighter))
             {
                 return freighter;
             }

--- a/Ship_Game/Building.cs
+++ b/Ship_Game/Building.cs
@@ -90,13 +90,14 @@ namespace Ship_Game
         [XmlIgnore] [StarData] public float Offense { get; private set; }
         [XmlIgnore] [StarData] public float MilitaryStrength { get; private set; }
         [XmlIgnore] [StarData] public int CurrentNumDefenseShips { get; private set; }
-        [XmlIgnore] public float ActualCost => Cost * UniverseState.DummyProductionPacePlaceholder;
         [XmlIgnore] public bool IsBadCacheResourceBuilding => 
             FoodCache > 0 && PlusFlatFoodAmount == 0 && PlusFoodPerColonist == 0 
             || ProdCache > 0 && PlusProdPerColonist == 0 && PlusFlatProductionAmount == 0 && PlusProdPerRichness == 0;
 
         public override string ToString()
-            => $"BID:{BID} Name:{Name} ActualCost:{ActualCost} +Tax:{PlusTaxPercentage}  Short:{GetShortDescrText()}";
+            => $"BID:{BID} Name:{Name} Gross Cost:{Cost} +Tax:{PlusTaxPercentage}  Short:{GetShortDescrText()}";
+
+        public float ActualCost(Empire e) => Cost * e.Universe.ProductionPace;
 
         [XmlIgnore] public LocalizedText TranslatedName  => new(NameTranslationIndex);
         [XmlIgnore] public LocalizedText DescriptionText => new(DescriptionIndex);

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -2129,7 +2129,7 @@ namespace Ship_Game
             {
                 Planet p = OwnedPlanets[i];
                 ExpansionScore  += p.Fertility*10 + p.MineralRichness*10 + p.PopulationBillion;
-                IndustrialScore += p.SumBuildings(b => b.ActualCost);
+                IndustrialScore += p.SumBuildings(b => b.ActualCost(this));
             }
             IndustrialScore *= 0.05f;
 
@@ -2537,7 +2537,7 @@ namespace Ship_Game
         public void RefundCreditsPostRemoval(Building b)
         {
             if (b.IsMilitary)
-                RefundCredits(b.ActualCost, 0.5f);
+                RefundCredits(b.ActualCost(this), 0.5f);
         }
 
         public void ChargeRushFees(float productionCost, bool immediate)

--- a/Ship_Game/EmpireData.cs
+++ b/Ship_Game/EmpireData.cs
@@ -138,8 +138,7 @@ namespace Ship_Game
         [StarData] public string DiplomacyDialogPath;
         [StarData] public DTrait DiplomaticPersonality;
         [StarData] public ETrait EconomicPersonality;
-
-        float TaxRateValue = 0.25f;
+        [StarData] float TaxRateValue;
 
         // player modified tax rate
         [StarData]

--- a/Ship_Game/Empire_Trade.cs
+++ b/Ship_Game/Empire_Trade.cs
@@ -88,7 +88,7 @@ namespace Ship_Game
                 DispatchOrBuildFreighters(Goods.Food, OwnedPlanets, false);
 
             float popRatio              = TotalPopBillion / MaxPopBillion;
-            float productionFirstChance = popRatio * 100;
+            float productionFirstChance = popRatio * (NonCybernetic ? 200 : 300);
             if (Random.RollDice(productionFirstChance))
             {
                 DispatchOrBuildFreighters(Goods.Production, OwnedPlanets, false);

--- a/Ship_Game/FreighterUtilizationWindow.cs
+++ b/Ship_Game/FreighterUtilizationWindow.cs
@@ -125,7 +125,7 @@ namespace Ship_Game
 
         public override void Update(float fixedDeltaTime)
         {
-            if (!IsOpen || Player.Universe.Paused)
+            if (!IsOpen) 
                 return;
 
             UpdateTimer -= fixedDeltaTime;

--- a/Ship_Game/GameScreens/ColonyBlueprints/BlueprintsBuildableListItem.cs
+++ b/Ship_Game/GameScreens/ColonyBlueprints/BlueprintsBuildableListItem.cs
@@ -84,8 +84,8 @@ namespace Ship_Game
             batch.Draw(b.IconTex, new Vector2(X, Y - 2), new Vector2(IconSize), Screen.PlanAreaHovered && Hovered ? Color.Green : Color.White); // Icon
             batch.DrawString(Font12, b.TranslatedName.Text, TextX + 2, Y + 2, Color.White); // Title
             batch.DrawString(Font8, BuildingDescr, TextX + 4, Y + 16, Screen.PlanAreaHovered && Hovered ? Color.Green : buildColor); // Description
-            int creditCost = b.IsMilitary ? GetCreditCharge((int)b.ActualCost) : 0;
-            DrawProductionInfo(batch, GetMaintenance(b), b.ActualCost, creditCost);
+            int creditCost = b.IsMilitary ? GetCreditCharge((int)b.ActualCost(Screen.Player)) : 0;
+            DrawProductionInfo(batch, GetMaintenance(b), b.ActualCost(Screen.Player), creditCost);
         }
 
         int GetCreditCharge(float cost)

--- a/Ship_Game/GameScreens/ColonyScreen/BuildableListItem.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/BuildableListItem.cs
@@ -138,8 +138,8 @@ namespace Ship_Game
             batch.Draw(b.IconTex, new Vector2(X, Y-2), new Vector2(IconSize), buildColor); // Icon
             batch.DrawString(Font12, b.TranslatedName.Text, TextX+2, Y+2, buildColor); // Title
             batch.DrawString(Font8, BuildingDescr, TextX+4, Y+16, profitColor); // Description
-            int creditCost = b.IsMilitary ? GetCreditCharge((int)b.ActualCost) : 0;
-            DrawProductionInfo(batch, GetMaintenance(b), b.ActualCost, creditCost);
+            int creditCost = b.IsMilitary ? GetCreditCharge((int)b.ActualCost(Screen.Player)) : 0;
+            DrawProductionInfo(batch, GetMaintenance(b), b.ActualCost(Screen.Player), creditCost);
         }
 
         void DrawTroop(SpriteBatch batch, Troop troop)

--- a/Ship_Game/GameScreens/ColonyScreen/GovernorDetailsComponent.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/GovernorDetailsComponent.cs
@@ -793,6 +793,8 @@ namespace Ship_Game
 
             BlueprintsCompletion.Progress = Planet.Blueprints.PercentCompleted;
             BlueprintsAchiveable.Text = $"({Planet.Blueprints.PercentAchievable.String()}% {Localizer.Token(GameText.Achievable)})";
+            if (Planet.HasBlueprints && Planet.Blueprints.Name != BlueprintsName.Text)
+                UpdateBlueprintsChanged();
         }
 
         void UpdateBudgets()

--- a/Ship_Game/GameScreens/ColonyScreen/QueueItem.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/QueueItem.cs
@@ -142,9 +142,14 @@ namespace Ship_Game
                 case QueueItemType.Building:        priority = planet.PrioritizeColonyBuilding(Building);                                       break;
                 case QueueItemType.Troop:           priority = 0.2f + owner.AI.DefensiveCoordinator.TroopsToTroopsWantedRatio * 5;              break;
                 case QueueItemType.Scout:           priority = owner.GetPlanets().Count * 0.02f;                                                break;
-                case QueueItemType.ColonyShip:      priority = (owner.GetPlanets().Count * (owner.IsExpansionists ? 0.005f : 0.01f));           break;
                 case QueueItemType.Orbital:         priority = 1 + (owner.TotalOrbitalMaintenance / owner.AI.DefenseBudget.LowerBound(1) * 10); break;
                 case QueueItemType.RoadNode:        priority = 0.5f + owner.AI.SpaceRoadsManager.NumOnlineSpaceRoads * 0.1f;                    break;
+                case QueueItemType.ColonyShip: 
+                    priority = (owner.GetPlanets().Count * (owner.IsExpansionists ? 0.005f : 0.01f));
+                    if (Goal != null && !Goal.TargetPlanet.System.HasPlanetsOwnedBy(owner))
+                        priority -= 0.5f;
+                    
+                    break;
                 case QueueItemType.Freighter: 
                     priority =  totalFreighters < owner.GetPlanets().Count ? 0 : 0.9f * totalFreighters / owner.FreighterCap;
                     break;

--- a/Ship_Game/GameScreens/NewGame/RuleOptionsScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RuleOptionsScreen.cs
@@ -15,7 +15,6 @@ public sealed class RuleOptionsScreen : GameScreen
     FloatSlider GravityWellSize;
     FloatSlider ExtraPlanets;
     FloatSlider IncreaseMaintenance;
-    FloatSlider MinAcceptableShipWarpRange;
     FloatSlider StartingRichness;
     FloatSlider TurnTimer;
     FloatSlider CustomMineralDecay;
@@ -95,14 +94,10 @@ public sealed class RuleOptionsScreen : GameScreen
 
 
         var optionTurnTimer  = new Rectangle(x, leftRect.Y + 390, 270, 50);
-        var minimumWarpRange = new Rectangle(x, leftRect.Y + 450, 270, 50);
-        var maintenanceRect  = new Rectangle(x, leftRect.Y + 510, 270, 50);
+        var maintenanceRect  = new Rectangle(x, leftRect.Y + 450, 270, 50);
 
         TurnTimer = Slider(optionTurnTimer,  GameText.SecondsPerTurn, 4, 10f, P.TurnTimer);
         TurnTimer.OnChange = (s) => P.TurnTimer = (int)s.AbsoluteValue;
-
-        MinAcceptableShipWarpRange = Slider(minimumWarpRange, GameText.MinAcceptableShipWarpRange, 0, 1200000f, P.MinAcceptableShipWarpRange);
-        MinAcceptableShipWarpRange.OnChange = (s) => P.MinAcceptableShipWarpRange = s.AbsoluteValue;
 
         IncreaseMaintenance = Slider(maintenanceRect,  GameText.MaintenanceMultiplier, 1, 10f, P.ShipMaintenanceMultiplier);
         IncreaseMaintenance.OnChange = (s) => P.ShipMaintenanceMultiplier = s.AbsoluteValue;
@@ -118,7 +113,6 @@ public sealed class RuleOptionsScreen : GameScreen
             extraPlanetsTip = $"{extraPlanetsTip} {Localizer.Token(GameText.ThisWillSlightlyIncreaseResearch)}";
 
         ExtraPlanets.Tip = extraPlanetsTip;
-        MinAcceptableShipWarpRange.Tip = GameText.MinAcceptableWarpRangeAShip;
         IncreaseMaintenance.Tip = GameText.MultiplyGlobalMaintenanceCostBy;
         StartingRichness.Tip = GameText.AddToAllStartingEmpire;
         TurnTimer.Tip = GameText.TimeInSecondsPerTurn;

--- a/Ship_Game/GameScreens/NewGame/RuleOptionsScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RuleOptionsScreen.cs
@@ -84,7 +84,7 @@ public sealed class RuleOptionsScreen : GameScreen
         var epRect = new Rectangle(x, leftRect.Y + 270, 270, 50);
         var richnessRect = new Rectangle(x, leftRect.Y + 330, 270, 50);
 
-        GravityWellSize = Slider(gwRect, GameText.GravityWellRadius, 0, 20000, P.GravityWellRange);
+        GravityWellSize = Slider(gwRect, GameText.GravityWellRadius, 4000, 16000, P.GravityWellRange);
         GravityWellSize.OnChange = (s) => P.GravityWellRange = s.AbsoluteValue;
 
         ExtraPlanets = Slider(epRect, GameText.ExtraPlanets, 0, 3f, P.ExtraPlanets);

--- a/Ship_Game/ResearchPopup.cs
+++ b/Ship_Game/ResearchPopup.cs
@@ -51,15 +51,17 @@ public sealed class ResearchPopup : PopupWindow
         UnlockSL = Add(new ScrollList<UnlockListItem>(rect, 100));
 
         Array<UnlockItem> unlocks = UnlockItem.CreateUnlocksList(Technology, Universe.Player);
-        UnlockSL.SetItems(unlocks.Select(u => new UnlockListItem(u)));
+        UnlockSL.SetItems(unlocks.Select(u => new UnlockListItem(u, Universe.Player)));
     }
 
     class UnlockListItem : ScrollListItem<UnlockListItem>
     {
         readonly UnlockItem Unlock;
-        public UnlockListItem(UnlockItem unlock)
+        readonly Empire Player;
+        public UnlockListItem(UnlockItem unlock, Empire player)
         {
             Unlock = unlock;
+            Player = player;
         }
 
         public override void Draw(SpriteBatch batch, DrawTimes elapsed)
@@ -83,7 +85,7 @@ public sealed class ResearchPopup : PopupWindow
                         iconRect = new(X + 16, CenterY - 32, 64, 64);
                         if (Unlock.building != null)
                         {
-                            comment = $"    Production Cost: {Unlock.building.ActualCost}";
+                            comment = $"    Production Cost: {Unlock.building.ActualCost(Player)}";
                         }
                         summary = Unlock.building?.GetShortDescrText() ?? "";
                         break;

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -1849,7 +1849,7 @@ namespace Ship_Game.Ships
         {
             if (!Active)
                 return false;
-            float minRange = Universe?.P.MinAcceptableShipWarpRange ?? GlobalStats.Defaults.MinAcceptableShipWarpRange;
+            float minRange = GlobalStats.Defaults.MinAcceptableShipWarpRange;
             bool warpTimeGood = IsWarpRangeGood(minRange);
             return warpTimeGood;
         }

--- a/Ship_Game/Ships/ShipDesign_Stats.cs
+++ b/Ship_Game/Ships/ShipDesign_Stats.cs
@@ -261,7 +261,7 @@ public partial class ShipDesign
         if (IsPlatformOrStation)
             return true;
 
-        float neededRange = e.Universe.P.MinAcceptableShipWarpRange;
+        float neededRange = GlobalStats.Defaults.MinAcceptableShipWarpRange;
         if (neededRange <= 0f)
             return true;
 

--- a/Ship_Game/Troops/Troop.cs
+++ b/Ship_Game/Troops/Troop.cs
@@ -89,8 +89,7 @@ namespace Ship_Game
         [XmlIgnore] public bool CanLaunch =>
                 HostPlanet?.Owner == null || Loyalty.isPlayer ? CanMove : CanMove && IsHealthFull;
 
-        public float ActualCost(Empire e) => Cost * (1 + e.DifficultyModifiers.TroopCostMod) 
-            * UniverseState.DummyProductionPacePlaceholder;
+        public float ActualCost(Empire e) => Cost * (1 + e.DifficultyModifiers.TroopCostMod) * e.Universe.ProductionPace;
 
         SpriteSystem.TextureAtlas TroopAnim;
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -460,7 +460,7 @@ namespace Ship_Game
             float value = 0;
             value += ColonyRawValue(empire);
             value += HasCapital ? 100 : 0;
-            value += SumBuildings(b => b.ActualCost) * 0.01f;
+            value += SumBuildings(b => b.ActualCost(empire)) * 0.01f;
             value += PopulationBillion * 5;
 
             return value;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
@@ -397,7 +397,7 @@ namespace Ship_Game
             if (MilitaryBuildingInTheWorks)
                 return;
 
-            var cheapestInfantryBuilding = BuildingsCanBuild.FindMinFiltered(b => b.AllowInfantry, b => b.ActualCost);
+            var cheapestInfantryBuilding = BuildingsCanBuild.FindMinFiltered(b => b.AllowInfantry, b => b.ActualCost(Owner));
             if (cheapestInfantryBuilding != null)
                 Construction.Enqueue(cheapestInfantryBuilding);
         }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
@@ -231,8 +231,20 @@ public partial class Planet
         return Storage.Max - effectiveProd; // Negative means we have excess prod
     }
 
-    public bool IsColonyShipInQueue() => FirstShipRoleInQueue(RoleName.colony) != null;
-    public bool IsColonyShipInQueue(Goal g) => ConstructionQueue.Any(q => q.isShip && q.Goal == g);
+    public bool IsColonyShipInQueue(Goal g) => ConstructionQueue.Any(qi => qi.isShip && qi.Goal == g);
+
+    public bool IsColonyShipInQueue(Goal g, out int queueIndex)
+    {
+        for (queueIndex = 0; queueIndex < ConstructionQueue.Count; queueIndex++) 
+        {
+            QueueItem qi = ConstructionQueue[queueIndex];
+            if (qi.isShip && qi.Goal == g)
+                return true;
+        }
+
+        return false;
+    }
+        
 
     public Ship FirstShipRoleInQueue(RoleName role)
     {

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
@@ -274,7 +274,7 @@ public partial class Planet
     public void ScrapBuilding(Building b, PlanetGridSquare tile = null)
     {
         RemoveBuildingFromPlanet(b, tile, refund:true);
-        ProdHere += b.ActualCost / 2f;
+        ProdHere += b.ActualCost(Owner) / 2f;
     }
 
     public void DestroyBuildingOn(PlanetGridSquare tile) => RemoveBuildingFromPlanet(null, tile, refund:false);

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
@@ -752,7 +752,7 @@ namespace Ship_Game
             if (potentialBio.Length == 0)
                 return;
 
-            PlanetGridSquare tile = Random.Item(potentialBio.Sorted(t => t.Building?.ActualCost ?? 0));
+            PlanetGridSquare tile = Random.Item(potentialBio.Sorted(t => t.Building?.ActualCost(Owner) ?? 0));
             if (!tile.Building?.CanBuildAnywhere == true)
                 ScrapBuilding(tile.Building, tile);
 

--- a/Ship_Game/Universe/SolarBodies/SBProduction.cs
+++ b/Ship_Game/Universe/SolarBodies/SBProduction.cs
@@ -282,7 +282,7 @@ namespace Ship_Game.Universe.SolarBodies
                 IsMilitary      = b.IsMilitary,
                 Building        = b,
                 pgs             = where,
-                Cost            = b.ActualCost,
+                Cost            = b.ActualCost(P.Owner),
                 ProductionSpent = 0.0f,
                 NotifyOnEmpty   = false,
                 Rush            = P.Owner.RushAllConstruction,

--- a/Ship_Game/Universe/UniverseParams.cs
+++ b/Ship_Game/Universe/UniverseParams.cs
@@ -31,7 +31,6 @@ public class UniverseParams
     [StarData(DefaultValue=1f)] public float StarsModifier = 1f;
 
     // Universe customization parameters:
-    [StarData] public float MinAcceptableShipWarpRange;
     [StarData] public int TurnTimer; // seconds between Empire turns, every turn advances stardate by 0.1
     [StarData] public bool PreventFederations;
     [StarData] public bool EliminationMode;
@@ -91,7 +90,6 @@ public class UniverseParams
 
         NumOpponents = s.DefaultNumOpponents.UpperBound(ResourceManager.MajorRaces.Count - 1);
         RacialTraitPoints = s.TraitPoints;
-        MinAcceptableShipWarpRange = s.MinAcceptableShipWarpRange;
         TurnTimer = s.TurnTimer;
         CustomMineralDecay = s.CustomMineralDecay;
         VolcanicActivity = s.VolcanicActivity;

--- a/Ship_Game/Universe/UniverseState.cs
+++ b/Ship_Game/Universe/UniverseState.cs
@@ -47,9 +47,6 @@ namespace Ship_Game.Universe
         public bool IsShipViewOrCloser   => ViewState <= UnivScreenState.ShipView;
         public bool ExoticFeaturesDisabled => P.DisableMiningOps && P.DisableResearchStations;
 
-        // TODO: This was too hard to fix, so added this placeholder until code is fixed
-        public static float DummyProductionPacePlaceholder = 1f;
-
         [StarData] public float SettingsResearchModifier = 1f;
         public float RemnantPaceModifier = 20;
         public string ResearchRootUIDToDisplay;

--- a/UnitTests/Serialization/BinarySerializerTests.cs
+++ b/UnitTests/Serialization/BinarySerializerTests.cs
@@ -1102,7 +1102,6 @@ namespace UnitTests.Serialization
             AssertEqual(instance.Mode, result.Mode);
             AssertEqual(instance.Pace, result.Pace);
             AssertEqual(instance.StarsModifier, result.StarsModifier);
-            AssertEqual(instance.MinAcceptableShipWarpRange, result.MinAcceptableShipWarpRange);
             AssertEqual(instance.TurnTimer, result.TurnTimer);
             AssertEqual(instance.PreventFederations, result.PreventFederations);
             AssertEqual(instance.EliminationMode, result.EliminationMode);

--- a/game/Content/ShipModules/Utility modules/Storage/BasicCargoHold.xml
+++ b/game/Content/ShipModules/Utility modules/Storage/BasicCargoHold.xml
@@ -16,8 +16,7 @@
   <Name>Small Cargo Hold</Name>
   <IconTexturePath>Modules/cargoSmall</IconTexturePath>
   <Mass>3</Mass>
-  <Health>300</Health>
-  <HealthMax>10</HealthMax>
+  <HealthMax>300</HealthMax>
   <energyreq>0</energyreq>
   
   

--- a/game/Content/ShipModules/Utility modules/Storage/LargeCargoHold.xml
+++ b/game/Content/ShipModules/Utility modules/Storage/LargeCargoHold.xml
@@ -20,8 +20,7 @@
   <Name>Small Cargo Hold</Name>
   <IconTexturePath>Modules/cargoLarge</IconTexturePath>
   <Mass>15</Mass>
-  <Health>3105</Health>
-  <HealthMax>3015</HealthMax>
+  <HealthMax>3105</HealthMax>
   <energyreq>0</energyreq>
   
   

--- a/game/Content/ShipModules/Utility modules/Storage/MediumCargoHold.xml
+++ b/game/Content/ShipModules/Utility modules/Storage/MediumCargoHold.xml
@@ -2,11 +2,10 @@
 <ShipModule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 
 
-  <Cost>8</Cost>
   <!-- Tech Level -->
   <TechLevel>1</TechLevel>
   <TechBranch>Storage</TechBranch>
-  <Cost>3</Cost>
+  <Cost>8</Cost>
   <XSize>2</XSize>
   <YSize>2</YSize>
   <!-- common traits shared by all ship modules -->

--- a/game/Mods/ExampleMod/Globals.yaml
+++ b/game/Mods/ExampleMod/Globals.yaml
@@ -12,14 +12,32 @@ Globals:
   CostBasedOnSizeThreshold: 3000
   HangarCombatShipCostMultiplier: 1
   RequiredExpansionPopRatio: 0.4 # required empire pop ratio before expansion is considered
-  ShipyardBonus: 0.25 # default 0.25
+  ShipyardBonus: 0.25 # default 0.25, this also improves repair rate
   CustomMineralDecay: 1 # default 1
   VolcanicActivity: 1 # default 1
   GravityWellRange: 8000 # sets the default gravity well range, 0 means disabled
   StartingPlanetRichnessBonus: 1 # bonus richness for empire capitals (default is 1 for richness of 2)
   ShipMaintenanceMultiplier: 1 # default 1
+  ResearchStationProductionPerResearch: 2 # default 2
   RushCostPercentage: 1 # default 1, How much rushing costs in percentage of production cost
   MinAcceptableShipWarpRange: 600000 # minimum ship warp range which is accepted as good
+  # gameplay: repair
+  BaseShipyardRepair: 10.0 # # repair multiplier of ship repair per turn from planetary buildings (per SECOND)
+  BonusRepairPerColonyLevel: 0.1 # +bonus based on colony level, 0.1 would be +10% increase per level
+  InCombatRepairModifier: 0.5 # repair rate modifier when a ship or planet is in combat
+  BonusColonyEMPRecovery: 5.0 # multiplier of EMP damage removed from shipyard repair when orbiting a colony
+  SelfRepairMultiplier: 1.0 # base repair rate from ship command/engineering modules per SECOND
+  BonusRepairPerCrewLevel: 0.2 # +bonus rate based on crew level, 0.2 would be +20% increase per each crew level
+  InCombatSelfRepairModifier: 0.2 # repair rate modifier for command/engineering self repair when in combat
+  ShieldPowerMultiplier: 1.0 # Global multiplier for Shields
+  ProjectileHitpointsMultiplier: 1.0 # Global multiplier for Projectile Hit Points (mainly affects missiles)
+  ConstructionShipOrbitalDiscount: 100 # When building orbitals, constructor ship cost over this threshold will be added to the gross orbital cost
+  ConstructionModuleBuildRate: 100 # How much consturction the construction module can process per turn   
+  BuilderShipConstructionAdded: 100 # How much consturction Builder ships add when they reach the contructor
+  ResearchBenefitFromAlliance: 0.1 # How much research each alliance is giving you (from other party research)  
+  MiningStationFoodPerOneRefining: 0.25 # How much Food is consumed per 1 refining point
+  ExoticRatioStorage: 0.02 # How much exotic resource storage an empire has per resource based on all planet normal storage  
+  EnableHullEditor: false # Alows modders to edut hulls. it is disabled by default since it will weaken the AI if not done correctly.
 
   # feature flags
   DisableShipPicker: true


### PR DESCRIPTION
Fix: Tax reset to 25% after load if it was 0% when saved. 
Fix: Build Freighter button in freighter util was ignoring selected freighter in automation window.
Fix: basic/medium/large cargo hold xml errors
Fix: Freighter util screen not shown with details on first open if game is paused.
Fix: buildingsand troops  cost do not corresponds to game pace.
Fix: Gravity wells lower bound of 4000.
Fix: Removed acceptable warp distance to a global flag instead on a configurable slider.
Fix: When blueprints changed to linked blueprints, UI is not fully updated.
Fix: Allow AI to rush colony ships if possible.
Balance: Production/Colonists trade
@gkapulis 