### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/AI/EmpireAI/EmpireAI.DiplomacyOffers.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.DiplomacyOffers.cs
@@ -536,7 +536,7 @@ namespace Ship_Game.AI
 
             if (usToThem.ActiveWar != null)
             {
-                if (us.Universe.StarDate - usToThem.ActiveWar.StartDate < 10)
+                if (us.Universe.StarDate - usToThem.ActiveWar.StartDate < (10 * us.Universe.P.Pace))
                     return ProcessPeace("REJECT_OFFER_PEACE_UNWILLING_BC");
             }
 

--- a/Ship_Game/Empire_RallyPlanets.cs
+++ b/Ship_Game/Empire_RallyPlanets.cs
@@ -251,7 +251,8 @@ public sealed partial class Empire
             float averageMaxProd = ports.Average(ModifiedNetMaxProductionPotential);
             bestPorts = ports.Filter(p => !p.IsCrippled
                                      && (p.CType != ColonyType.Research || !filterResearchPorts)
-                                     && p.Prod.NetMaxPotential.GreaterOrEqual(averageMaxProd * portQuality));
+                                     && (p.CType != ColonyType.Colony && p.Prod.NetMaxPotential.GreaterOrEqual(averageMaxProd * portQuality))
+                                         || p.CType == ColonyType.Colony && p.Prod.NetIncome.GreaterOrEqual(averageMaxProd * portQuality));
         }
 
 

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -1276,17 +1276,24 @@ namespace Ship_Game.Fleets
                     }
                     break;
                 case 3:// Waiting for AO change from RemnandDefendPortal Goal
+                    RetaskFleetIfNoPortals();
                     break;
                 case 4:
+                    if (RetaskFleetIfNoPortals())
+                        break;
+
                     CombatMoveToAO(task, 10_000);
                     TaskStep = 5;
                     break;
                 case 5:
-                    if (ArrivedAtCombatRally(FinalPosition))
+                    if (!RetaskFleetIfNoPortals() && ArrivedAtCombatRally(FinalPosition))
                         TaskStep = 6;
 
                     break;
                 case 6:
+                    if (RetaskFleetIfNoPortals())
+                        break;
+                    
                     Owner.Remnants.DisbandDefenseFleet(this);
                     FleetTask.EndTask();
                     break;

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -1276,24 +1276,17 @@ namespace Ship_Game.Fleets
                     }
                     break;
                 case 3:// Waiting for AO change from RemnandDefendPortal Goal
-                    RetaskFleetIfNoPortals();
                     break;
                 case 4:
-                    if (RetaskFleetIfNoPortals())
-                        break;
-
                     CombatMoveToAO(task, 10_000);
                     TaskStep = 5;
                     break;
                 case 5:
-                    if (!RetaskFleetIfNoPortals() && ArrivedAtCombatRally(FinalPosition))
+                    if (ArrivedAtCombatRally(FinalPosition))
                         TaskStep = 6;
 
                     break;
                 case 6:
-                    if (RetaskFleetIfNoPortals())
-                        break;
-                    
                     Owner.Remnants.DisbandDefenseFleet(this);
                     FleetTask.EndTask();
                     break;

--- a/Ship_Game/GameScreens/Universe/ResearchScreenNew.cs
+++ b/Ship_Game/GameScreens/Universe/ResearchScreenNew.cs
@@ -336,7 +336,7 @@ namespace Ship_Game
                 }
             }
 
-            if (input.ResearchExitScreen || input.RightMouseClick)
+            if (!Queue.HitTest(input.CursorPosition) && (input.ResearchExitScreen || input.RightMouseClick))
             {
                 GameAudio.EchoAffirmative();
                 ExitScreen();

--- a/Ship_Game/Gameplay/Relationship.cs
+++ b/Ship_Game/Gameplay/Relationship.cs
@@ -1111,7 +1111,7 @@ namespace Ship_Game.Gameplay
 
         void RequestPeace(Empire us, bool requestNow = false)
         {
-            if (ActiveWar.TurnsAtWar == 0 || ActiveWar.TurnsAtWar % 100 > 0 && !requestNow)
+            if (ActiveWar.TurnsAtWar == 0 || ActiveWar.TurnsAtWar % (int)(100 * us.Universe.P.Pace) > 0 && !requestNow)
                 return;
 
             WarState warState    = ActiveWar.GetWarScoreState();

--- a/Ship_Game/ResearchQueueUIComponent.cs
+++ b/Ship_Game/ResearchQueueUIComponent.cs
@@ -80,21 +80,17 @@ namespace Ship_Game
 
         public override bool HandleInput(InputState input)
         {
-            if (input.Escaped)
-            {
-                Screen.ExitScreen();
-                return true;
-            }
-
-            if (ResearchQueueList.Visible && input.RightMouseClick &&
-                ResearchQueueList.HitTest(input.CursorPosition))
-            {
-                Screen.ExitScreen();
-                return true;
-            }
-
             if (CurrentResearch != null && CurrentResearch.HandleInput(input))
                 return true;
+
+            if (ResearchQueueList.Visible && input.RightMouseClick && ResearchQueueList.Any(item => item.HitTest(input.CursorPosition)))
+                return base.HandleInput(input);
+
+            if (input.Escaped || input.RightMouseClick)
+            {
+                Screen.ExitScreen();
+                return true;
+            }
 
             return base.HandleInput(input);
         }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -293,7 +293,8 @@ namespace Ship_Game
             }
             else if (data != null)
             {
-                GeneratePlanetFromSystemData(random, data);
+                GeneratePlanetFromSystemData(random, data, out PlanetType type);
+                TrySetExoticPlanet(type, random, system.IsStartingSystem ?  exoticPlanetMultiplier*0.33f : exoticPlanetMultiplier);
             }
             else
             {
@@ -308,21 +309,7 @@ namespace Ship_Game
                 if (type.Category == PlanetCategory.GasGiant)
                     scale += 1f;
 
-                if (!Universe.P.DisableResearchStations 
-                    && !type.Habitable 
-                    && random.RollDice(type.ResearchableChance * exoticPlanetMultiplier))
-                {
-                    SetResearchable(true, Universe);
-                    //Log.Info($"{Name} can be researched");
-                }
-                else if (!Universe.P.DisableMiningOps 
-                    && type.Category == PlanetCategory.GasGiant 
-                    && random.RollDice(type.MiningChance * exoticPlanetMultiplier))
-                {
-                    Mining = new(this);
-                    //Log.Info($"{Name} can be mined");
-                }
-
+                TrySetExoticPlanet(type, random, exoticPlanetMultiplier);
                 InitNewMinorPlanet(random, type, scale);
             }
 
@@ -343,6 +330,24 @@ namespace Ship_Game
             if (HasRings)
             {
                 RingTilt = random.Float(-80f, -45f).ToRadians();
+            }
+        }
+
+        void TrySetExoticPlanet(PlanetType type, RandomBase random, float exoticPlanetMultiplier)
+        {
+            if (!Universe.P.DisableResearchStations
+                && !type.Habitable
+                && random.RollDice(type.ResearchableChance * exoticPlanetMultiplier))
+            {
+                SetResearchable(true, Universe);
+                //Log.Info($"{Name} can be researched");
+            }
+            else if (!Universe.P.DisableMiningOps
+                && type.Category == PlanetCategory.GasGiant
+                && random.RollDice(type.MiningChance * exoticPlanetMultiplier))
+            {
+                Mining = new(this);
+                //Log.Info($"{Name} can be mined");
             }
         }
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -522,8 +522,8 @@ namespace Ship_Game
     
         public float ColonyWarValueTo(Empire empire)
         {
-            if (Owner == null)             return ColonyPotentialValue(empire);
-            if (Owner.IsAtWarWith(empire)) return ColonyBaseValue(empire) + ColonyPotentialValue(empire);
+            if (Owner == null)                                return ColonyPotentialValue(empire);
+            if (Owner == empire || Owner.IsAtWarWith(empire)) return ColonyBaseValue(empire) + ColonyPotentialValue(empire);
 
             return 0;
         }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
@@ -130,9 +130,9 @@ namespace Ship_Game
             }
         }
 
-        void GeneratePlanetFromSystemData(RandomBase random, SolarSystemData.Ring data)
+        void GeneratePlanetFromSystemData(RandomBase random, SolarSystemData.Ring data, out PlanetType type)
         {
-            PlanetType type = ResourceManager.Planets.PlanetOrRandom(data.WhichPlanet);
+            type = ResourceManager.Planets.PlanetOrRandom(data.WhichPlanet);
 
             float scale;
             if (data.planetScale > 0)

--- a/game/Content/ShipModules/Utility modules/Misc/ResearchArray.xml
+++ b/game/Content/ShipModules/Utility modules/Misc/ResearchArray.xml
@@ -32,7 +32,7 @@
   <energyreq>0</energyreq>
   
   <PowerDraw>100</PowerDraw>
-  <ResearchPerTurn>0.1</ResearchPerTurn>
+  <ResearchPerTurn>0.15</ResearchPerTurn>
   <NameIndex>4991</NameIndex>
   <DescriptionIndex>4992</DescriptionIndex>
 </ShipModule>

--- a/game/Content/ShipModules/Utility modules/Misc/ResearchLab.xml
+++ b/game/Content/ShipModules/Utility modules/Misc/ResearchLab.xml
@@ -32,7 +32,7 @@
   <energyreq>0</energyreq>
   
   <PowerDraw>450</PowerDraw>
-  <ResearchPerTurn>0.4</ResearchPerTurn>
+  <ResearchPerTurn>0.6</ResearchPerTurn>
   <NameIndex>4989</NameIndex>
   <DescriptionIndex>4990</DescriptionIndex>
 </ShipModule>


### PR DESCRIPTION
Fix: Right Clicking on research item in research queue exit screen instead of showing research popup
Fix: defined systems do not get a chance to have mineable or researchable planets. For Starting systems the chance is 33% of normal.
Fix: Requisition fleets took max prod potential fraction even if planets did not have governors to adjust sliders.
Fix: Critical bug in War where ColonyValueWon and InitialColonyValues were 0 and the AI thought they are always losing badly.
Balance: BB+ research stations need 2 production per research and  outputs 50% more research.
@gkapulis 