### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/AutomationWindow.cs
+++ b/Ship_Game/AutomationWindow.cs
@@ -30,7 +30,7 @@ namespace Ship_Game
         {
             Screen = screen;
             const int windowWidth = 220;
-            Rect = new Rectangle(ScreenWidth - 15 - windowWidth, 130, windowWidth, 660);
+            Rect = new Rectangle(ScreenWidth - 15 - windowWidth, 100, windowWidth, 685);
             CanEscapeFromScreen = false;
         }
 
@@ -95,6 +95,7 @@ namespace Ship_Game
             rest.AddCheckbox(() => UState.P.DisableInhibitionWarning,     title: GameText.DisableInhibitionAlerts, tooltip: GameText.InhibitionAlertsAreDisplayedWhen);
             rest.AddCheckbox(() => UState.P.DisableVolcanoWarning,        title: GameText.DisableVolcanoAlerts, tooltip: GameText.DisableVolcanoActivationOrDeactivation);
             rest.AddCheckbox(() => UState.P.EnableStarvationWarning,      title: GameText.EnableStarvationWarning, tooltip: GameText.EnableStarvationWarningTip);
+            rest.AddCheckbox(() => UState.P.PrioitizeProjectors,          title: GameText.PrioritizeProjector, tooltip: GameText.PrioritizeProjectorTip);
 
             UIList ticks = AddList(new Vector2(win.X + 10f, win.Y + 26f));
             ticks.Padding = new Vector2(2f, 10f);

--- a/Ship_Game/Commands/Goals/PirateDirectorPayment.cs
+++ b/Ship_Game/Commands/Goals/PirateDirectorPayment.cs
@@ -116,9 +116,9 @@ namespace Ship_Game.Commands.Goals
                     error             = false;
                     int moneyDemand   = Pirates.GetMoneyModifier(TargetEmpire, e.PercentMoneyDemanded);
                     float chanceToPay = 1 - moneyDemand/TargetEmpire.Money.LowerBound(1);
-                    chanceToPay       = chanceToPay.LowerBound(0) * 100 / ((int)UState.P.Difficulty+1);
+                    chanceToPay       = chanceToPay.LowerBound(0) * 100 / ((int)UState.P.Difficulty+1) * Owner.PersonalityModifiers.PiratePayChanceModifier;
                         
-                    if (TargetEmpire.data.TaxRate < 0.4f && Owner.Random.RollDice(chanceToPay)) // We can expand that with AI personality
+                    if (TargetEmpire.AI.CreditRating > 0.6f && Owner.Random.RollDice(chanceToPay))
                     {
                         TargetEmpire.AddMoney(-moneyDemand);
                         TargetEmpire.AI.EndWarFromEvent(Pirates.Owner);

--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -4688,7 +4688,13 @@ namespace Ship_Game
 
 
 
-
+        /// <summary>Prioritize Projectors</summary>
+        PrioritizeProjector = 4922,
+        /// <summary>Whenever a Subspace Projector is placed in</summary>
+        PrioritizeProjectorTip = 4923,
+        // -------------------------------------
+        // 4924 to 4987 is reserved and used !!!
+        // -------------------------------------
         /// <summary>Ship Maintenance Modifier</summary>
         ShipMaintenanceModifier = 4988,
         /// <summary>on surface</summary>

--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -4686,8 +4686,10 @@ namespace Ship_Game
 
 
 
-
-
+        /// <summary>Specialzied Trade-Hubs</summary>
+        SpecializedTradeHub = 4920,
+        /// <summary>Spacialized Trade-hub will enable the Governor management</summary>
+        SpecializedTradeHubTip = 4921,
         /// <summary>Prioritize Projectors</summary>
         PrioritizeProjector = 4922,
         /// <summary>Whenever a Subspace Projector is placed in</summary>

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -594,6 +594,7 @@ namespace Ship_Game
         public void RemovePlanet(Planet planet)
         {
             OwnedPlanets.Remove(planet);
+            planet.SetSpecializedTradeHub(false);
             Universe.OnPlanetOwnerRemoved(this, planet);
 
             if (!planet.System.HasPlanetsOwnedBy(this)) // system no more in owned planets?

--- a/Ship_Game/EmpirePersonalityModifiers.cs
+++ b/Ship_Game/EmpirePersonalityModifiers.cs
@@ -35,6 +35,7 @@ namespace Ship_Game
         public readonly bool CanWeSurrenderToPlayerAfterBetrayal; // Will the AI be able to surrender to player after s/he betrayed them in allied war
         public readonly float DistanceToDefendAllyThreshold; // Defend Allies' systems if they are closer to us, basaed on this threshold lower is closer
         public readonly float ImperialistWarPlanetsToTakeMult; // multiplier for how many planets to take from available enemy planets if we have better score
+        public readonly float PiratePayChanceModifier; // How inclined to pay pirates
 
         public PersonalityModifiers(PersonalityType type)
         {
@@ -55,6 +56,7 @@ namespace Ship_Game
                     WarGradeThresholdForPeace    = 0.4f * War.MaxWarGrade;
                     ClearNeutralExoticSystems    = false; 
                     AddAngerAlliedWithEnemy      = 0;
+                    PiratePayChanceModifier      = 1;
                     CloserToUsClaimWarn   = 0.3f;
                     DefenseTaskWeight     = 1;
                     FleetStrMultiplier    = 1;
@@ -87,6 +89,7 @@ namespace Ship_Game
                     ClearNeutralExoticSystems    = true;
                     PlanetStoleTrustMultiplier   = 0.5f;
                     AddAngerAlliedWithEnemy      = 50;
+                    PiratePayChanceModifier      = 0.4f;
                     CloserToUsClaimWarn   = 0.5f;
                     DefenseTaskWeight     = 1.2f;
                     FleetStrMultiplier    = 1.15f;
@@ -119,6 +122,7 @@ namespace Ship_Game
                     ClearNeutralExoticSystems    = true;
                     PlanetStoleTrustMultiplier   = 0.6f;
                     AddAngerAlliedWithEnemy      = 25;
+                    PiratePayChanceModifier      = 0.5f;
                     CloserToUsClaimWarn   = 0.4f;
                     DefenseTaskWeight     = 1;
                     FleetStrMultiplier    = 1.1f;
@@ -151,6 +155,7 @@ namespace Ship_Game
                     WarGradeThresholdForPeace    = 0.25f * War.MaxWarGrade;
                     ClearNeutralExoticSystems    = true;
                     AddAngerAlliedWithEnemy      = 100;
+                    PiratePayChanceModifier      = 0.6f;
                     CloserToUsClaimWarn   = 0.6f;
                     DefenseTaskWeight     = 1.2f;
                     FleetStrMultiplier    = 1.05f;
@@ -184,6 +189,7 @@ namespace Ship_Game
                     WarGradeThresholdForPeace    = 0.5f * War.MaxWarGrade;
                     ClearNeutralExoticSystems    = false;
                     AddAngerAlliedWithEnemy      = 0;
+                    PiratePayChanceModifier      = 0.7f;
                     CloserToUsClaimWarn   = 0.3f;
                     DefenseTaskWeight     = 1.3f;
                     FleetStrMultiplier    = 0.95f;
@@ -216,6 +222,7 @@ namespace Ship_Game
                     WarGradeThresholdForPeace    = 0.55f * War.MaxWarGrade;
                     ClearNeutralExoticSystems    = false;
                     AddAngerAlliedWithEnemy      = 75;
+                    PiratePayChanceModifier      = 0.25f;
                     CloserToUsClaimWarn   = 0.4f;
                     DefenseTaskWeight     = 1.5f;
                     FleetStrMultiplier    = 1f;
@@ -248,6 +255,7 @@ namespace Ship_Game
                     ClearNeutralExoticSystems    = false;
                     PlanetStoleTrustMultiplier   = 0.8f;
                     AddAngerAlliedWithEnemy      = 0;
+                    PiratePayChanceModifier      = 0.75f;
                     CloserToUsClaimWarn   = 0.2f;
                     DefenseTaskWeight     = 2;
                     FleetStrMultiplier    = 0.9f;

--- a/Ship_Game/Empire_RallyPlanets.cs
+++ b/Ship_Game/Empire_RallyPlanets.cs
@@ -262,11 +262,12 @@ public sealed partial class Empire
             switch (planet.CType)
             {
                 case ColonyType.TradeHub:
+                case ColonyType.Colony:       maxPotential  = planet.Prod.NetIncome; break;
                 case ColonyType.Core:         maxPotential *= 0.5f;                  break;
                 case ColonyType.Agricultural: maxPotential *= 0.25f;                 break;
                 case ColonyType.Military:     maxPotential *= 0.75f;                 break;
                 case ColonyType.Research:     maxPotential *= 0.1f;                  break;
-                case ColonyType.Colony:       maxPotential  = planet.Prod.NetIncome; break;
+
             }
 
             return maxPotential;

--- a/Ship_Game/Empire_Trade.cs
+++ b/Ship_Game/Empire_Trade.cs
@@ -268,7 +268,7 @@ namespace Ship_Game
                 case FreighterPriority.UnloadedAllCargo: ratioDiff = -0.02f;  break;
             }
 
-            float numPiratesAtWarModifier = 0.1f * Universe.PirateFactions.Count(e => IsAtWarWith(e));
+            float numPiratesAtWarModifier = 0.02f * Universe.PirateFactions.Count(e => IsAtWarWith(e));
             IncreaseFastVsBigFreighterRatio(ratioDiff+ numPiratesAtWarModifier);
         }
 

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -1276,17 +1276,24 @@ namespace Ship_Game.Fleets
                     }
                     break;
                 case 3:// Waiting for AO change from RemnandDefendPortal Goal
+                    RetaskFleetIfNoPortals();
                     break;
                 case 4:
+                    if (RetaskFleetIfNoPortals())
+                        break;
+
                     CombatMoveToAO(task, 10_000);
                     TaskStep = 5;
                     break;
                 case 5:
-                    if (ArrivedAtCombatRally(FinalPosition))
+                    if (!RetaskFleetIfNoPortals() && ArrivedAtCombatRally(FinalPosition))
                         TaskStep = 6;
 
                     break;
                 case 6:
+                    if (RetaskFleetIfNoPortals())
+                        break;
+                    
                     Owner.Remnants.DisbandDefenseFleet(this);
                     FleetTask.EndTask();
                     break;

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -1276,24 +1276,17 @@ namespace Ship_Game.Fleets
                     }
                     break;
                 case 3:// Waiting for AO change from RemnandDefendPortal Goal
-                    RetaskFleetIfNoPortals();
                     break;
                 case 4:
-                    if (RetaskFleetIfNoPortals())
-                        break;
-
                     CombatMoveToAO(task, 10_000);
                     TaskStep = 5;
                     break;
                 case 5:
-                    if (!RetaskFleetIfNoPortals() && ArrivedAtCombatRally(FinalPosition))
+                    if (ArrivedAtCombatRally(FinalPosition))
                         TaskStep = 6;
 
                     break;
                 case 6:
-                    if (RetaskFleetIfNoPortals())
-                        break;
-                    
                     Owner.Remnants.DisbandDefenseFleet(this);
                     FleetTask.EndTask();
                     break;

--- a/Ship_Game/GameScreens/ColonyScreen/ColonySlider.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/ColonySlider.cs
@@ -100,7 +100,7 @@ namespace Ship_Game
             set => Resource.PercentLock = value;
         }
 
-        bool IsAIGovernor => P.CType != Planet.ColonyType.Colony;
+        bool IsAIGovernor => P.CType != Planet.ColonyType.Colony && P.CType != Planet.ColonyType.TradeHub;
 
         public override bool HandleInput(InputState input)
         {

--- a/Ship_Game/GameScreens/ColonyScreen/ColonySliderGroup.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/ColonySliderGroup.cs
@@ -113,7 +113,8 @@ namespace Ship_Game
             int numLocked = Sliders.Count(s => s.LockedByUser);
             foreach (ColonySlider s in Sliders)
             {
-                s.CanDrag = !s.LockedByUser && numLocked <= 1 && P.CType == Planet.ColonyType.Colony;
+                s.CanDrag = !s.LockedByUser && numLocked <= 1 
+                    && (P.CType is Planet.ColonyType.Colony or Planet.ColonyType.TradeHub);
             }
 
             Prod.IsCrippled = P.CrippledTurns > 0;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -109,7 +109,7 @@ namespace Ship_Game
         public bool WeAreInvadingHere(Empire empire)    => Troops.WeAreInvadingHere(empire);
         public bool MightBeAWarZone(Empire empire)      => Troops.MightBeAWarZone(empire);
         public bool ForeignTroopHere(Empire empire)     => Troops.ForeignTroopHere(empire);
-        public bool NoGovernorAndNotTradeHub            => !Governor && CType != ColonyType.TradeHub;
+        public bool NoGovernorAndNotTradeHub            => CType == ColonyType.Colony || SpecializedTradeHub;
         public int SpecialCommodities                   => CountBuildings(b => b.IsCommodity);
         public bool HasCommodities => HasBuilding(b => b.IsCommodity || b.IsVolcano || b.IsCrater);
         public bool Governor => CType != ColonyType.Colony;
@@ -1084,7 +1084,7 @@ namespace Ship_Game
             if (!Habitable)
                 return;
 
-            NumShipyards = OrbitalStations.Count(s => s.Active && s.ShipData.IsShipyard);
+            NumShipyards = OrbitalStations.Count(s => s.Active && s.ShipData.IsShipyard && s.Loyalty == Owner);
             CalcShipCostModifier(NumShipyards);
         }
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
@@ -26,9 +26,10 @@ namespace Ship_Game
 
         private void BuildPlatformsAndStations(PlanetBudget budget) // Rewritten by Fat Bastard
         {
-            if (CType == ColonyType.Colony || OwnerIsPlayer && !GovOrbitals
-                                                || SpaceCombatNearPlanet
-                                                || !HasSpacePort)
+            if (CType == ColonyType.Colony 
+                || OwnerIsPlayer && (!GovOrbitals || SpecializedTradeHub)
+                || SpaceCombatNearPlanet
+                || !HasSpacePort)
             {
                 return;
             }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
@@ -125,7 +125,7 @@ public partial class Planet
         // This is to consider food production flactuations
         float ModifiedTotalTurnsToComplete()
         {
-            if (IsCybernetic)   
+            if (IsCybernetic || SpecializedTradeHub)   
                 return 1;
 
             switch (CType)

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
@@ -803,12 +803,26 @@ namespace Ship_Game
             if (IsPlanetExtraDebugTarget())
                 Log.Info(ConsoleColor.Green, $"{Owner.PortraitName} BUILT {bio.Name} on planet {Name}");
 
+            return Construction.Enqueue(bio, GetPrefettedTile()); // Preferred is null safe in this call
 
-            PlanetGridSquare preferred = Owner.IsBuildingUnlocked(Building.TerraformerId) 
-                ? TilesList.Find(t => !t.Habitable && !t.Terraformable)
-                : null;
+            PlanetGridSquare GetPrefettedTile()
+            {
+                PlanetGridSquare preferred = null;
+                if (Owner.IsBuildingUnlocked(Building.TerraformerId))
+                {
+                    preferred = TilesList.Find(t => !t.Habitable && !t.Terraformable && !t.BuildingOnTile);
+                    if (preferred == null)
+                        preferred = TilesList.Find(t => !t.Habitable && !t.Terraformable);
+                }
+                else
+                {
+                    preferred = TilesList.Find(t => !t.Habitable && !t.BuildingOnTile);
+                    if (preferred == null)
+                        preferred = TilesList.Find(t => !t.Habitable);
+                }
 
-            return Construction.Enqueue(bio, preferred); // Preferred is null safe in this call
+                return preferred;
+            }
         }
 
         bool BioSphereProfitable(Building bio)

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
@@ -151,9 +151,10 @@ namespace Ship_Game
 
         public void GenerateNewHomeWorld(RandomBase random, Empire owner, SolarSystemData.Ring data = null)
         {
-            PlanetType type = ResourceManager.Planets.RandomPlanet(owner.data.PreferredEnvPlanet);
-            float scale = 1f * owner.data.Traits.HomeworldSizeMultiplier; // base max pop is affected by scale
+            PlanetType type = data?.WhichPlanet > 0 ? ResourceManager.Planets.PlanetOrRandom(data.WhichPlanet) 
+                                                    : ResourceManager.Planets.RandomPlanet(owner.data.PreferredEnvPlanet);
 
+            float scale = 1f * owner.data.Traits.HomeworldSizeMultiplier; // base max pop is affected by scale
             InitPlanetType(type, scale, fromSave: false);
             SetOwner(owner);
             IsHomeworld = true;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Govern.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Govern.cs
@@ -18,16 +18,19 @@ namespace Ship_Game
         float EstimatedAverageFood => (Food.NetMaxPotential / 3).LowerBound(0.1f);
 
         [StarData] public ColonyBlueprints Blueprints {get; private set;}
+        [StarData] public bool SpecializedTradeHub { get; private set; }
 
         public bool HasBlueprints => Blueprints != null;
         public bool HasExclusiveBlueprints => Blueprints?.Exclusive == true;
         bool RequiredInBlueprints(Building b) => Blueprints?.IsRequired(b) == true;
 
-
+        public void SetSpecializedTradeHub(bool value)
+        {
+            SpecializedTradeHub = value;
+        }
 
         public void DoGoverning()
         {
-            UpdateShipyards(); // FB: this can be removed later (lets say Feb 2024) - only for save support
             RefreshBuildingsWeCanBuildHere();
             if (RecentCombat)
                 return; // Cant Build stuff when there is combat on the planet
@@ -49,15 +52,17 @@ namespace Ship_Game
             if (!OwnerIsPlayer && Owner.GetPlanets().Count == 1)
                 CType = ColonyType.Core;
 
-            Food.Percent = 0;
-            Prod.Percent = 0;
-            Res.Percent  = 0;
+            if (CType != ColonyType.TradeHub)
+            {
+                Food.Percent = 0;
+                Prod.Percent = 0;
+                Res.Percent = 0;
+            }
 
             CreateAndOrUpdateBudget();
             switch (CType) // New resource management by Gretman
             {
                 case ColonyType.TradeHub:
-                    AssignCoreWorldWorkers();
                     DetermineFoodState(0.2f, 0.8f);
                     DetermineProdState(0.2f, 0.8f);
                     break;
@@ -128,6 +133,9 @@ namespace Ship_Game
         //New Build Logic by Gretman, modified by Fat Bastard
         void BuildAndScrapBuildings(PlanetBudget colonyBudget)
         {
+            if (OwnerIsPlayer && SpecializedTradeHub)
+                return;
+
             BuildAndScrapCivilianBuildings(colonyBudget.RemainingCivilian);
             BuildAndScrapMilitaryBuildings(colonyBudget.RemainingGroundDef);
         }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Resources.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Resources.cs
@@ -47,15 +47,6 @@ namespace Ship_Game
             }
         }
 
-        public void SetWorkerPercentages(float farmerPercent, float workerPercent, float researchPercent)
-        {
-            Food.Percent = farmerPercent.NaNChecked(0.4f, "SetWorkerPercentages farmer");
-            Prod.Percent = workerPercent.NaNChecked(0.4f, "SetWorkerPercentages worker");
-            Res.Percent  = researchPercent.NaNChecked(0.2f, "SetWorkerPercentages research");
-            if (Owner != null)
-                Food.AutoBalanceWorkers();
-        }
-
         [StarData] public float PopulationBillion { get; private set; }
         public float PlusFlatPopulationPerTurn { get; private set; }
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
@@ -169,7 +169,7 @@ namespace Ship_Game
 
             if (NoGovernorAndNotTradeHub)
             {
-                // for players with no governor or with trade hub - only 90% storage or less will open slots
+                // for players with no governor or trade hub - only 90% storage or less will open slots
                 if (Storage.FoodRatio > 0.9f)
                     return 0;  
             }

--- a/Ship_Game/Universe/SolarBodies/SBProduction.cs
+++ b/Ship_Game/Universe/SolarBodies/SBProduction.cs
@@ -433,9 +433,10 @@ namespace Ship_Game.Universe.SolarBodies
                     int totalFreighters = Owner.TotalFreighters;
                     ConstructionQueue.Sort(q => q.GetAndUpdatePriorityForAI(P, totalFreighters));
                 }
-                else if (item.Rush && item.QType == QueueItemType.OrbitalUrgent)
+                else if (item.Rush && item.QType == QueueItemType.OrbitalUrgent 
+                    || P.Universe.P.PrioitizeProjectors && item.QType == QueueItemType.RoadNode)
                 {
-                    // prioritize projector bridges for the player.
+                    // prioritize projector bridges for the player (or any projector if flag is set).
                     MoveTo(0, Count - 1);
                 }
             }

--- a/Ship_Game/Universe/UniverseParams.cs
+++ b/Ship_Game/Universe/UniverseParams.cs
@@ -70,6 +70,7 @@ public class UniverseParams
     [StarData] public bool ShipListFilterNotInFleets;
     [StarData] public bool CordrazinePlanetCaptured;
     [StarData] public bool DisableVolcanoWarning;
+    [StarData] public bool PrioitizeProjectors;
     [StarData(DefaultValue=true)] public bool ShowAllDesigns = true;
     [StarData] public bool FilterOldModules;
 

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.HandleInput.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.HandleInput.cs
@@ -692,7 +692,8 @@ namespace Ship_Game
                 return true;
             }
 
-            ClearSelectedItems(clearFlags: false);
+            if (!input.IsShiftKeyDown && !input.IsAltKeyDown && !input.IsCtrlKeyDown)
+                ClearSelectedItems(clearFlags: false);
             return false;
         }
 

--- a/UnitTests/Serialization/BinarySerializerTests.cs
+++ b/UnitTests/Serialization/BinarySerializerTests.cs
@@ -1133,6 +1133,7 @@ namespace UnitTests.Serialization
             AssertEqual(instance.FixedPlayerCreditCharge, result.FixedPlayerCreditCharge);
             AssertEqual(instance.DisableResearchStations, result.DisableResearchStations);
             AssertEqual(instance.DisableMiningOps, result.DisableMiningOps);
+            AssertEqual(instance.PrioitizeProjectors, result.PrioitizeProjectors);
         }
 
         [TestMethod]

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -13002,6 +13002,12 @@ DisableScreenPanningOption:
 DisableScreenPanningOptionTip:
  Id: 4525
  ENG: "Mouse pointer cannot be used for edge screen movement, only WASD keys. Useful for players with multiple screens if their maps keeps moving when they focus on another screen."   
+PrioritizeProjector:
+ Id: 4922
+ ENG: "Prioritize Projectors"
+rioritizeProjectorTip:
+ Id: 4923
+ ENG: "Whenever a Subspace Projector is placed in a planet's consturction queue, manually or automatically, it would be placed at the top of the list."  
 BB_MiningSpeedTech:
  Id: 4924
  ENG: "Mining Ships Speed"

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -2121,9 +2121,9 @@ Tradehub:
  UKR: "Торговий хаб"
 GovernorWillControlProductionLevels:
  Id: 394
- ENG: "Governor will control production levels as a core system, but will not build any structures. It will start importing if stores are below 20% and continue importing until they reach 40%. It will start exporting if stores are above 80% and continue exporting until stores go down to 40%."
- RUS: "Губернатор будет контролировать уровни производства,но не будет строить никаких зданий.Он начнет импорт при запасах 20%,и продолжит импорт, пока не достигнет 40% склад.запасов.Начнет экспорт,если на складе будет 80% ,и продолжит экспорт, пока склад не опустеет до 40%."
- UKR: "Губернатор контролюватиме рівень виробництва як основні світи, але не будуватиме жодних структур. Він почне імпортувати, якщо запаси будуть нижчими за 20%, і продовжуватиме імпортувати, поки вони не досягнуть 40%. Він почне експортувати, якщо запаси перевищують 80%, і продовжуватиме експортувати, поки запаси не знизяться до 40%."
+ ENG: "Governor will not build any structures or assign labor, It will only Control Import/Export. It will start importing if stores are below 20% and continue importing until they reach 40%. It will start exporting if stores are above 80% and continue exporting until stores go down to 40%."
+ RUS: "Губернатор не будет строить никаких сооружений или назначать рабочую силу, он будет только контролировать импорт/экспорт. Он начнет импорт, если уровень запасов будет ниже 20%, и продолжит импорт, пока он не достигнет 40%. Он начнет экспортировать, если запасы превысят 80%, и продолжит экспорт, пока запасы не упадут до 40%."
+ UKR: "Губернатор не буде будувати жодних структур чи призначати робочу силу, він лише контролюватиме імпорт/експорт. Він розпочне імпорт, якщо кількість магазинів буде нижчою за 20%, і продовжить імпорт, доки не досягне 40%. Він розпочне експорт, якщо кількість магазинів перевищить 80%, і продовжить експорт, доки кількість магазинів не знизиться до 40%."
 AbandonedMine:
  Id: 400
  ENG: "Abandoned Mine"
@@ -11738,9 +11738,9 @@ OverrideThisBudgetAndSet:
  UKR: "Перевизначте цей бюджет і встановіть свій власний."
 CivilianBuildingsExpenditurebudgetInByc:
  Id: 4228
- ENG: "Civilian Buildings Expenditure/Budget in BY/C. If you see over-budget, you might have buildings you have manually built and the Governor cannot scrap them."
- RUS: "Расходы/бюджет на гражданские здания в МК/Г (Миллиард Кредитов/Год). Если вы наблюдаете превышение бюджета, возможно, есть здания, которые вы построили вручную, и губернатор не может их снести."
- UKR: "Витрати/бюджет на цивільні будівлі в BY/C. Якщо ви бачите перевиконання бюджету, можливо, у вас є будівлі, які ви побудували вручну, і губернатор не може їх здати на металобрухт."
+ ENG: "Civilian Buildings Expenditure/Budget in bc/y. If you see over-budget, you might have buildings you have manually built and the Governor cannot scrap them."
+ RUS: "Расходы/бюджет на гражданские здания в МГ/K (Миллиард Кредитов/Год). Если вы наблюдаете превышение бюджета, возможно, есть здания, которые вы построили вручную, и губернатор не может их снести."
+ UKR: "Витрати/бюджет на цивільні будівлі в bc/y. Якщо ви бачите перевиконання бюджету, можливо, у вас є будівлі, які ви побудували вручну, і губернатор не може їх здати на металобрухт."
 GroundDefenseBuildingsExpenditurebudgetIn:
  Id: 4229
  ENG: "Ground Defense Buildings Expenditure/Budget in BY/C. If you see over-budget, you might have buildings you have manually built and the Governor cannot scrap them."
@@ -13002,6 +13002,12 @@ DisableScreenPanningOption:
 DisableScreenPanningOptionTip:
  Id: 4525
  ENG: "Mouse pointer cannot be used for edge screen movement, only WASD keys. Useful for players with multiple screens if their maps keeps moving when they focus on another screen."   
+SpecializedTradeHub:
+ Id: 4920
+ ENG: "Specialzied Trade-Hub"  
+SpecializedTradeHubTip:
+ Id: 4921
+ ENG: "Spacialized Trade-hub will enable the Governor management for Import/Export preferences based on the Govenror Type and for the automation of Labor sliders, again, based on the Governor type. it wiil not build or scrap buildings." 
 PrioritizeProjector:
  Id: 4922
  ENG: "Prioritize Projectors"

--- a/game/Content/Globals.yaml
+++ b/game/Content/Globals.yaml
@@ -39,7 +39,7 @@ Globals:
   ResearchBenefitFromAlliance: 0.1 # How much research each alliance is giving you (from other party research)  
   MiningStationFoodPerOneRefining: 0.25 # How much Food is consumed per 1 refining point
   ExoticRatioStorage: 0.02 # How much exotic resource storage an empire has per resource based on all planet normal storage  
-  EnableHullEditor: false # Alows modders to edut hulls. it is disabled by default since it will weaken the AI if not done correctly.
+  EnableHullEditor: false # Allows modders to edit hulls. it is disabled by default since it will weaken the AI if not done correctly.
   
 
   # feature flags


### PR DESCRIPTION
- Feature: Specialized tradehub - each governor can be set to a specialized tradehub where it will not build or scrap, only assign workers and export/import. Original Tradehub will now only control Import/Export.
- Feature: Automation - Added Prioritize Projectors checkbox in AI window.
- Balance: AI Pirate Payment Logic now modified by AI personality.
- Fix: Biosphere placement logic now prefers tiles with no buildings.
- Fix: not showing correctly the planets in defined solar systems (texture dds).
- Fix: Holding shift when selecting more ships will correctly add to already selected ships. Holding Alt will select non player ships.
- Fix: Dont Count a shipyard benefit if it is not the same loyalty as the planet owner
- Fix: typos in localization.


