### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/AI/DroneAI.cs
+++ b/Ship_Game/AI/DroneAI.cs
@@ -40,7 +40,7 @@ public sealed class DroneAI
         DroneTarget = Drone.Owner?.AI.FriendliesNearby.FindMinFiltered(
             ship => !ship.IsDeadOrDying && !ship.IsHangarShip
                  && ship.HealthStatus < Status.Maximum
-                 && ship.Position.InRadius(Drone.Owner.Position, 10000),
+                 && ship.Position.InRadius(Drone.Owner.Position, 10000f),
             ship =>
         {
             float distance = ship.Position.Distance(Drone.Owner.Position);

--- a/Ship_Game/AI/EmpireAI/SpaceRoadsManager.cs
+++ b/Ship_Game/AI/EmpireAI/SpaceRoadsManager.cs
@@ -61,7 +61,7 @@ namespace Ship_Game.AI
             for (int i = 0; i < Owner.AI.Goals.Count; i++)
             {
                 Goal g = Owner.AI.Goals[i];
-                if (g is BuildConstructionShip && g.BuildPosition.InRadius(pos, 1000))
+                if (g is BuildConstructionShip && g.BuildPosition.InRadius(pos, 1000f))
                     return true;
             }
 

--- a/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
@@ -695,7 +695,15 @@ namespace Ship_Game.AI
 
             if (badGuysNear && !inCombat && Target != null && ShouldEnterAutoCombat())
             {
-                EnterCombatState(AIState.Combat);
+                if (CombatState == CombatState.Evade)
+                {
+                    OrderFlee();
+                    Owner.InCombat = true;
+                }
+                else
+                {
+                    EnterCombatState(AIState.Combat);
+                }
             }
             // no nearby bad guys, no priority target, exit auto-combat
             else if (!badGuysNear && inCombat && Target == null)

--- a/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
@@ -749,7 +749,7 @@ namespace Ship_Game.AI
             }
 
             ThrustOrWarpToPos(goal.MovePosition, timeStep);
-            if (Owner.Position.InRadius(goal.MovePosition, 200))
+            if (Owner.Position.InRadius(goal.MovePosition, 200f))
             {
                 goal.TargetPlanet.LandBuilderShip();
                 Owner.QueueTotalRemoval();

--- a/Ship_Game/AI/ShipAI/ShipAI.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.cs
@@ -799,9 +799,14 @@ namespace Ship_Game.AI
 
         void ResetStateFlee()
         {
-            if (State != AIState.Flee || BadGuysNear || State == AIState.Resupply || HasPriorityOrder) return;
-            if (OrderQueue.NotEmpty)
+            if (State == AIState.Flee
+                && !BadGuysNear 
+                && !HasPriorityOrder
+                && CombatState != CombatState.Evade
+                && OrderQueue.NotEmpty)
+            {
                 OrderQueue.RemoveLast();
+            }
         }
 
         void PrioritizePlayerCommands()

--- a/Ship_Game/AI/ShipAI/ShipAI.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.cs
@@ -607,7 +607,7 @@ namespace Ship_Game.AI
 
         bool ShouldReturnToFleet(Fleet fleet)
         {
-            if (Owner.Position.InRadius(fleet.GetFormationPos(Owner), 400))
+            if (Owner.Position.InRadius(fleet.GetFormationPos(Owner), 400f))
                 return false;
             // separated for clarity as this section can be very confusing.
             // we might need a toggle for the player action here.

--- a/Ship_Game/Commands/Goals/AssaultBombers.cs
+++ b/Ship_Game/Commands/Goals/AssaultBombers.cs
@@ -67,7 +67,7 @@ namespace Ship_Game.Commands.Goals  // Created by Fat Bastard
                                     Owner.Universe.Notifications.AddEnemyLaunchedTroopsVsFleet(PlanetBuildingAt, Owner);
                             }
 
-                            float distance = ship.Position.InRadius(PlanetBuildingAt.Position, PlanetBuildingAt.Radius + 1500) ? 300 : 600;
+                            float distance = ship.Position.InRadius(PlanetBuildingAt.Position, PlanetBuildingAt.Radius + 1500f) ? 300 : 600;
                             troopShip.Position = ship.Position.GenerateRandomPointOnCircle(distance, Owner.Random);
                             troopShip.Rotation = troopShip.Position.DirectionToTarget(ship.Position).ToRadians();
                             troopShip.InitLaunch(LaunchPlan.Hangar, troopShip.RotationDegrees);

--- a/Ship_Game/Commands/Goals/BuildOrbital.cs
+++ b/Ship_Game/Commands/Goals/BuildOrbital.cs
@@ -117,7 +117,7 @@ namespace Ship_Game.Commands.Goals  // Created by Fat Bastard
             {
                 Owner.Universe?.DebugWin?.DrawCircle(DebugModes.SpatialManager,
                     orbital.Position, 1000, Color.LightCyan, 10.0f);
-                if (position.InRadius(orbital.Position, 500))
+                if (position.InRadius(orbital.Position, 500f))
                     return true;
             }
 
@@ -129,7 +129,7 @@ namespace Ship_Game.Commands.Goals  // Created by Fat Bastard
         {
             return Owner.AI.Goals.Any(g => g != this 
                                            && g is BuildOrbital bo && bo.TetherPlanet == TetherPlanet 
-                                           && g.BuildPosition.InRadius(position, 500));
+                                           && g.BuildPosition.InRadius(position, 500f));
 
             /*var ships = Owner.OwnedShips;
             foreach (Ship ship in ships.Filter(s => s.IsConstructor))

--- a/Ship_Game/Commands/Goals/InhibitorInvestigate.cs
+++ b/Ship_Game/Commands/Goals/InhibitorInvestigate.cs
@@ -17,7 +17,7 @@ namespace Ship_Game.Commands.Goals
         [StarData] Vector2 InvestigatePos { get; set; }
         [StarData] float StrNeeded { get; set; }
 
-        public override bool IsInvsestigationHere(Vector2 pos) => pos.InRadius(InvestigatePos, 50_000);
+        public override bool IsInvsestigationHere(Vector2 pos) => pos.InRadius(InvestigatePos, 50000f);
 
 
         [StarDataConstructor]

--- a/Ship_Game/Commands/Goals/ScoutSystem.cs
+++ b/Ship_Game/Commands/Goals/ScoutSystem.cs
@@ -96,7 +96,7 @@ namespace Ship_Game.Commands.Goals
                 return GoalStep.RestartGoal;
             }
 
-            return FinishedShip.Position.InRadius(FinishedShip.AI.ExplorationTarget.Position, 20000) 
+            return FinishedShip.Position.InRadius(FinishedShip.AI.ExplorationTarget.Position, 20000f) 
                     ? GoalStep.GoalComplete 
                     : GoalStep.TryAgain;
         }

--- a/Ship_Game/GameScreens/Espionage/EmpiresButton.cs
+++ b/Ship_Game/GameScreens/Espionage/EmpiresButton.cs
@@ -266,7 +266,6 @@ namespace Ship_Game.GameScreens
                 {
                     EspionageBudgetMultiplier?.Draw(batch, elapsed);
                     CostPerTurn?.Draw(batch, elapsed);
-                    //EspionageDisableMessages?.Draw(batch, elapsed);
                 }
             }
         }

--- a/Ship_Game/GameScreens/Espionage/EmpiresButton.cs
+++ b/Ship_Game/GameScreens/Espionage/EmpiresButton.cs
@@ -266,6 +266,7 @@ namespace Ship_Game.GameScreens
                 {
                     EspionageBudgetMultiplier?.Draw(batch, elapsed);
                     CostPerTurn?.Draw(batch, elapsed);
+                    //EspionageDisableMessages?.Draw(batch, elapsed);
                 }
             }
         }

--- a/Ship_Game/GameScreens/MainMenu/AutoPatcher.cs
+++ b/Ship_Game/GameScreens/MainMenu/AutoPatcher.cs
@@ -35,7 +35,7 @@ internal class AutoPatcher : PopupWindow
     {
         base.LoadContent();
 
-        Log.LogEventStats(Log.GameEvent.AutoUpdateStarted);
+        //Log.LogEventStats(Log.GameEvent.AutoUpdateStarted);
 
         ProgressSteps = Add(new UIList(new(460, 200), ListLayoutStyle.ResizeList));
         ProgressSteps.AxisAlign = Align.TopCenter;
@@ -404,7 +404,7 @@ internal class AutoPatcher : PopupWindow
     {
         Log.Write("AutoUpdate finished. Restarting in 3 seconds...");
         Log.FlushAllLogs();
-        Log.LogEventStats(Log.GameEvent.AutoUpdateFinished);
+        //Log.LogEventStats(Log.GameEvent.AutoUpdateFinished);
 
         Thread.Sleep(2900);
         Program.RunCleanup();

--- a/Ship_Game/GameScreens/MainMenu/AutoUpdateChecker.cs
+++ b/Ship_Game/GameScreens/MainMenu/AutoUpdateChecker.cs
@@ -111,7 +111,7 @@ public class AutoUpdateChecker : UIElementContainer
 
         void OnAutoUpdateClicked()
         {
-            Log.LogEventStats(Log.GameEvent.AutoUpdateClicked);
+            //Log.LogEventStats(Log.GameEvent.AutoUpdateClicked);
 
             Remove();
             var mb = new MessageBoxScreen(Screen, "This will automatically update to the latest version. Continue?", 10f);

--- a/Ship_Game/GameScreens/NewGame/CreatingNewGameScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/CreatingNewGameScreen.cs
@@ -32,7 +32,7 @@ namespace Ship_Game
 
         public override void LoadContent()
         {
-            Log.LogEventStats(Log.GameEvent.NewGame, P);
+            //Log.LogEventStats(Log.GameEvent.NewGame, P);
 
             ScreenManager.ClearScene();
             LoadingScreenTexture = ResourceManager.LoadRandomLoadingScreen(Generator.Random, TransientContent);

--- a/Ship_Game/Gameplay/SpaceRoad.cs
+++ b/Ship_Game/Gameplay/SpaceRoad.cs
@@ -247,7 +247,7 @@ namespace Ship_Game.Gameplay
             for (int i = 0; i < RoadNodesList.Count; i++)
             {
                 RoadNode node = RoadNodesList[i];
-                if (node.Position.InRadius(buildPos, 100))
+                if (node.Position.InRadius(buildPos, 100f))
                 {
                     SetProjectorAtNode(node, projector);
                     return true;

--- a/Ship_Game/Ships/PlanetCrash.cs
+++ b/Ship_Game/Ships/PlanetCrash.cs
@@ -45,7 +45,7 @@ namespace Ship_Game.Ships
             Owner.Velocity = dir * (Owner.MaxSTLSpeed * 0.8f).LowerBound(200);
             Scale = Owner.Position.Distance(CrashPos) / Distance;
 
-            if (Owner.Position.InRadius(CrashPos, 200))
+            if (Owner.Position.InRadius(CrashPos, 200f))
             {
                 P.TryCrashOn(Owner);
                 Owner.SetReallyDie();

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -264,10 +264,6 @@ namespace Ship_Game.Ships
         public void SetCombatStance(CombatState stance)
         {
             AI.CombatState = stance;
-            if (stance == CombatState.HoldPosition)
-            {
-                AI.OrderAllStop();
-            }
             ShipStatusChanged = true;
         }
 

--- a/Ship_Game/Ships/Ship_Troop.cs
+++ b/Ship_Game/Ships/Ship_Troop.cs
@@ -262,7 +262,7 @@ namespace Ship_Game.Ships
                 return;
 
             TroopUpdateTimer = Universe.P.TurnTimer;
-            if (OurTroops.Count > 0)
+            if (OurTroops.Count > 0 && !Loyalty.WeArePirates)
             {
                 // leave a garrison of 1 if a ship without barracks was boarded
                 int troopThreshold = TroopCapacity + (TroopCapacity > 0 ? 0 : 1);

--- a/Ship_Game/Troops/Troop.cs
+++ b/Ship_Game/Troops/Troop.cs
@@ -253,10 +253,9 @@ namespace Ship_Game
 
         void DrawTexture(SpriteBatch sb, SubTexture tex, Rectangle drawRect, bool flip)
         {
-            Troop t = ResourceManager.GetTroopTemplate(Name);
-            int x_offset = t.idle_x_offset;
-            int y_offset = t.idle_y_offset;
-            int width = Idle ? tex.Width : t.attack_width;
+            int x_offset = idle_x_offset;
+            int y_offset = idle_y_offset;
+            int width = Idle ? tex.Width : attack_width;
 
             float scale = drawRect.Width / 128f;
             drawRect.Width = (int)(width * scale);

--- a/Ship_Game/Troops/Troop.cs
+++ b/Ship_Game/Troops/Troop.cs
@@ -505,7 +505,7 @@ namespace Ship_Game
             PlanetGridSquare tileToLand = PickTileToLand(planet, freeTiles);
             AssignTroopToTile(planet, tileToLand, resetMove);
             // some buildings can injure landing troops
-            if (Loyalty != planet.Owner)
+            if (Loyalty != planet.Owner && !Loyalty.data.IsRebelFaction)
                 DamageTroop(planet.TotalInvadeInjure, planet, tileToLand,  out bool _);
 
             tileToLand.CheckAndTriggerEvent(planet, Loyalty);

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -664,7 +664,7 @@ namespace Ship_Game
             for (int i = 0; i < System.ShipList.Count; ++i)
             {
                 Ship ship = System.ShipList[i];
-                if (ship?.Position.InRadius(Position, 15000) == true
+                if (ship?.Position.InRadius(Position, 15000f) == true
                     && ship.BaseStrength > 10
                     && (!ship.IsTethered || ship.GetTether() == this) // orbitals orbiting another nearby planet
                     && Owner.IsEmpireAttackable(ship.Loyalty))
@@ -865,7 +865,8 @@ namespace Ship_Game
             if (ShieldStrengthMax.AlmostZero() || ShieldStrengthCurrent.AlmostEqual(ShieldStrengthMax))
                 return;
 
-            float maxRechargeRate = SpaceCombatNearPlanet ? ShieldStrengthMax * 0.005f : ShieldStrengthMax * 0.05f;
+            bool threatPresent = ThreatsNearPlanet(System.DangerousForcesPresent(Owner));
+            float maxRechargeRate = threatPresent ? ShieldStrengthMax * 0.005f : ShieldStrengthMax * 0.05f;
             float rechargeRate = (ShieldStrengthCurrent * 100 / ShieldStrengthMax).Clamped(1, maxRechargeRate);
             Owner.AddExoticConsumption(ExoticBonusType.ShieldRecharge, rechargeRate);
             float rechargeExoticBonus = Owner.GetDynamicExoticBonusMuliplier(ExoticBonusType.ShieldRecharge);

--- a/StarDrive.csproj
+++ b/StarDrive.csproj
@@ -1783,10 +1783,10 @@
       <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.Text.Json">
-      <Version>7.0.2</Version>
+      <Version>8.0.4</Version>
     </PackageReference>
     <PackageReference Include="WiX">
-      <Version>3.11.2</Version>
+      <Version>3.14.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Remove Autoupdate sentry logs.
Fix: Evade and Hold ground stance not working as expected.
Fix: Rebels should not get injured when spawning as they dont actually land.
Fix: Rebel empire template not found when viewing rebels combat.
Fix: Planetary Shield recharge in battle and inradius issues
Fix: Dont disengage excess pirate troops after board.