### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/AI/EmpireAI/EmpireAI.RunEconomicPlanner.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.RunEconomicPlanner.cs
@@ -115,7 +115,7 @@ namespace Ship_Game.AI
             // spy budget is a special case currently and is not distributed.
             if (OwnerEmpire.isPlayer)
             {
-                float budgetBalance = (build + spy) / 2f;
+                float budgetBalance = (build + spy) * 0.5f;
                 defense            += budgetBalance;
                 colony             += budgetBalance;
                 SSP                += budgetBalance;

--- a/Ship_Game/AI/EmpireAI/ShipBuilder.cs
+++ b/Ship_Game/AI/EmpireAI/ShipBuilder.cs
@@ -273,7 +273,7 @@ namespace Ship_Game.AI
             float cargo    = ShipStats.GetCargoSpace(s.BaseCargoSpace, s);
             float turnRate = ShipStats.GetTurnRadsPerSec(s).ToDegrees();
             float fastVsBigWeight = fastVsBig * 10;
-            float costWeight     = s.GetCost(empire) * 0.2f;
+            float costWeight     = s.GetCost(empire) * 0.2f * empire.Universe.ProductionPace* empire.Universe.ProductionPace;
             float movementWeight = (maxKFTL + maxDSTL + turnRate) * fastVsBigWeight;
             float cargoWeight    = cargo * (10 - fastVsBigWeight);
             float score          = movementWeight + cargoWeight - costWeight;

--- a/Ship_Game/Commands/Goals/PirateDirectorRaid.cs
+++ b/Ship_Game/Commands/Goals/PirateDirectorRaid.cs
@@ -51,12 +51,12 @@ namespace Ship_Game.Commands.Goals
             return GoalStep.TryAgain;
         }
 
-        int RaidStartChance()
+        float RaidStartChance()
         {
             if (!Pirates.CanDoAnotherRaid(out int numRaids))
                 return 0; // Limit maximum of concurrent raids
 
-            int startChance = Pirates.Level.LowerBound((int)UState.P.Difficulty + 1);
+            float startChance = Pirates.Level.LowerBound((int)UState.P.Difficulty + 1) / UState.P.Pace;
             startChance     = (startChance / Pirates.Universe.PirateFactions.Length.LowerBound(1)).LowerBound(1);
             startChance    /= numRaids + 1;
 

--- a/Ship_Game/Debug/Page/EmpireInfoDebug.cs
+++ b/Ship_Game/Debug/Page/EmpireInfoDebug.cs
@@ -44,7 +44,7 @@ public class EmpireInfoDebug : DebugPage
         }
         Text.String($"Money: {e.Money.String()} A:({e.GetActualNetLastTurn().String()}) T:({e.GrossIncome.String()})");
        
-        Text.String($"Treasury Goal: {(int)eAI.ProjectedMoney} ({(int)( e.AI.CreditRating * 100)}%)");
+        Text.String($"Treasury Goal: {(int)eAI.ProjectedMoney} (cr {(int)( e.AI.CreditRating * 100)}%)");
         float taxRate = e.data.TaxRate * 100f;
         
         var ships = e.OwnedShips;

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -1897,7 +1897,7 @@ namespace Ship_Game
 
         void CheckFederationVsPlayer(UniverseState us)
         {
-            if (us.P.PreventFederations || us.StarDate < 1100f || us.StarDate % 1 > 0)
+            if (us.P.PreventFederations || us.StarDate < 1100f || us.StarDate % 10 > 0)
                 return;
 
             float playerScore    = TotalScore;

--- a/Ship_Game/Empire_Trade.cs
+++ b/Ship_Game/Empire_Trade.cs
@@ -35,7 +35,7 @@ namespace Ship_Game
         public int AverageTradeIncome    => AllTimeTradeIncome / TurnCount;
         public bool ManualTrade          => isPlayer && !AutoFreighters;
         public float TotalAvgTradeIncome => TotalTradeTreatiesIncome() + AverageTradeIncome;
-        public int NumTradeTreaties      => TradeTreaties.Count;
+        public bool EconomicSafeToBuildFreighter => AI.CreditRating >= 0.4;
 
         Array<Relationship> TradeTreaties = new();
         public IReadOnlyList<Relationship> TradeRelations => TradeTreaties;
@@ -242,7 +242,7 @@ namespace Ship_Game
 
         void BuildFreighter()
         {
-            if (ManualTrade)
+            if (ManualTrade || !EconomicSafeToBuildFreighter)
                 return;
 
             int beingBuilt = FreightersBeingBuilt;

--- a/Ship_Game/Empire_Trade.cs
+++ b/Ship_Game/Empire_Trade.cs
@@ -268,7 +268,8 @@ namespace Ship_Game
                 case FreighterPriority.UnloadedAllCargo: ratioDiff = -0.02f;  break;
             }
 
-            IncreaseFastVsBigFreighterRatio(ratioDiff);
+            float numPiratesAtWarModifier = 0.1f * Universe.PirateFactions.Count(e => IsAtWarWith(e));
+            IncreaseFastVsBigFreighterRatio(ratioDiff+ numPiratesAtWarModifier);
         }
 
         public void AffectFastVsBigFreighterByEta(Planet importPlanet, Goods goods, float eta)

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -1276,17 +1276,24 @@ namespace Ship_Game.Fleets
                     }
                     break;
                 case 3:// Waiting for AO change from RemnandDefendPortal Goal
+                    RetaskFleetIfNoPortals();
                     break;
                 case 4:
+                    if (RetaskFleetIfNoPortals())
+                        break;
+
                     CombatMoveToAO(task, 10_000);
                     TaskStep = 5;
                     break;
                 case 5:
-                    if (ArrivedAtCombatRally(FinalPosition))
+                    if (!RetaskFleetIfNoPortals() && ArrivedAtCombatRally(FinalPosition))
                         TaskStep = 6;
 
                     break;
                 case 6:
+                    if (RetaskFleetIfNoPortals())
+                        break;
+                    
                     Owner.Remnants.DisbandDefenseFleet(this);
                     FleetTask.EndTask();
                     break;

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -1276,24 +1276,17 @@ namespace Ship_Game.Fleets
                     }
                     break;
                 case 3:// Waiting for AO change from RemnandDefendPortal Goal
-                    RetaskFleetIfNoPortals();
                     break;
                 case 4:
-                    if (RetaskFleetIfNoPortals())
-                        break;
-
                     CombatMoveToAO(task, 10_000);
                     TaskStep = 5;
                     break;
                 case 5:
-                    if (!RetaskFleetIfNoPortals() && ArrivedAtCombatRally(FinalPosition))
+                    if (ArrivedAtCombatRally(FinalPosition))
                         TaskStep = 6;
 
                     break;
                 case 6:
-                    if (RetaskFleetIfNoPortals())
-                        break;
-                    
                     Owner.Remnants.DisbandDefenseFleet(this);
                     FleetTask.EndTask();
                     break;

--- a/Ship_Game/GameScreens/ColonyScreen/QueueItem.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/QueueItem.cs
@@ -151,7 +151,7 @@ namespace Ship_Game
                     
                     break;
                 case QueueItemType.Freighter: 
-                    priority =  totalFreighters < owner.GetPlanets().Count ? 0 : 0.9f * totalFreighters / owner.FreighterCap;
+                    priority =  totalFreighters < owner.GetPlanets().Count*1.5f ? 0 : 0.5f * totalFreighters / owner.FreighterCap;
                     break;
                 case QueueItemType.CombatShip:      
                     priority = (owner.TotalWarShipMaintenance / owner.AI.BuildCapacity.LowerBound(1));

--- a/Ship_Game/GameScreens/NewGame/RuleOptionsScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RuleOptionsScreen.cs
@@ -99,8 +99,8 @@ public sealed class RuleOptionsScreen : GameScreen
         TurnTimer = Slider(optionTurnTimer,  GameText.SecondsPerTurn, 4, 10f, P.TurnTimer);
         TurnTimer.OnChange = (s) => P.TurnTimer = (int)s.AbsoluteValue;
 
-        IncreaseMaintenance = Slider(maintenanceRect,  GameText.MaintenanceMultiplier, 1, 10f, P.ShipMaintenanceMultiplier);
-        IncreaseMaintenance.OnChange = (s) => P.ShipMaintenanceMultiplier = s.AbsoluteValue;
+        IncreaseMaintenance = SliderDecimal1(maintenanceRect,  GameText.MaintenanceMultiplier, 1, 2, P.ShipMaintenanceMultiplier);
+        IncreaseMaintenance.OnChange = (s) => P.ShipMaintenanceMultiplier = s.AbsoluteValue.RoundToFractionOf10();
 
         EnemyFTLPenaltySlider.Tip = GameText.UsingThisSliderYouCan2;
         CustomMineralDecay.Tip = GameText.HigherMineralDecayIncreasesThe;

--- a/Ship_Game/Pirates.cs
+++ b/Ship_Game/Pirates.cs
@@ -63,7 +63,7 @@ namespace Ship_Game
         }
 
         public int MinimumColoniesForPayment   => Owner.data.MinimumColoniesForStartPayment;
-        int PaymentPeriodTurns                 => Owner.data.PiratePaymentPeriodTurns;
+        int PaymentPeriodTurns                 => (int)(Owner.data.PiratePaymentPeriodTurns * Owner.Universe.ProductionPace);
         public bool PaidBy(Empire victim)      => !Owner.IsAtWarWith(victim);
 
         float PirateBaseDetectionChance => Level * 4 + ((Owner.Universe.StarDate - 1000) * 0.025f);

--- a/Ship_Game/RefitToWindow.cs
+++ b/Ship_Game/RefitToWindow.cs
@@ -168,12 +168,12 @@ namespace Ship_Game
             ExitScreen();
         }
 
-        void RefitAllShips()
+        void RefitAllShips(Fleet specificFleet = null)
         {
             var ships = Player.OwnedShips;
             foreach (Ship ship in ships)
             {
-                if (ship.Name == ShipToRefit.Name)
+                if (ship.Name == ShipToRefit.Name && (specificFleet == null || ship.Fleet == specificFleet))
                     Player.AI.AddGoalAndEvaluate(GetRefitGoal(ship));
             }
 
@@ -184,7 +184,7 @@ namespace Ship_Game
         void OnRefitFleetClicked(UIButton b)
         {
             ShipToRefit.Fleet?.RefitNodeName(ShipToRefit.Name, RefitTo.Name);
-            RefitAllShips();
+            RefitAllShips(ShipToRefit.Fleet);
             GameAudio.EchoAffirmative();
             ExitScreen();
         }

--- a/Ship_Game/Ships/IShipDesign.cs
+++ b/Ship_Game/Ships/IShipDesign.cs
@@ -150,7 +150,7 @@ public interface IShipDesign
 
     TacticalIcon GetTacticalIcon();
 
-    float GetCost(Empire e);
+    float GetCost(Empire e, bool ignorePace = false);
 
     float GetMaintenanceCost(Empire empire);
 

--- a/Ship_Game/Ships/ShipDesign_Stats.cs
+++ b/Ship_Game/Ships/ShipDesign_Stats.cs
@@ -194,12 +194,14 @@ public partial class ShipDesign
             ShipCategory = ShipCategory.Conservative;
     }
 
-    public float GetCost(Empire e)
+    // Ignore pace is for maintenance calc
+    public float GetCost(Empire e, bool ignorePace)
     {
+        float pace = ignorePace ? 1 : e.Universe.ProductionPace;
         if (FixedCost > 0)
-            return FixedCost * e.Universe.ProductionPace;
+            return FixedCost * pace;
 
-        float cost = BaseCost * e.Universe.ProductionPace;
+        float cost = BaseCost * pace;
         cost += Bonuses.StartingCost;
         cost += cost * e.data.Traits.ShipCostMod;
         cost *= 1f - Bonuses.CostBonus; // @todo Sort out (1f - CostBonus) weirdness

--- a/Ship_Game/Ships/ShipMaintenance.cs
+++ b/Ship_Game/Ships/ShipMaintenance.cs
@@ -43,7 +43,7 @@ namespace Ship_Game.Ships
             }
             else
             {
-                float shipCost    = ship.GetCost(empire);
+                float shipCost    = ship.GetCost(empire, ignorePace: true);
                 float hangarsArea = ship.AllFighterHangars.Sum(m => m.MaximumHangarShipSize);
                 float surfaceArea = ship.BaseHull.SurfaceArea + hangarsArea;
                 maint = hullUpkeep ? surfaceArea * MaintModifierBySize : shipCost * MaintModifierByCost;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
@@ -182,7 +182,7 @@ namespace Ship_Game
                                        : (flatProdToFeedAll - netProdPerColonist - Prod.NetFlatBonus).LowerBound(0);
 
             float richnessMultiplier = NonCybernetic ? 5 : 10;
-            float perRichness        = (MineralRichness * richnessMultiplier - Prod.NetFlatBonus / 2).LowerBound(0);
+            float perRichness        = (MineralRichness * richnessMultiplier - Prod.NetFlatBonus * 0.5f).LowerBound(0);
             float perCol             = 10 - netProdPerColonist - flatProdToFeedAll * richnessBonus;
             perCol                   = (perCol * MineralRichness).LowerBound(0);
 
@@ -198,9 +198,10 @@ namespace Ship_Game
             perCol += (1 - Storage.ProdRatio) * MineralRichness;
             perCol *= PopulationRatio;
 
-            float flatMulti = Prod.NetMaxPotential < 1 ? 4 : 1;
+            float maxPotentialThreshold = IsCybernetic ? 2 : 1;
+            float flatMulti = (IsCybernetic ? maxPotentialThreshold / Prod.NetMaxPotential.LowerBound(0.1f) : 4).Clamped(4, 20);
             flat        = ApplyGovernorBonus(flat, 1f, 2f, 1f, 1f, 1.5f) * flatMulti;
-            perRichness = ApplyGovernorBonus(perRichness, 1f, 2f, 0.5f, 0.5f, 1.5f);
+            perRichness = ApplyGovernorBonus(perRichness, 1f, 2f, 0.5f, 0.5f, 1.5f) * flatMulti;
             perCol      = ApplyGovernorBonus(perCol, 1f, 2f, 0.5f, 0.5f, 1.5f);
             Priorities[ColonyPriority.ProdFlat]        = flat;
             Priorities[ColonyPriority.ProdPerRichness] = perRichness;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
@@ -213,7 +213,7 @@ namespace Ship_Game
             float totalProdSlots  = (totalProdNeeded / averageFreighterCargoCap).LowerBound(0);
 
             if (IsCybernetic) // They need prod as food
-                totalProdSlots += ((int)(-Prod.NetIncome * AverageProdImportTurns / averageFreighterCargoCap)).LowerBound(0);
+                totalProdSlots += ((int)(-Prod.NetIncome * AverageProdImportTurns / averageFreighterCargoCap)).LowerBound(1);
 
             return (int)totalProdSlots.Clamped(0, maxSlots);
         }

--- a/Ship_Game/Universe/SolarBodies/SBProduction.cs
+++ b/Ship_Game/Universe/SolarBodies/SBProduction.cs
@@ -546,9 +546,9 @@ namespace Ship_Game.Universe.SolarBodies
                 {
                     float percentCompleted = q.ProductionSpent / q.ActualCost;
                     q.ShipData = newShip;
-                    q.Cost = percentCompleted.AlmostZero() 
+                    q.Cost = q.ProductionSpent <= 10
                            ? newShip.GetCost(Owner) 
-                           : q.Cost + refitCost * percentCompleted * P.ShipCostModifier;
+                           : q.Cost + refitCost*P.ShipCostModifier;
                 }
             }
         }


### PR DESCRIPTION
Fix: Refit in fleet refitted all ships.
Fix: Formula updates for refit ship cost added to ships in construction queue
Fix: Ship maintenance increased with game pacing. 
Fix: Limit Freighter build based on empire credit rating.
Fix:  Cybernetic Governors issue with construction queue and negative production and import Trade slots.
Balance: Limit Maintenance multiplier to a max of x2
Balance: Pirates attack/demand pace now align with game pace. 
Balance: Freighter Cost weight in shipbuilder for auto select freighters now puts more weight when pace is slower.
Balance: Freighter AI prioritize.
Balance: Governor Eval production buildings for cybernetics.
