### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/AI/EmpireAI/EspionageManager.cs
+++ b/Ship_Game/AI/EmpireAI/EspionageManager.cs
@@ -152,7 +152,9 @@ namespace Ship_Game.AI
 
         void UpdateOperationsByPersonality(Map<InfiltrationOpsType, bool> operations, Relationship relations, Espionage espionage, Empire them)
         {
-            bool theyHaveInfiltratedUs = espionage.WeHaveInfoOnTheirInfiltration && them.GetEspionage(Owner).EffectiveLevel > 0;
+            bool theyHaveInfiltratedUs = espionage.WeHaveInfoOnTheirInfiltration 
+                && them.GetEspionage(Owner).EffectiveLevel > (relations.Treaty_Alliance ? 3 : 2);
+
             Array<InfiltrationOpsType> opsWanted = new();
             if (theyHaveInfiltratedUs)
                 opsWanted.Add(InfiltrationOpsType.CounterEspionage);
@@ -223,20 +225,21 @@ namespace Ship_Game.AI
 
             if (!relations.Treaty_Alliance || Owner.IsSafeToActivateOpsOnAllies(them))
             {
-                if (Owner.TechScore * Owner.PersonalityModifiers.EspionageTechScoreOpsMultiplier < them.TechScore)
-                    opsWanted.Add(InfiltrationOpsType.SlowResearch);
+                int allyMultiplier = relations.Treaty_Alliance ? 2 : 1;
+                if (Owner.TechScore * Owner.PersonalityModifiers.EspionageTechScoreOpsMultiplier * allyMultiplier  < them.TechScore)
+                    opsWanted.AddUnique(InfiltrationOpsType.SlowResearch);
 
-                if (Owner.ExpansionScore * Owner.PersonalityModifiers.EspionageExpansionScoreOpsMultiplier  < them.ExpansionScore)
-                    opsWanted.Add(InfiltrationOpsType.Uprise);
+                if (Owner.ExpansionScore * Owner.PersonalityModifiers.EspionageExpansionScoreOpsMultiplier  * allyMultiplier < them.ExpansionScore)
+                    opsWanted.AddUnique(InfiltrationOpsType.Uprise);
 
-                if (Owner.IndustrialScore * Owner.PersonalityModifiers.EspionageIndustryScoreOpsMultiplier < them.IndustrialScore)
-                    opsWanted.Add(InfiltrationOpsType.Sabotage);
+                if (Owner.IndustrialScore * Owner.PersonalityModifiers.EspionageIndustryScoreOpsMultiplier * allyMultiplier < them.IndustrialScore)
+                    opsWanted.AddUnique(InfiltrationOpsType.Sabotage);
 
-                if (Owner.MilitaryScore * Owner.PersonalityModifiers.EspionageMilitaryScoreOpsMultiplier < them.MilitaryScore)
-                    opsWanted.Add(InfiltrationOpsType.Rebellion);
+                if (Owner.MilitaryScore * Owner.PersonalityModifiers.EspionageMilitaryScoreOpsMultiplier * allyMultiplier < them.MilitaryScore)
+                    opsWanted.AddUnique(InfiltrationOpsType.Rebellion);
 
-                if (Owner.TotalScore * Owner.PersonalityModifiers.EspionageTotalScoreOpsMultiplier < them.TotalScore)
-                    opsWanted.Add(InfiltrationOpsType.DisruptProjection);
+                if (Owner.TotalScore * Owner.PersonalityModifiers.EspionageTotalScoreOpsMultiplier * allyMultiplier < them.TotalScore)
+                    opsWanted.AddUnique(InfiltrationOpsType.DisruptProjection);
             }
 
             foreach (InfiltrationOpsType type in opsWanted)

--- a/Ship_Game/EmpirePersonalityModifiers.cs
+++ b/Ship_Game/EmpirePersonalityModifiers.cs
@@ -300,11 +300,11 @@ namespace Ship_Game
                     GoToWarTolerance      = 1.1f;
                     WarSneakiness         = -10;
 
-                    EspionageTechScoreOpsMultiplier      = 1.6f;
-                    EspionageExpansionScoreOpsMultiplier = 1.5f;
-                    EspionageIndustryScoreOpsMultiplier  = 1.5f;
-                    EspionageMilitaryScoreOpsMultiplier  = 1.75f;
-                    EspionageTotalScoreOpsMultiplier     = 2f;
+                    EspionageTechScoreOpsMultiplier      = 2.6f;
+                    EspionageExpansionScoreOpsMultiplier = 2.5f;
+                    EspionageIndustryScoreOpsMultiplier  = 2.5f;
+                    EspionageMilitaryScoreOpsMultiplier  = 2.75f;
+                    EspionageTotalScoreOpsMultiplier     = 3f;
                     break;
                 case PersonalityType.Pacifist:
                     ColonizationClaimRatioWarningThreshold = 1.25f;
@@ -342,11 +342,11 @@ namespace Ship_Game
                     GoToWarTolerance      = 2f;
                     WarSneakiness         = -5;
 
-                    EspionageTechScoreOpsMultiplier      = 1.5f;
-                    EspionageExpansionScoreOpsMultiplier = 1.6f;
-                    EspionageIndustryScoreOpsMultiplier  = 1.75f;
-                    EspionageMilitaryScoreOpsMultiplier  = 1.75f;
-                    EspionageTotalScoreOpsMultiplier     = 2f;
+                    EspionageTechScoreOpsMultiplier      = 2f;
+                    EspionageExpansionScoreOpsMultiplier = 2.5f;
+                    EspionageIndustryScoreOpsMultiplier  = 2.75f;
+                    EspionageMilitaryScoreOpsMultiplier  = 2.75f;
+                    EspionageTotalScoreOpsMultiplier     = 3f;
                     break;
             }
         }

--- a/Ship_Game/Empire_Trade.cs
+++ b/Ship_Game/Empire_Trade.cs
@@ -177,7 +177,7 @@ namespace Ship_Game
                 return;
             }
 
-            importingPlanets.Sort(p => p.GetCachedIncomingCargo(goods));
+            importingPlanets.Sort(p => p.GetCachedIncomingCargoPriority(goods));
 
             for (int i = 0; i < importingPlanets.Length; i++)
             {

--- a/Ship_Game/GameScreens/ColonyScreen/ColonyScreen.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/ColonyScreen.cs
@@ -392,7 +392,7 @@ namespace Ship_Game
             Rectangle outgoingFoodRect = new Rectangle((int)(outgoingFoodPos.X + indent), (int)outgoingFoodPos.Y, barWidth, 20);
             AddProgressBar(ref OutgoingFoodBar, outgoingFoodRect, P.FoodExportSlots, "green");
             Rectangle exportFoodSlotsRect = new Rectangle((int)(pos.X + indentSlider), (int)(outgoingFoodPos.Y-12), sliderWidth, sliderSize);
-            AddUiSlider(ref ExportFoodSlotSlider, exportFoodSlotsRect, "", 0, 20, P.ManualFoodExportSlots, GameText.ManualTradeSlotTip);
+            AddUiSlider(ref ExportFoodSlotSlider, exportFoodSlotsRect, "", 0, 25, P.ManualFoodExportSlots, GameText.ManualTradeSlotTip);
 
             // Outgoing Prod
             Vector2 outgoingProdPos = new Vector2(pos.X, outgoingFoodPos.Y + spacing);
@@ -400,7 +400,7 @@ namespace Ship_Game
             Rectangle outgoingProdRect = new Rectangle((int)(outgoingProdPos.X + indent), (int)outgoingProdPos.Y, barWidth, 20);
             AddProgressBar(ref OutgoingProdBar, outgoingProdRect, P.ProdExportSlots, "brown");
             Rectangle exportProdSlotsRect = new Rectangle((int)(pos.X + indentSlider), (int)(outgoingProdPos.Y-12), sliderWidth, sliderSize);
-            AddUiSlider(ref ExportProdSlotSlider, exportProdSlotsRect, "", 0, 20, P.ManualProdExportSlots, GameText.ManualTradeSlotTip);
+            AddUiSlider(ref ExportProdSlotSlider, exportProdSlotsRect, "", 0, 25, P.ManualProdExportSlots, GameText.ManualTradeSlotTip);
 
             // Outgoing Colonists
             Vector2 outgoingColoPos = new Vector2(pos.X, outgoingProdPos.Y + spacing);
@@ -408,7 +408,7 @@ namespace Ship_Game
             Rectangle outgoingColoRect = new Rectangle((int)(outgoingColoPos.X + indent), (int)outgoingColoPos.Y, barWidth, 20);
             AddProgressBar(ref OutgoingColoBar, outgoingColoRect, P.ColonistsExportSlots, "blue");
             Rectangle exportColoSlotsRect = new Rectangle((int)(pos.X + indentSlider), (int)(outgoingColoPos.Y-12), sliderWidth, sliderSize);
-            AddUiSlider(ref ExportColoSlotSlider, exportColoSlotsRect, "", 0, 20, P.ManualColoExportSlots, GameText.ManualTradeSlotTip);
+            AddUiSlider(ref ExportColoSlotSlider, exportColoSlotsRect, "", 0, 25, P.ManualColoExportSlots, GameText.ManualTradeSlotTip);
         }
 
         void CreateTerraformingDetails(Vector2 pos)

--- a/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
@@ -322,8 +322,7 @@ namespace Ship_Game
             {
                 FoodStorage.Draw(batch);
                 FoodDropDown.Draw(batch);
-                if (!IsTradeTabSelected)
-                    DrawFoodSlots(batch);
+                DrawFoodSlots(batch);
             }
             else
             {
@@ -336,8 +335,7 @@ namespace Ship_Game
             else if (P.PS == Planet.GoodState.IMPORT) ProdDropDown.ActiveIndex = 1;
             else if (P.PS == Planet.GoodState.EXPORT) ProdDropDown.ActiveIndex = 2;
             ProdDropDown.Draw(batch);
-            if (!IsTradeTabSelected)
-                DrawProdSlots(batch);
+            DrawProdSlots(batch);
             batch.Draw(ResourceManager.Texture("NewUI/icon_storage_food"), FoodStorageIcon, Color.White);
             batch.Draw(ResourceManager.Texture("NewUI/icon_storage_production"), ProfStorageIcon, Color.White);
 
@@ -366,7 +364,6 @@ namespace Ship_Game
             }
 
             DrawTradeSlots(batch, textPos, text, Color.LightGreen, enroute, maxSlots, amount);
-
         }
 
         void DrawProdSlots(SpriteBatch batch)

--- a/Ship_Game/GameScreens/Espionage/EmpiresButton.cs
+++ b/Ship_Game/GameScreens/Espionage/EmpiresButton.cs
@@ -266,7 +266,6 @@ namespace Ship_Game.GameScreens
                 {
                     EspionageBudgetMultiplier?.Draw(batch, elapsed);
                     CostPerTurn?.Draw(batch, elapsed);
-                    //EspionageDisableMessages?.Draw(batch, elapsed);
                 }
             }
         }

--- a/Ship_Game/GameScreens/Espionage/EmpiresButton.cs
+++ b/Ship_Game/GameScreens/Espionage/EmpiresButton.cs
@@ -23,6 +23,7 @@ namespace Ship_Game.GameScreens
         FloatSlider InfiltrationDefense;
         FloatSlider EspionageBudgetMultiplier;
         UILabel CostPerTurn, LimitLevel;
+        UICheckBox EspionageDisableMessages;
 
 
         bool UsingLegacyEspionage => Screen != null;
@@ -66,6 +67,9 @@ namespace Ship_Game.GameScreens
                     Player.SetEspionageDefenseWeight(s.AbsoluteValue.RoundUpTo(1));
                     Player.UpdateEspionageDefenseRatio();
                 };
+
+                EspionageDisableMessages = InfiltrationScreen.Add(new UICheckBox(weightRect.X, weightRect.Y + 42, () => Player.data.SpyMute, Fonts.Arial12, "Disable Messages", 
+                    "Disable all Espionage notifications."));
 
                 if (Player.Universe.MajorEmpires.Any(e => !e.isPlayer && Player.IsKnown(e)))
                 {
@@ -262,6 +266,7 @@ namespace Ship_Game.GameScreens
                 {
                     EspionageBudgetMultiplier?.Draw(batch, elapsed);
                     CostPerTurn?.Draw(batch, elapsed);
+                    //EspionageDisableMessages?.Draw(batch, elapsed);
                 }
             }
         }

--- a/Ship_Game/Shield.cs
+++ b/Ship_Game/Shield.cs
@@ -95,8 +95,12 @@ namespace Ship_Game
 
         public void HitShield(Planet planet, Ship ship, Vector2 planetCenter, float shieldRadius)
         {
-            Matrix soWorld = (Matrix)ship.GetSO().World;
-            HitShield(planet, soWorld, ship.Position.ToVec3(soWorld.Translation.Z), planetCenter, shieldRadius);
+            var shipSo = ship.GetSO();
+            if (shipSo != null)
+            {
+                Matrix soWorld = (Matrix)shipSo.World;
+                HitShield(planet, soWorld, ship.Position.ToVec3(soWorld.Translation.Z), planetCenter, shieldRadius);
+            }
         }
 
         public void HitShield(Planet planet, in Matrix world, Vector3 pos, Vector2 planetCenter, float shieldRadius)

--- a/Ship_Game/Ships/RoleData.cs
+++ b/Ship_Game/Ships/RoleData.cs
@@ -124,21 +124,13 @@ namespace Ship_Game.Ships
                 switch (Category)
                 {
                     case ShipCategory.Unclassified:
-                        break;
                     case ShipCategory.Civilian:
-                        break;
                     case ShipCategory.Recon:
-                        return RoleName.scout;
                     case ShipCategory.Conservative:
-                        break;
                     case ShipCategory.Neutral:
-                        break;
                     case ShipCategory.Reckless:
-                        break;
-                    case ShipCategory.Kamikaze:
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
+                    case ShipCategory.Kamikaze: break;
+                    default: throw new ArgumentOutOfRangeException();
                 }
             }
 

--- a/Ship_Game/Ships/RoleData.cs
+++ b/Ship_Game/Ships/RoleData.cs
@@ -119,21 +119,6 @@ namespace Ship_Game.Ships
             if (pSpecial > 0.10f)
                 return RoleName.support;
 
-            if (Category != ShipCategory.Unclassified)
-            {
-                switch (Category)
-                {
-                    case ShipCategory.Unclassified:
-                    case ShipCategory.Civilian:
-                    case ShipCategory.Recon:
-                    case ShipCategory.Conservative:
-                    case ShipCategory.Neutral:
-                    case ShipCategory.Reckless:
-                    case ShipCategory.Kamikaze: break;
-                    default: throw new ArgumentOutOfRangeException();
-                }
-            }
-
             RoleName fixRole = DataRole == RoleName.prototype ? DataRole : HullRole;
             switch (fixRole)
             {

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -1539,10 +1539,8 @@ namespace Ship_Game.Ships
                 return false;
 
             // will ship instantly explode?
-            if (proj is { Explodes: true } && proj.DamageAmount > (SurfaceArea/2f).LowerBound(200))
-            {
+            if (IsMeteor || proj is { Explodes: true } && proj.DamageAmount > (SurfaceArea/2f).LowerBound(200))
                 return true;
-            }
 
             if (Loyalty.Random.RollDice(35))
             {

--- a/Ship_Game/Ships/ShipInfoUIElement.cs
+++ b/Ship_Game/Ships/ShipInfoUIElement.cs
@@ -263,7 +263,7 @@ namespace Ship_Game.Ships
 
         void DrawStructuralIntegrity(SpriteBatch batch, Vector2 mousePos, Ship ship, ref int numStatus)
         {
-            if (ship.HealthPercent > 0.999f)
+            if (ship.InternalSlotsHealthPercent > 0.999f)
                 return;
 
             SubTexture iconStructure = ResourceManager.Texture("StatusIcons/icon_structure");
@@ -271,11 +271,11 @@ namespace Ship_Game.Ships
                 Color.White, numStatus);
 
             var textPos = new Vector2((int)StatusArea.X + 33 + numStatus * 53, (int)StatusArea.Y + 15);
-            int health = (int)(ship.HealthPercent * 100);
+            int integrity = (int)(ship.InternalSlotsHealthPercent * 100);
 
             float repairPerSec = ship.CurrentRepairPerSecond;
             float timeUntilRepaired = (ship.HealthMax - ship.Health) / repairPerSec;
-            string integrityText = $"{health}% (+{(int)repairPerSec}HP/s ETA:{timeUntilRepaired.TimeString()})";
+            string integrityText = $"{integrity}% (+{(int)repairPerSec}HP/s ETA:{timeUntilRepaired.TimeString()})";
             batch.DrawString(Fonts.Arial12, integrityText, textPos, Color.White);
             numStatus++;
         }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
@@ -122,10 +122,10 @@ namespace Ship_Game
                 return ManualFoodExportSlots;
 
             int min = Storage.FoodRatio > 0.75f ? 2 : 1;
-            int maxSlots = CType is ColonyType.Agricultural or ColonyType.Colony ? 14 : 10;
+            int maxSlots = CType is ColonyType.Agricultural or ColonyType.Colony or ColonyType.TradeHub? 14 : 7;
             int storageSlots = (int)(Storage.Food / Owner.AverageFreighterCargoCap);
             int outputSlots  = (int)(Food.NetIncome * AverageFoodExportTurns / Owner.AverageFreighterCargoCap);
-            return (storageSlots + outputSlots).Clamped(min, maxSlots);
+            return (storageSlots + outputSlots).Clamped(min, maxSlots+outputSlots);
         }
 
         int GetProdExportSlots()
@@ -137,18 +137,20 @@ namespace Ship_Game
                 return ManualProdExportSlots;
 
             int min = Storage.ProdRatio > 0.5f ? 2 : 1;
-            int maxSlots = IsCybernetic ? 6 : 5;
+            int maxSlots = 5;
             switch (CType)
             {
-                case ColonyType.Industrial: maxSlots += 7; break;
-                case ColonyType.Core:       maxSlots += 5; break;
-                case ColonyType.Research:   maxSlots += 3;  break;
+                case ColonyType.Colony:
+                case ColonyType.TradeHub:   maxSlots += IsCybernetic ? 9 : 5; break;
+                case ColonyType.Industrial: maxSlots += IsCybernetic ? 9 : 7; break;
+                case ColonyType.Core:       maxSlots += IsCybernetic ? 7 : 5; break;
+                case ColonyType.Research:   maxSlots += 3;                    break;
             }
 
             int storageSlots = (int)(Storage.Prod / Owner.AverageFreighterCargoCap);
-            int outputSlots  = (int)(Prod.NetIncome * AverageFoodExportTurns / Owner.AverageFreighterCargoCap);
+            int outputSlots  = (int)(Prod.NetIncome * AverageProdExportTurns / Owner.AverageFreighterCargoCap);
 
-            return (storageSlots + outputSlots).Clamped(min, maxSlots);
+            return (storageSlots + outputSlots).Clamped(min, maxSlots + outputSlots);
         }
 
         int GetColonistsExportSlots()
@@ -372,9 +374,20 @@ namespace Ship_Game
             return numActiveFreighters;
         }
 
-        // total (cached) amount of cargo of specified type incoming via freighters
-        public float GetCachedIncomingCargo(Goods goods)
+        // total (cached) amount of cargo of specified type incoming via freighters for prioritize importing planets
+        public float GetCachedIncomingCargoPriority(Goods goods)
         {
+            switch (goods)
+            { 
+                case Goods.Production when IsCybernetic && IsStarving: return Prod.NetIncome*10 + IncomingProd;
+                case Goods.Production:           return IncomingProd;
+                case Goods.Food when IsStarving: return Food.NetIncome*10 + IncomingFood; // food net income is negative when starting
+                case Goods.Food:                 return IncomingFood;
+                case Goods.Colonists:            return IncomingPop;
+                default:                         return 0;
+            }
+
+
             if (goods == Goods.Food) return IncomingFood;
             if (goods == Goods.Production) return IncomingProd;
             if (goods == Goods.Colonists) return IncomingPop;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
@@ -386,12 +386,6 @@ namespace Ship_Game
                 case Goods.Colonists:            return IncomingPop;
                 default:                         return 0;
             }
-
-
-            if (goods == Goods.Food) return IncomingFood;
-            if (goods == Goods.Production) return IncomingProd;
-            if (goods == Goods.Colonists) return IncomingPop;
-            return 0f;
         }
 
         float GetTotalCargo(Ship[] freighterList, Goods goods)

--- a/Ship_Game/Universe/SolarBodies/SolarSystemBody.cs
+++ b/Ship_Game/Universe/SolarBodies/SolarSystemBody.cs
@@ -297,7 +297,7 @@ namespace Ship_Game
                 {
                     if (template.BID == Building.VolcanoId)
                     {
-                        Random.Item(TilesList).CreateVolcano(this as Planet);
+                        Random.Item(TilesList.Filter(t => !t.BuildingOnTile)).CreateVolcano(this as Planet);
                         //Log.Info($"Volcano Created on '{Name}' ");
                     }
                     else


### PR DESCRIPTION
Fix: Improved Free Import Food and Prod slots upper bounds. 
Fix: Show incoming freighter data in storage tab even while trade tab is selected.
Fix: Do not create volcanos on tiles with buildings on it at game start
Fix: Show correct ship's structural integrity in Ship info UI.
Fix: ships marked as recon has their role changed to scout.
Fix: Meteors - dont delay explosion or crash if destroyed
Fix: Crash when stuff hits planet shields and not memory for ship scene object available.
Fix: Add Disable Espionage messages to Espionage screen
Balance: Espionage - Allies offensive missions.
Balance: Increase player manual trade slots maximum to 25.
@gkapulis 