### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/Commands/Goals/BuildOrbital.cs
+++ b/Ship_Game/Commands/Goals/BuildOrbital.cs
@@ -38,8 +38,7 @@ namespace Ship_Game.Commands.Goals  // Created by Fat Bastard
         public BuildOrbital(Planet planetBuildingAt, Planet targetPlanet, string toBuildName, 
             Empire owner, Vector2 dynamicBuildPos) : this(owner)
         {
-            Initialize(toBuildName, Vector2.Zero, targetPlanet, 
-                dynamicBuildPos == Vector2.Zero ? dynamicBuildPos : dynamicBuildPos - targetPlanet.Position);
+            Initialize(toBuildName, Vector2.Zero, targetPlanet, dynamicBuildPos);
             Setup(planetBuildingAt);
         }
 

--- a/Ship_Game/DeepSpaceBuildingWindow.cs
+++ b/Ship_Game/DeepSpaceBuildingWindow.cs
@@ -155,7 +155,7 @@ namespace Ship_Game
                 Vector2 worldPos = Screen.CursorWorldPosition2D;
                 if (ShipToBuild.IsResearchStation)
                 {
-                    if (TargetPlanet != null)      Player.AI.AddGoalAndEvaluate(new ProcessResearchStation(Player, TargetPlanet, ShipToBuild, worldPos));
+                    if (TargetPlanet != null)      Player.AI.AddGoalAndEvaluate(new ProcessResearchStation(Player, TargetPlanet, ShipToBuild, TetherOffset));
                     else if (TargetSystem != null) Player.AI.AddGoalAndEvaluate(new ProcessResearchStation(Player, TargetSystem, worldPos, ShipToBuild));
                 }
                 else if (ShipToBuild.IsMiningStation)

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -1276,17 +1276,24 @@ namespace Ship_Game.Fleets
                     }
                     break;
                 case 3:// Waiting for AO change from RemnandDefendPortal Goal
+                    RetaskFleetIfNoPortals();
                     break;
                 case 4:
+                    if (RetaskFleetIfNoPortals())
+                        break;
+
                     CombatMoveToAO(task, 10_000);
                     TaskStep = 5;
                     break;
                 case 5:
-                    if (ArrivedAtCombatRally(FinalPosition))
+                    if (!RetaskFleetIfNoPortals() && ArrivedAtCombatRally(FinalPosition))
                         TaskStep = 6;
 
                     break;
                 case 6:
+                    if (RetaskFleetIfNoPortals())
+                        break;
+                    
                     Owner.Remnants.DisbandDefenseFleet(this);
                     FleetTask.EndTask();
                     break;

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -1276,24 +1276,17 @@ namespace Ship_Game.Fleets
                     }
                     break;
                 case 3:// Waiting for AO change from RemnandDefendPortal Goal
-                    RetaskFleetIfNoPortals();
                     break;
                 case 4:
-                    if (RetaskFleetIfNoPortals())
-                        break;
-
                     CombatMoveToAO(task, 10_000);
                     TaskStep = 5;
                     break;
                 case 5:
-                    if (!RetaskFleetIfNoPortals() && ArrivedAtCombatRally(FinalPosition))
+                    if (ArrivedAtCombatRally(FinalPosition))
                         TaskStep = 6;
 
                     break;
                 case 6:
-                    if (RetaskFleetIfNoPortals())
-                        break;
-                    
                     Owner.Remnants.DisbandDefenseFleet(this);
                     FleetTask.EndTask();
                     break;

--- a/Ship_Game/GameScreens/ColonyBlueprints/BlueprintsScreen.cs
+++ b/Ship_Game/GameScreens/ColonyBlueprints/BlueprintsScreen.cs
@@ -535,6 +535,7 @@ namespace Ship_Game
         {
             Player.Universe.RefreshEmpiresPlanetsBlueprints(template, delete: true);
             LinkBlueprints.Enabled = BlueprintsName.Text != template.Name;
+            ResourceManager.BlueprintsTemplatesDict.Remove(template.Name);
         } 
 
         public void RemoveAllBlueprintsLinkTo(BlueprintsTemplate template)

--- a/Ship_Game/GameScreens/ColonyBlueprints/BlueprintsScreen.cs
+++ b/Ship_Game/GameScreens/ColonyBlueprints/BlueprintsScreen.cs
@@ -342,9 +342,9 @@ namespace Ship_Game
             ColonyScreen.DrawBuildingInfo(ref bCursor, batch, BigFont, PlannedFlatProd,
                 "NewUI/icon_production", GameText.NetFlatProductionGeneratedPer);
             ColonyScreen.DrawBuildingInfo(ref bCursor, batch, BigFont, PlannedFlatResearch,
-                "NewUI/icon_science", GameText.NetResearchPerColonistAllocated);
-            ColonyScreen.DrawBuildingInfo(ref bCursor, batch, BigFont, PlannedResearchPerCol,
                 "NewUI/icon_science", GameText.NetFlatResearchGeneratedPer);
+            ColonyScreen.DrawBuildingInfo(ref bCursor, batch, BigFont, PlannedResearchPerCol,
+                "NewUI/icon_science", GameText.NetResearchPerColonistAllocated); 
             ColonyScreen.DrawBuildingInfo(ref bCursor, batch, BigFont, PlannnedInfrastructure,
                 "NewUI/icon_queue_rushconstruction", GameText.MaximumProductionToQueuePer);
             ColonyScreen.DrawBuildingInfo(ref bCursor, batch, BigFont, PlannedStorage,
@@ -403,7 +403,7 @@ namespace Ship_Game
                 b.UpdateOffense(PlanetLevel, Player.Universe);
             }
 
-            PlannedGrossMoney  *= 1+taxRateMultiplier;
+            PlannedGrossMoney  = PlannedGrossMoney * tax * taxRateMultiplier;
             PlannedMaintenance *= Player.data.Traits.MaintMultiplier;
             PlannedNetIncome = PlannedGrossMoney - PlannedMaintenance;
             PlannedShields *= 1 + Player.data.ShieldPowerMod;

--- a/Ship_Game/Universe/SolarBodies/SBProduction.cs
+++ b/Ship_Game/Universe/SolarBodies/SBProduction.cs
@@ -433,6 +433,11 @@ namespace Ship_Game.Universe.SolarBodies
                     int totalFreighters = Owner.TotalFreighters;
                     ConstructionQueue.Sort(q => q.GetAndUpdatePriorityForAI(P, totalFreighters));
                 }
+                else if (item.Rush && item.QType == QueueItemType.OrbitalUrgent)
+                {
+                    // prioritize projector bridges for the player.
+                    MoveTo(0, Count - 1);
+                }
             }
         }
 


### PR DESCRIPTION
Fix: Deleted blueprints are not deleted from the resource manager.
Fix: Blueprints screen incorrect tax calculation. 
Fix: Blueprints screen per col and flat research stats were switched.
Fix: Prioritize auto projector bridges for players, if needed.
Fix: Deep space manual build for mining ops and research stations setting build pos vector zero