### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/AutomationWindow.cs
+++ b/Ship_Game/AutomationWindow.cs
@@ -30,7 +30,7 @@ namespace Ship_Game
         {
             Screen = screen;
             const int windowWidth = 220;
-            Rect = new Rectangle(ScreenWidth - 15 - windowWidth, 100, windowWidth, 685);
+            Rect = new Rectangle(ScreenWidth - 15 - windowWidth, 89, windowWidth, 710);
             CanEscapeFromScreen = false;
         }
 
@@ -94,6 +94,7 @@ namespace Ship_Game
             rest.AddCheckbox(() => UState.P.SuppressOnBuildNotifications, title: GameText.DisableBuildingAlerts, tooltip: GameText.NormallyWhenYouManuallyAdd);
             rest.AddCheckbox(() => UState.P.DisableInhibitionWarning,     title: GameText.DisableInhibitionAlerts, tooltip: GameText.InhibitionAlertsAreDisplayedWhen);
             rest.AddCheckbox(() => UState.P.DisableVolcanoWarning,        title: GameText.DisableVolcanoAlerts, tooltip: GameText.DisableVolcanoActivationOrDeactivation);
+            rest.AddCheckbox(() => UState.P.DisableCrashSiteWarning,      title: GameText.DisableCrashSiteAlerts, tooltip: GameText.DisableCrashSiteAlertsTip);
             rest.AddCheckbox(() => UState.P.EnableStarvationWarning,      title: GameText.EnableStarvationWarning, tooltip: GameText.EnableStarvationWarningTip);
             rest.AddCheckbox(() => UState.P.PrioitizeProjectors,          title: GameText.PrioritizeProjector, tooltip: GameText.PrioritizeProjectorTip);
 

--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -5577,6 +5577,10 @@ namespace Ship_Game
         EspionageLimitLevel = 6341,
         /// <summary>Left click to increase by 1\nright click to decrease by 1\nWhen limiting Infiltration Level</summary>
         EspionageLimitLevelTip = 6342,
+        /// <summary>Disable Ship Crash Alerts</summary>
+        DisableCrashSiteAlerts = 6343,
+        /// <summary>Disable Ship Crash Alerts</summary>
+        DisableCrashSiteAlertsTip = 6344,
 
 
 

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -2574,7 +2574,7 @@ namespace Ship_Game
         public void RefundCreditsPostRemoval(Building b)
         {
             if (b.IsMilitary)
-                RefundCredits(b.ActualCost(this), 0.5f);
+                RefundCredits(EstimateCreditCost(b.ActualCost(this)), 0.5f);
         }
 
         public void ChargeRushFees(float productionCost, bool immediate)

--- a/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
@@ -903,7 +903,11 @@ namespace Ship_Game
                 TerraTargetFertility   = TerraformTargetFertility();
                 MinEstimatedMaxPop     = P.PotentialMaxPopBillionsFor(P.Owner);
                 TerraMaxPopBillion     = P.PotentialMaxPopBillionsFor(P.Owner, true);
-                UpdateTimer            = 150;
+
+                if (TerraformLevel > 0 && PFacilities.Tabs.Count < 4)
+                    PFacilities.AddTab(GameText.BB_Tech_Terraforming_Name);
+
+                UpdateTimer = 150;
             }
             else
             {

--- a/Ship_Game/GameScreens/ColonyScreen/QueueItem.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/QueueItem.cs
@@ -19,6 +19,7 @@ namespace Ship_Game
         [StarData] public Planet Planet;
         [StarData] public bool isBuilding;
         [StarData] public bool IsMilitary; // Military building
+        [StarData] public bool IsTerraformer; 
         [StarData] public bool isShip;
         [StarData] public bool isOrbital;
         [StarData] public bool isTroop;

--- a/Ship_Game/GameScreens/Universe/ColoniesListItem.cs
+++ b/Ship_Game/GameScreens/Universe/ColoniesListItem.cs
@@ -363,7 +363,7 @@ namespace Ship_Game
             NumShipsInQueue     = P.ConstructionQueue.Filter(q => q.isShip).Length;
             NumBuildingsInQueue = P.ConstructionQueue.Filter(q => q.isBuilding).Length;
             NumTroopsInQueue    = P.ConstructionQueue.Filter(q => q.isTroop).Length;
-            TotalProdNeeded     = (int)(P.TotalProdNeededInQueue() - P.ConstructionQueue.Sum(q => q.ProductionSpent));
+            TotalProdNeeded     = (int)P.TotalProdNeededInQueue();
         }
     }
 }

--- a/Ship_Game/Gameplay/Relationship_trust.cs
+++ b/Ship_Game/Gameplay/Relationship_trust.cs
@@ -65,7 +65,9 @@ namespace Ship_Game.Gameplay
             if (!them.isPlayer && them.data.EconomicPersonality.EconomicPersonality() == eType)
                 trust += baseGain*2;
 
-            return them.isPlayer ? trust /= ((int)us.Universe.P.Difficulty).LowerBound(1) : trust;
+            float trustDifficulty = them.isPlayer ? (-baseGain) * ((int)us.Universe.P.Difficulty) : 0;
+
+            return trust - trustDifficulty;
         }
 
         float BaseEtraitTrustGain(float baseGain, Empire us, Empire them, EconomicPersonalityType eType)

--- a/Ship_Game/StoryAndEvents/Artifact.cs
+++ b/Ship_Game/StoryAndEvents/Artifact.cs
@@ -60,7 +60,7 @@ namespace Ship_Game
                 if (TrySetArtifactEffect(ref bonus, FertilityMod,
                     triggerer.data.Traits, "Fertility Bonus to all Owned Colonies: ",popup))
                 {
-                    triggerer.data.EmpireFertilityBonus += triggeredOutcome.GetArtifact().FertilityMod;
+                    triggerer.data.EmpireFertilityBonus += bonus;
                     foreach (Planet planet in triggerer.GetPlanets())
                     {
                         planet.AddMaxBaseFertility(bonus);

--- a/Ship_Game/StoryAndEvents/NotificationManager.cs
+++ b/Ship_Game/StoryAndEvents/NotificationManager.cs
@@ -551,6 +551,9 @@ namespace Ship_Game
 
         public void AddShipCrashed(Planet p, string message)
         {
+            if (p.Universe.P.DisableCrashSiteWarning)
+                return;
+
             AddNotification(new Notification
             {
                 Pause           = false,
@@ -567,6 +570,9 @@ namespace Ship_Game
         /// </summary>
         public void AddShipRecovered(Planet p, Ship s, string message)
         {
+            if (s == null && p.Universe.P.DisableCrashSiteWarning)
+                return;
+
             var recover = new Notification
             {
                 Pause   = false,

--- a/Ship_Game/Troops/Troop.cs
+++ b/Ship_Game/Troops/Troop.cs
@@ -557,7 +557,7 @@ namespace Ship_Game
         int CombatLandingTileScore(PlanetGridSquare tile, Planet planet)
         {
             int score = 0;
-            Ping ping = new(tile, planet, 1);
+            PlanetGridSquare.Ping ping = new(tile, 1);
             for (int y = ping.Top; y <= ping.Bottom; ++y)
             {
                 for (int x = ping.Left; x <= ping.Right; ++x)
@@ -574,7 +574,7 @@ namespace Ship_Game
         {
             int bestScore = 0;
             targetTile = null;
-            Ping ping = new(tile, planet, ActualRange);
+            PlanetGridSquare.Ping ping = new(tile, ActualRange);
             for (int y = ping.Top; y <= ping.Bottom; ++y)
             {
                 for (int x = ping.Left; x <= ping.Right; ++x)
@@ -590,24 +590,6 @@ namespace Ship_Game
             }
 
             return bestScore > 0;
-        }
-
-        struct Ping
-        {
-            public readonly int Left;
-            public readonly int Right;
-            public readonly int Top;
-            public readonly int Bottom;
-            public readonly int Width;
-
-            public Ping(PlanetGridSquare tile, Planet planet, int pingSize)
-            {
-                Left   = (tile.X - pingSize).LowerBound(0);
-                Right  = (tile.X + pingSize).UpperBound(SolarSystemBody.TileMaxX - 1);
-                Top    = (tile.Y - pingSize).LowerBound(0);
-                Bottom = (tile.Y + pingSize).UpperBound(SolarSystemBody.TileMaxY - 1);
-                Width  = SolarSystemBody.TileMaxX;
-            }
         }
 
         void RemoveTroopFromHostShip()

--- a/Ship_Game/Universe/SolarBodies/ColonyBlueprints.cs
+++ b/Ship_Game/Universe/SolarBodies/ColonyBlueprints.cs
@@ -27,10 +27,12 @@ namespace Ship_Game.Universe.SolarBodies
         bool Completed => PercentCompleted == 100;
 
         public bool IsAchievableCompleted => PercentAchievable == 0 || PercentAchievable == PercentCompleted;
-
+        bool IsHalfAchievableCompleted => PercentAchievable == 0 || PercentAchievable >= PercentCompleted/2;
 
         public bool IsRequired(Building b) => PlannedBuildings.Contains(b.Name);
         public bool IsNotRequired(Building b) => !IsRequired(b);
+
+        public bool OkToBuildTerraformers => PlannedBuildings.Count < P.TileArea / 2 ? IsAchievableCompleted : IsHalfAchievableCompleted;
 
         [StarDataConstructor]
         public ColonyBlueprints() { }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
@@ -461,7 +461,7 @@ namespace Ship_Game
                 Construction.Enqueue(best);
         }
         
-        bool TryScrapMilitaryBuilding()
+        void TryScrapMilitaryBuilding()
         {
             Building weakest = null;
             if (HasBlueprints)
@@ -475,12 +475,7 @@ namespace Ship_Game
                                                        b => b.CostEffectiveness);
 
             if (weakest != null)
-            {
                 ScrapBuilding(weakest);
-                return true;
-            }
-
-            return false;
         }
 
         public void AddTroop(Troop troop, PlanetGridSquare tile)

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
@@ -461,7 +461,7 @@ namespace Ship_Game
                 Construction.Enqueue(best);
         }
         
-        void TryScrapMilitaryBuilding()
+        bool TryScrapMilitaryBuilding()
         {
             Building weakest = null;
             if (HasBlueprints)
@@ -475,7 +475,12 @@ namespace Ship_Game
                                                        b => b.CostEffectiveness);
 
             if (weakest != null)
+            {
                 ScrapBuilding(weakest);
+                return true;
+            }
+
+            return false;
         }
 
         public void AddTroop(Troop troop, PlanetGridSquare tile)

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
@@ -66,8 +66,8 @@ public partial class Planet
         return TilesList.All(tile => tile.Habitable);
     }
         
-    public bool MilitaryBuildingInTheWorks => ConstructionQueue.Any(b => b.isBuilding && b.IsMilitary);
-    public bool CivilianBuildingInTheWorks => ConstructionQueue.Any(b => b.IsCivilianBuilding);
+    public bool MilitaryBuildingInTheWorks => ConstructionQueue.Any(qi => qi.IsMilitary);
+    public bool CivilianBuildingInTheWorks => ConstructionQueue.Any(qi => qi.IsCivilianBuilding && !qi.IsTerraformer);
 
     public bool CanBuildInfantry         => HasBuilding(b => b.AllowInfantry);
     public bool TroopsInTheWorks         => ConstructionQueue.Any(t => t.isTroop);

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
@@ -51,7 +51,7 @@ namespace Ship_Game
         void BuildAndScrapCivilianBuildings(float budget)
         {
             UpdateGovernorPriorities();
-            bool overBudget = budget < -0.0499f;
+            bool overBudget = budget < -0.1f;
             if (overBudget || Blueprints?.ShouldScrapNonRequiredBuilding() == true)
             {
                 // We must scrap something to bring us above of our debt tolerance
@@ -724,15 +724,11 @@ namespace Ship_Game
                         PlanetGridSquare tile = PickTileForTerraformer(unHabitableTiles);
                         Construction.Enqueue(terraformer, tile);
                     }
-                    else if (!Construction.Enqueue(terraformer))
+                    else if (TryScrapBuilding(true, scrapZeroMaintenance: true, terraformerOverride: true))
                     {
                         // If could not add a terraformer anywhere due to planet being full
                         // try to scrap a building and then retry construction
-                        if (CType != ColonyType.Military && TryScrapMilitaryBuilding()
-                            || TryScrapBuilding(true, scrapZeroMaintenance: true, terraformerOverride: true))
-                        {
-                            Construction.Enqueue(terraformer);
-                        }
+                        Construction.Enqueue(terraformer);
                     }
                 }
             }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
@@ -425,11 +425,11 @@ namespace Ship_Game
             }
         }
 
-        void RemoveTerraformers(bool removeOne = false)
+        void RemoveTerraformers(bool removeOne = false, bool fullCompletion = false)
         {
             foreach (PlanetGridSquare tile in TilesList)
             {
-                if (tile.Building?.PlusTerraformPoints > 0)
+                if (tile.BuildingOnTile && (tile.Building.IsTerraformer || fullCompletion && tile.Building.IsEventTerraformer))
                 {
                     ScrapBuilding(tile.Building);
                     if (removeOne)
@@ -476,7 +476,7 @@ namespace Ship_Game
             if (BasePopPerTile <= 200)
                 BasePopPerTile = (BasePopPerTile * 2).LowerBound(200);
             UpdateMaxPopulation();
-            RemoveTerraformers();
+            RemoveTerraformers(fullCompletion: true);
         }
 
         private void ReCalculateHabitableChances(RandomBase random) // FB - We might need it for planet degrade

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
@@ -286,7 +286,8 @@ namespace Ship_Game
 
         public bool HasTilesToTerraform     => TilesList.Any(t => t.CanTerraform);
         public bool BioSpheresToTerraform   => TilesList.Any(t => t.BioCanTerraform);
-        public int TerraformerLimit         => Owner != null && Owner.data.Traits.TerraformingLevel < 2 ? 2 : TilesList.Count(t => t.CanTerraform)/2 + 2;
+        public int TerraformerLimit         => Owner != null 
+            && Owner.data.Traits.TerraformingLevel < 2 ? 2 : (TilesList.Count(t => t.CanTerraform)/2 + 2).UpperBound(TileArea/5);
 
         public bool HasTerrainToTerraform => HasBuilding(b => b.CanBeTerraformed);
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
@@ -286,7 +286,7 @@ namespace Ship_Game
 
         public bool HasTilesToTerraform     => TilesList.Any(t => t.CanTerraform);
         public bool BioSpheresToTerraform   => TilesList.Any(t => t.BioCanTerraform);
-        public int TerraformerLimit         => TilesList.Count(t => t.CanTerraform)/2 + 2;
+        public int TerraformerLimit         => Owner != null && Owner.data.Traits.TerraformingLevel < 2 ? 2 : TilesList.Count(t => t.CanTerraform)/2 + 2;
 
         public bool HasTerrainToTerraform => HasBuilding(b => b.CanBeTerraformed);
 

--- a/Ship_Game/Universe/SolarBodies/PlanetGridSquare.cs
+++ b/Ship_Game/Universe/SolarBodies/PlanetGridSquare.cs
@@ -378,6 +378,24 @@ namespace Ship_Game
             }
             return p;
         }
+
+        public struct Ping
+        {
+            public readonly int Left;
+            public readonly int Right;
+            public readonly int Top;
+            public readonly int Bottom;
+            public readonly int Width;
+
+            public Ping(PlanetGridSquare tile, int pingSize)
+            {
+                Left   = (tile.X - pingSize).LowerBound(0);
+                Right  = (tile.X + pingSize).UpperBound(SolarSystemBody.TileMaxX - 1);
+                Top    = (tile.Y - pingSize).LowerBound(0);
+                Bottom = (tile.Y + pingSize).UpperBound(SolarSystemBody.TileMaxY - 1);
+                Width  = SolarSystemBody.TileMaxX;
+            }
+        }
     }
 
     public enum TileDirection

--- a/Ship_Game/Universe/SolarBodies/SBProduction.cs
+++ b/Ship_Game/Universe/SolarBodies/SBProduction.cs
@@ -433,7 +433,7 @@ namespace Ship_Game.Universe.SolarBodies
                 }
                 else
                 {
-                    if (P.Owner.AutoBuildTerraformers && P.Owner.data.Traits.TerraformingLevel > 0 )
+                    if (P.Owner.AutoBuildTerraformers && P.Owner.data.Traits.TerraformingLevel > 0 && !item.IsPlayerAdded)
                         DePrioritizeTerraformer();
 
                     if (item.Rush && item.QType == QueueItemType.OrbitalUrgent

--- a/Ship_Game/Universe/SolarBodies/SBProduction.cs
+++ b/Ship_Game/Universe/SolarBodies/SBProduction.cs
@@ -141,8 +141,8 @@ namespace Ship_Game.Universe.SolarBodies
         {
             bool ok = false;
 
-            if (q.isBuilding) ok = OnBuildingComplete(q);
-            else if (q.isShip) ok = OnShipComplete(q);
+            if (q.isBuilding)   ok = OnBuildingComplete(q);
+            else if (q.isShip)  ok = OnShipComplete(q);
             else if (q.isTroop) ok = TrySpawnTroop(q);
 
             Finish(q, success: ok);
@@ -269,17 +269,15 @@ namespace Ship_Game.Universe.SolarBodies
         //         FALSE if `where` is occupied or if there is no free random tiles
         public bool Enqueue(Building b, PlanetGridSquare where = null, bool playerAdded = false)
         {
-            if (b.Unique || b.BuildOnlyOnce)
-            {
-                if (P.BuildingBuiltOrQueued(b))
-                    return false; // unique building already built
-            }
+            if ((b.Unique || b.BuildOnlyOnce) && P.BuildingBuiltOrQueued(b))
+                return false; // unique building already built
 
             var qi = new QueueItem(P)
             {
                 IsPlayerAdded   = playerAdded,
                 isBuilding      = true,
                 IsMilitary      = b.IsMilitary,
+                IsTerraformer   = b.IsTerraformer,
                 Building        = b,
                 pgs             = where,
                 Cost            = b.ActualCost(P.Owner),
@@ -433,11 +431,17 @@ namespace Ship_Game.Universe.SolarBodies
                     int totalFreighters = Owner.TotalFreighters;
                     ConstructionQueue.Sort(q => q.GetAndUpdatePriorityForAI(P, totalFreighters));
                 }
-                else if (item.Rush && item.QType == QueueItemType.OrbitalUrgent 
-                    || P.Universe.P.PrioitizeProjectors && item.QType == QueueItemType.RoadNode)
+                else
                 {
-                    // prioritize projector bridges for the player (or any projector if flag is set).
-                    MoveTo(0, Count - 1);
+                    if (P.Owner.AutoBuildTerraformers && P.Owner.data.Traits.TerraformingLevel > 0 )
+                        DePrioritizeTerraformer();
+
+                    if (item.Rush && item.QType == QueueItemType.OrbitalUrgent
+                        || P.Universe.P.PrioitizeProjectors && item.QType == QueueItemType.RoadNode)
+                    {
+                        // prioritize projector bridges for the player (or any projector if flag is set).
+                        MoveTo(0, Count - 1);
+                    }
                 }
             }
         }
@@ -512,6 +516,23 @@ namespace Ship_Game.Universe.SolarBodies
                     && q.Goal.BuildPosition == buildPos)
                 {
                     MoveTo(0, i);
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Relevant for player who is using Governor, since there is no prioritization ofr buildings
+        /// but we need to prefer buildings which are not terraformers.
+        /// </summary>
+        public void DePrioritizeTerraformer()
+        {
+            for (int i = 0; i < ConstructionQueue.Count; ++i)
+            {
+                QueueItem q = ConstructionQueue[i];
+                if (q.IsTerraformer)
+                {
+                    MoveTo(Count-1, i);
                     break;
                 }
             }

--- a/Ship_Game/Universe/UniverseParams.cs
+++ b/Ship_Game/Universe/UniverseParams.cs
@@ -71,6 +71,7 @@ public class UniverseParams
     [StarData] public bool ShipListFilterNotInFleets;
     [StarData] public bool CordrazinePlanetCaptured;
     [StarData] public bool DisableVolcanoWarning;
+    [StarData] public bool DisableCrashSiteWarning;
     [StarData] public bool PrioitizeProjectors;
     [StarData(DefaultValue=true)] public bool ShowAllDesigns = true;
     [StarData] public bool FilterOldModules;

--- a/UnitTests/Serialization/BinarySerializerTests.cs
+++ b/UnitTests/Serialization/BinarySerializerTests.cs
@@ -1124,6 +1124,7 @@ namespace UnitTests.Serialization
             AssertEqual(instance.ShipListFilterNotInFleets, result.ShipListFilterNotInFleets);
             AssertEqual(instance.CordrazinePlanetCaptured, result.CordrazinePlanetCaptured);
             AssertEqual(instance.DisableVolcanoWarning, result.DisableVolcanoWarning);
+            AssertEqual(instance.DisableCrashSiteWarning, result.DisableCrashSiteWarning);
             AssertEqual(instance.ShowAllDesigns, result.ShowAllDesigns);
             AssertEqual(instance.FilterOldModules, result.FilterOldModules);
             AssertEqual(instance.DisableRemnantStory, result.DisableRemnantStory);

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -15446,6 +15446,12 @@ EspionageLimitLevel:
 EspionageLevelLimitTip:
  Id: 6342
  ENG: "Left click to increase by 1\nright click to decrease by 1\nWhen limiting Infiltration Level, we progress up to the level limit specified. If our Infiltration Level is above the limit level, all relevant operations and passive effects will be paused, and if our infiltration level is discovered, they will only see our limited level."                 
+DisableCrashSiteAlerts:
+ Id: 6343
+ ENG: "Disable Ship Crash Alerts"                 
+DisableCrashSiteAlertsTip:
+ Id: 6344
+ ENG: "Disable all ship crash on planet alreats. Recovered ship crash site notifications will be sent only if an actual ship was recovered."                  
 IndicatesTheChanceOfEcm:
  Id: 7001
  ENG: "Indicates the % chance of ECM disruption against incoming guided weapons, before the weapon's ECM resistance is deducted. Successful ECM disruption jams targeting and prevents the munition from hitting."


### PR DESCRIPTION
Fix: Terraformers Limit is set to 2 if Terraforming level is 1. 
Fix: Terraformers upper limit is tile area (default 35) / 5.
Fix:  Try not to build terraformers next to volcanos if possible.
Fix: Allow Governor to build buildings even if there is a Terraformer in queue.
Fix: Deprioritize terraformers for non blueprints player governors and AI.
Fix: In case a planet has blueprints - do not build terraformers until completion has reached 50% (if the plan size is over 50% of tile area) or reached 100% if plan is less than 50% of tile area)
Fix: Update Colony Screen Terraform tab on the fly if terraforming was research when the tab was open.
Fix: Artifact fertility mod ignored spiritual or cynical trait for future colonization.
Fix: Empire management screen - production left for construction queue was wrong.
Fix: Do not delete event terraformers when removing terraformers unless terraform process is fully completed.
Fix: When scrapping military buildings, the credits refund was based on production cost instead of credit costs.
Notifications: Added an option to disable ships planet crash events.
Balance: Trust vs player
@gkapulis 