### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/AI/EmpireAI/ShipBuilder.cs
+++ b/Ship_Game/AI/EmpireAI/ShipBuilder.cs
@@ -273,7 +273,7 @@ namespace Ship_Game.AI
             float cargo    = ShipStats.GetCargoSpace(s.BaseCargoSpace, s);
             float turnRate = ShipStats.GetTurnRadsPerSec(s).ToDegrees();
             float fastVsBigWeight = fastVsBig * 10;
-            float costWeight     = s.GetCost(empire) * 0.2f * empire.Universe.ProductionPace* empire.Universe.ProductionPace;
+            float costWeight     = s.GetCost(empire) * empire.Universe.ProductionPace * empire.Universe.NumPirateFactions;
             float movementWeight = (maxKFTL + maxDSTL + turnRate) * fastVsBigWeight;
             float cargoWeight    = cargo * (10 - fastVsBigWeight);
             float score          = movementWeight + cargoWeight - costWeight;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
@@ -389,10 +389,9 @@ public partial class Planet
     void UpdatePlanetStatsFromPlacedBuilding(Building b)
     {
         HasSpacePort |= b.IsSpacePort || b.AllowShipBuilding;
-
         // this is automatically unset
-        HasLimitedResourceBuilding |= (b.ProdCache > 0 && b.PlusProdPerColonist > 0)
-                                   || (b.FoodCache > 0 && b.PlusFlatFoodAmount > 0);
+        HasLimitedResourceBuilding |= (b.ProdCache > 0 && (b.PlusProdPerColonist > 0 || b.PlusFlatProductionAmount > 0 || b.PlusProdPerRichness > 0))
+                                   || (b.FoodCache > 0 && (b.PlusFlatFoodAmount > 0 || b.PlusFoodPerColonist > 0));
 
         UpdatePlanetStatsByRecalculation();
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
@@ -217,15 +217,15 @@ namespace Ship_Game
 
         void CalcPopulationPriorities()
         {
-            float eatableRatio = IsCybernetic ? Storage.ProdRatio : Storage.FoodRatio;
-            float popGrowth    = (10 - PopulationRatio * 10).LowerBound(0);
-            popGrowth   *= eatableRatio;
+            float empirePopRatio = Owner.TotalPopBillion / Owner.MaxPopBillion;
+            float popGrowth = 20 - PopulationRatio*10 - empirePopRatio*10;
             float popCap = 0;
+
             if (FreeHabitableTiles > 0 && PopulationRatio > 0.5f)
                 popCap = (PopulationRatio - 0.5f) * 2;
 
-            popGrowth    = ApplyGovernorBonus(popGrowth, 1f, 1f, 1f, 1f, 1f);
-            popCap       = ApplyGovernorBonus(popCap, 1f, 1f, 1f, 1f, 1f);
+            popGrowth = ApplyGovernorBonus(popGrowth, 1.5f, 1f, 1f, 1.5f, 1f);
+            popCap    = ApplyGovernorBonus(popCap, 1.5f, 1f, 1f, 1f, 1f);
             Priorities[ColonyPriority.PopGrowth] = popGrowth;
             Priorities[ColonyPriority.PopCap]    = popCap;
         }
@@ -577,7 +577,7 @@ namespace Ship_Game
             score += EvalTraits(Priorities[ColonyPriority.FoodPerCol],      b.PlusFoodPerColonist * 3);
             score += EvalTraits(Priorities[ColonyPriority.ProdFlat],        b.PlusFlatProductionAmount * 2);
             score += EvalTraits(Priorities[ColonyPriority.ProdPerCol],      b.PlusProdPerColonist * 2);
-            score += EvalTraits(Priorities[ColonyPriority.ProdPerRichness], b.PlusProdPerRichness);
+            score += EvalTraits(Priorities[ColonyPriority.ProdPerRichness], b.PlusProdPerRichness * 3);
             score += EvalTraits(Priorities[ColonyPriority.ProdPerRichness], b.IncreaseRichness * 50);
             score += EvalTraits(Priorities[ColonyPriority.PopGrowth],       b.PlusFlatPopulation / 10);
             score += EvalTraits(Priorities[ColonyPriority.PopCap],          b.MaxPopIncrease / 200);

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
@@ -721,7 +721,7 @@ namespace Ship_Game
                     var freeTiles = TilesList.Filter(t => t.CanEnqueueBuildingHere(terraformer));
                     if (freeTiles.Length > 0) // fall back to free tiles
                     {
-                        PlanetGridSquare tile = PickTileForTerraformer(unHabitableTiles);
+                        PlanetGridSquare tile = PickTileForTerraformer(freeTiles);
                         Construction.Enqueue(terraformer, tile);
                     }
                     else if (TryScrapBuilding(true, scrapZeroMaintenance: true, terraformerOverride: true))
@@ -734,18 +734,18 @@ namespace Ship_Game
             }
         }
 
-        PlanetGridSquare PickTileForTerraformer(PlanetGridSquare[] unHabitableTiles)
+        PlanetGridSquare PickTileForTerraformer(PlanetGridSquare[] tileList)
         {
             var potentialTiles = new Array<PlanetGridSquare>();
-            for (int i = 0; i < unHabitableTiles.Length; ++i)
+            for (int i = 0; i < tileList.Length; ++i)
             {
-                PlanetGridSquare tile = unHabitableTiles[i];
+                PlanetGridSquare tile = tileList[i];
                 if (NoVolcanosAround(tile))
                     potentialTiles.Add(tile);
 
             }
 
-            return Random.Item(potentialTiles.Count > 0 ? potentialTiles : unHabitableTiles.ToArrayList());
+            return Random.Item(potentialTiles.Count > 0 ? potentialTiles : tileList.ToArrayList());
 
             bool NoVolcanosAround(PlanetGridSquare tile)
             {

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.UpdateGame.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.UpdateGame.cs
@@ -158,7 +158,6 @@ namespace Ship_Game
                     }
 
                     AutoAdjustSimulationFrameRate();
-
                     if (GlobalStats.RestrictAIPlayerInteraction)
                     {
                         if (TurnTimePerf.MeasuredSamples > 0 && TurnTimePerf.AvgTime * UState.GameSpeed < 0.05f)
@@ -310,6 +309,7 @@ namespace Ship_Game
                     }
                 }
 
+                UState.UpdateNumPirateFactions();
                 if (UState.Objects.EnableParallelUpdate)
                     Parallel.For(wereUpdated.Count, PostEmpireUpdate, UState.Objects.MaxTaskCores);
                 else

--- a/Ship_Game/Universe/UniverseState_Empires.cs
+++ b/Ship_Game/Universe/UniverseState_Empires.cs
@@ -5,6 +5,7 @@ using Microsoft.Xna.Framework.Graphics;
 using SDGraphics;
 using SDUtils;
 using Ship_Game.AI;
+using Ship_Game.Data.Serialization;
 using Ship_Game.Gameplay;
 
 namespace Ship_Game.Universe;
@@ -16,6 +17,8 @@ namespace Ship_Game.Universe;
 
 public partial class UniverseState
 {
+    [StarData] public int NumPirateFactions { get; private set; }
+
     public IReadOnlyList<Empire> Empires => EmpireList;
     public int NumEmpires => EmpireList.Count;
 
@@ -146,6 +149,11 @@ public partial class UniverseState
         }
 
         return e;
+    }
+
+    public void UpdateNumPirateFactions()
+    {
+        NumPirateFactions = Factions.Count(f => f.WeArePirates && !f.IsDefeated);
     }
 
     void ClearEmpires()

--- a/game/Content/Hulls/Remnant/AncientFrigate.hull
+++ b/game/Content/Hulls/Remnant/AncientFrigate.hull
@@ -12,9 +12,8 @@ Animated=false
 IsShipyard=false
 IsOrbitalDefense=false
 #Thruster PosX,PosY,PosZ,Scale
-Thruster=14,60,0,27
-Thruster=3,59,0,27
-Thruster=-10,60,0,27
+Thruster=14,60,0,80
+Thruster=-10,60,0,80
 Slots
 ___|___|___|___|___|___|O  |O  |___|___|___|___|___|___
 ___|___|___|___|___|O  |O  |O  |O  |___|___|___|___|___


### PR DESCRIPTION
Fix: Some resource caches were not decreasing. 
Fix: Freighter auto selection logic to consider number of pirate faction for cost weight.
Fix: Ancient Frigate hull thrusters.
Fix: Improve Governor eval logic for ProdPerRichness and Population Growth
Fix: Crash in Pick Terraformers