### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/AI/EmpireAI/EspionageManager.cs
+++ b/Ship_Game/AI/EmpireAI/EspionageManager.cs
@@ -1,11 +1,7 @@
 ﻿using Ship_Game.Gameplay;
-using System.IO;
 using SDGraphics;
 using SDUtils;
-using Ship_Game.GameScreens.Espionage;
 using Ship_Game.Data.Serialization;
-using System.Collections.Generic;
-using System.Reflection;
 using System;
 
 
@@ -51,16 +47,16 @@ namespace Ship_Game.AI
         void SetupDefenseWeight()
         {
             int numWars = Owner.AtWarCount;
-            int numAllies = Owner.Universe.ActiveMajorEmpires.Filter(e => e != Owner && e.IsAlliedWith(Owner)).Length;
-            int total = numWars + numAllies;
-            int weight = (total * 10).Clamped(10, Empire.MaxEspionageDefenseWeight);
+            int numAllies = Owner.Universe.GetAllies(Owner).Count;
+            int total = numWars + numAllies + (Owner.IsAtWarWith(Owner.Universe.Player) ? 20 : 0);
+            int weight = (total * 10).LowerBound(10);
             Owner.SetEspionageDefenseWeight(weight);    
         }
 
-        void SetupInfiltrationWeights(Relationship relations, Espionage espionage, Empire them)
+        void SetupInfiltrationWeights(Relationship relations, Espionage espionage)
         {
             if (relations.AtWar || relations.PreparingForWar) espionage.SetWeight(10);
-            else if (relations.Treaty_Alliance)               espionage.SetWeight(3);
+            else if (relations.Treaty_Alliance)               espionage.SetWeight(2);
             else if (relations.TotalAnger > 50)               espionage.SetWeight(7);
             else                                              espionage.SetWeight(5);
         }
@@ -82,7 +78,7 @@ namespace Ship_Game.AI
                 Espionage espionage = relations.Espionage;
                 if (relations.Known)
                 {
-                    SetupInfiltrationWeights(relations, espionage, empire);
+                    SetupInfiltrationWeights(relations, espionage);
                     if (espionage.Level > 0)
                     {
                         SetEspionageLimitLevel(relations, espionage);

--- a/Ship_Game/AI/ExpansionAI/ExpansionPlanner.cs
+++ b/Ship_Game/AI/ExpansionAI/ExpansionPlanner.cs
@@ -203,7 +203,12 @@ namespace Ship_Game.AI.ExpansionAI
 
         bool CanBeColonized(Planet p)
         {
-            return p.IsExploredBy(Owner) && p.Habitable && (p.Owner == null || p.Owner.IsFaction);
+            return p.IsExploredBy(Owner) 
+                   && p.Habitable 
+                   && (p.Owner == null 
+                       || p.Owner.IsFaction && (p.Owner.ParentEmpire == null
+                                                || p.Owner.ParentEmpire == Owner
+                                                || Owner.IsAtWarWith(p.Owner.ParentEmpire)));
         }
 
         Array<Planet> GetPotentialPlanetsNonLocal(SolarSystem[] systems)

--- a/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
@@ -5,6 +5,7 @@ using Ship_Game.ExtensionMethods;
 using Ship_Game.Gameplay;
 using Ship_Game.Ships;
 using Ship_Game.Ships.AI;
+using Ship_Game.Ships.Components;
 using static Ship_Game.AI.ShipAI;
 using Vector2 = SDGraphics.Vector2;
 
@@ -212,8 +213,16 @@ namespace Ship_Game.AI
             Target = toIntercept;
         }
 
-        public void OrderLandAllTroops(Planet target, bool clearOrders)
+        public bool OrderLandAllTroops(Planet target, bool clearOrders, Vector2 cursorPos = default)
         {
+            Empire us = Owner.Loyalty;
+            if (us.InvasionBlockedNotEnoughWarmup(target.Owner))
+            {
+                if (cursorPos != default)
+                    ToolTip.CreateFloatingText(GameText.InvasionblockedWarmup, "", cursorPos, 3);
+                return false;
+            }
+
             if (clearOrders)
                 ResetPriorityOrderWithClear();
 
@@ -223,6 +232,8 @@ namespace Ship_Game.AI
                 // This deals also with single Troop Ships / Assault Shuttles
                 AddPlanetGoal(Plan.LandTroop, target, AIState.AssaultPlanet);
             }
+
+            return true;
         }
 
         public void OrderMoveTo(Vector2 position, Vector2 finalDir, MoveOrder order = MoveOrder.Regular)

--- a/Ship_Game/AI/Tasks/MilitaryTask_Requistions.cs
+++ b/Ship_Game/AI/Tasks/MilitaryTask_Requistions.cs
@@ -403,7 +403,7 @@ namespace Ship_Game.AI.Tasks
                 case TaskType.DefendClaim:          return "Scout Fleet";
                 case TaskType.ClearAreaOfEnemies:   return "Defensive Fleet";
                 case TaskType.InhibitorInvestigate: return "Investigation Fleet";
-                case TaskType.StageFleet when TargetEmpire.isPlayer && Owner.Universe.P.Difficulty > GameDifficulty.Normal: return "Defensive Fleet";
+                case TaskType.StageFleet when TargetEmpire.isPlayer && Owner.Universe.P.Difficulty > GameDifficulty.Normal: return "Investigation Fleet";
                 case TaskType.StageFleet:           return "Stage Fleet";
             }
         }

--- a/Ship_Game/Commands/Goals/MarkForColonization.cs
+++ b/Ship_Game/Commands/Goals/MarkForColonization.cs
@@ -84,7 +84,7 @@ namespace Ship_Game.Commands.Goals
 
                 empireAi.AddPendingTask(Task);
             }
-            else if (!Owner.AnyActiveFleetsTargetingSystem(TargetPlanet.System) && Owner.Universe.P.Difficulty > GameDifficulty.Normal)
+            else if (Owner.Universe.P.Difficulty > GameDifficulty.Normal && !Owner.AnyActiveFleetsTargetingSystem(TargetPlanet.System))
             {
                 // This task is independent and not related to this goal Task var
                 Owner.AI.AddPendingTask(MilitaryTask.CreateGuardTask(Owner, TargetPlanet));

--- a/Ship_Game/Commands/Goals/MarkForColonization.cs
+++ b/Ship_Game/Commands/Goals/MarkForColonization.cs
@@ -84,7 +84,7 @@ namespace Ship_Game.Commands.Goals
 
                 empireAi.AddPendingTask(Task);
             }
-            else if (!Owner.AnyActiveFleetsTargetingSystem(TargetPlanet.System))
+            else if (!Owner.AnyActiveFleetsTargetingSystem(TargetPlanet.System) && Owner.Universe.P.Difficulty > GameDifficulty.Normal)
             {
                 // This task is independent and not related to this goal Task var
                 Owner.AI.AddPendingTask(MilitaryTask.CreateGuardTask(Owner, TargetPlanet));
@@ -283,8 +283,11 @@ namespace Ship_Game.Commands.Goals
 
         bool PlanetCanBeColonized()
         {
-            if (!Owner.isPlayer && PlanetRanker.IsColonizeBlockedByMorals(TargetPlanet.System, Owner))
+            if (!Owner.isPlayer && (PlanetRanker.IsColonizeBlockedByMorals(TargetPlanet.System, Owner)
+                                   || TargetPlanet.Owner?.ParentEmpire != null && !Owner.IsAtWarWith(TargetPlanet.Owner.ParentEmpire)))
+            {
                 return false;
+            }
 
             if (CheckNewOwnersInSystem
                 && TargetPlanet.System.OwnerList.Count > 0

--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -5585,7 +5585,8 @@ namespace Ship_Game
         UpriseAssetsTheyLost = 6345,
         /// <summary>All Military Buildings</summary>
         UpriseAllMilitaryBuildings = 6346,
-
+        /// <summary>Not enough time passed since war started</summary>
+        InvasionblockedWarmup = 6347,
 
 
 

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -1563,6 +1563,15 @@ namespace Ship_Game
             return troopShip != null;
         }
 
+        public bool InvasionBlockedNotEnoughWarmup(Empire target)
+        {
+            if (!isPlayer || target == null || target == this) 
+                return false;
+
+            Relationship relations = GetRelations(target);
+            return relations.AtWar && relations.TurnsAtWar < 10; 
+        }
+
         public int GetSpyDefense()
         {
             if (NewEspionageEnabled)

--- a/Ship_Game/EmpireExoticBonuses.cs
+++ b/Ship_Game/EmpireExoticBonuses.cs
@@ -72,12 +72,6 @@ namespace Ship_Game
                 default: break;
             }
 
-            if (float.IsNaN(consumption)) // FB: remove by Feb 24 - i think i solved it
-            {
-                Log.Error($"consumption was nan for {Owner.Name}, {Good.ExoticBonusType}!");
-                return;
-            }
-
             Consumption = consumption * Good.ConsumptionMultiplier;
         }
 

--- a/Ship_Game/EmpirePersonalityModifiers.cs
+++ b/Ship_Game/EmpirePersonalityModifiers.cs
@@ -104,7 +104,7 @@ namespace Ship_Game
                     ImperialistWarPlanetsToTakeMult = 0.6f;
                     DistanceToDefendAllyThreshold   = 0.8f;
                     SpyDamageRelationsMultiplier = 1;
-                    TurnsAbove95FederationNeeded = 350;
+                    TurnsAbove95FederationNeeded = 250;
                     TurnsAbove95AllianceTreshold = 300;
                     AllianceValueAlliedWithEnemy = 0.4f;
                     WantedAgentMissionMultiplier = 0.115f;
@@ -119,7 +119,7 @@ namespace Ship_Game
                     WantedMoleCovreage    = 0.25f;
                     DefenseTaskWeight     = 1.2f;
                     FleetStrMultiplier    = 1.15f;
-                    FederationPopRatioWar = 3.5f;
+                    FederationPopRatioWar = 2.5f;
                     PopRatioBeforeMerge   = 0.15f;
                     DoomFleetThreshold    = 1.5f;
                     AssaultBomberRatio    = 0.75f;
@@ -147,7 +147,7 @@ namespace Ship_Game
                     ImperialistWarPlanetsToTakeMult = 0.8f;
                     DistanceToDefendAllyThreshold   = 0.6f;
                     SpyDamageRelationsMultiplier = 1.25f;
-                    TurnsAbove95FederationNeeded = 420;
+                    TurnsAbove95FederationNeeded = 320;
                     TurnsAbove95AllianceTreshold = 250;
                     AllianceValueAlliedWithEnemy = 0.5f;
                     WantedAgentMissionMultiplier = 0.115f;
@@ -162,7 +162,7 @@ namespace Ship_Game
                     WantedMoleCovreage    = 0.2f;
                     DefenseTaskWeight     = 1;
                     FleetStrMultiplier    = 1.1f;
-                    FederationPopRatioWar = 3.2f;
+                    FederationPopRatioWar = 2.2f;
                     PopRatioBeforeMerge   = 0.125f;
                     DoomFleetThreshold    = 1f;
                     AssaultBomberRatio    = 1;
@@ -190,7 +190,7 @@ namespace Ship_Game
                     ImperialistWarPlanetsToTakeMult = 0.5f;
                     DistanceToDefendAllyThreshold   = 0.7f;
                     SpyDamageRelationsMultiplier = 2.5f;
-                    TurnsAbove95FederationNeeded = 600;
+                    TurnsAbove95FederationNeeded = 400;
                     TurnsAbove95AllianceTreshold = 200;
                     AllianceValueAlliedWithEnemy = 0.5f;
                     WantedAgentMissionMultiplier = 0.13f;
@@ -205,7 +205,7 @@ namespace Ship_Game
                     WantedMoleCovreage    = 0.15f;
                     DefenseTaskWeight     = 1.2f;
                     FleetStrMultiplier    = 1.05f;
-                    FederationPopRatioWar = 4f;
+                    FederationPopRatioWar = 3f;
                     PopRatioBeforeMerge   = 0.03f;
                     DoomFleetThreshold    = 1.75f;
                     AllyCallToWarRatio    = 1.1f;
@@ -235,7 +235,7 @@ namespace Ship_Game
                     ImperialistWarPlanetsToTakeMult = 0.7f;
                     DistanceToDefendAllyThreshold   = 0.9f;
                     SpyDamageRelationsMultiplier = 0.5f;
-                    TurnsAbove95FederationNeeded = 320;
+                    TurnsAbove95FederationNeeded = 220;
                     TurnsAbove95AllianceTreshold = 150;
                     AllianceValueAlliedWithEnemy = 0.6f;
                     WantedAgentMissionMultiplier = 0.13f;
@@ -250,7 +250,7 @@ namespace Ship_Game
                     WantedMoleCovreage    = 0.5f;
                     DefenseTaskWeight     = 1.3f;
                     FleetStrMultiplier    = 0.95f;
-                    FederationPopRatioWar = 3f;
+                    FederationPopRatioWar = 2f;
                     PopRatioBeforeMerge   = 0.2f;
                     DoomFleetThreshold    = 2;
                     AssaultBomberRatio    = 0.8f;
@@ -278,7 +278,7 @@ namespace Ship_Game
                     ImperialistWarPlanetsToTakeMult = 0.5f;
                     DistanceToDefendAllyThreshold   = 1.25f;
                     SpyDamageRelationsMultiplier = 2f;
-                    TurnsAbove95FederationNeeded = 250;
+                    TurnsAbove95FederationNeeded = 200;
                     TurnsAbove95AllianceTreshold = 125;
                     AllianceValueAlliedWithEnemy = 0.5f;
                     WantedAgentMissionMultiplier = 0.1f;
@@ -293,7 +293,7 @@ namespace Ship_Game
                     WantedMoleCovreage    = 0.15f;
                     DefenseTaskWeight     = 1.5f;
                     FleetStrMultiplier    = 1f;
-                    FederationPopRatioWar = 2.5f;
+                    FederationPopRatioWar = 1.5f;
                     PopRatioBeforeMerge   = 0.15f;
                     HullTechMultiplier    = 0.9f;
                     DoomFleetThreshold    = 2.5f;
@@ -321,7 +321,7 @@ namespace Ship_Game
                     ImperialistWarPlanetsToTakeMult = 0.4f;
                     DistanceToDefendAllyThreshold   = 1.4f;
                     SpyDamageRelationsMultiplier = 1.5f;
-                    TurnsAbove95FederationNeeded = 300;
+                    TurnsAbove95FederationNeeded = 200;
                     TurnsAbove95AllianceTreshold = 100;
                     AllianceValueAlliedWithEnemy = 0.8f;
                     WantedAgentMissionMultiplier = 0.1f;
@@ -336,7 +336,7 @@ namespace Ship_Game
                     WantedMoleCovreage    = 0.25f;
                     DefenseTaskWeight     = 2;
                     FleetStrMultiplier    = 0.9f;
-                    FederationPopRatioWar = 2f;
+                    FederationPopRatioWar = 1.2f;
                     PopRatioBeforeMerge   = 0.2f;
                     HullTechMultiplier    = 1f;
                     DoomFleetThreshold    = 3;

--- a/Ship_Game/Espionage/Espionage.cs
+++ b/Ship_Game/Espionage/Espionage.cs
@@ -256,7 +256,7 @@ namespace Ship_Game
             // 3 - 300
             // 4 - 600
             // 5 - 1200
-            return level == 0 ? 0 : (int)(75 * Math.Pow(2, level-1) * Owner.Universe.SettingsResearchModifier * Owner.Universe.P.Pace);
+            return level == 0 ? 0 : (int)(75 * Math.Pow(2, level-1) * Owner.Universe.SettingsResearchModifier.LowerBound(0.25f) * Owner.Universe.P.Pace);
         }
 
         public void AddLeechedMoney(float money)

--- a/Ship_Game/GameScreens/CombatScreen/CombatScreen.cs
+++ b/Ship_Game/GameScreens/CombatScreen/CombatScreen.cs
@@ -405,6 +405,11 @@ namespace Ship_Game
 
         void OnLandAllClicked(UIButton b)
         {
+            if (Player.InvasionBlockedNotEnoughWarmup(P.Owner))
+            {
+                GameAudio.NegativeClick();
+                return;
+            }
             bool instantLand = P.WeCanLandTroopsViaSpacePort(Player);
             if (instantLand)
                 GameAudio.TroopLand();
@@ -424,7 +429,7 @@ namespace Ship_Game
                     && troopShip.AI.State != AI.AIState.RebaseToShip
                     && troopShip.AI.State != AI.AIState.AssaultPlanet)
                 {
-                    troopShip.AI.OrderLandAllTroops(P, clearOrders:true);
+                    troopShip.AI.OrderLandAllTroops(P, clearOrders: true, Input.CursorPosition);
                 }
             }
             OrbitSL.Reset();
@@ -539,13 +544,13 @@ namespace Ship_Game
         {
             Ship ship = item.Troop.HostShip;
             if (ship != null && ship.Carrier.TryScrambleSingleAssaultShuttle(item.Troop, out Ship shuttle))
-                shuttle.AI.OrderLandAllTroops(P, clearOrders:true);
+                shuttle.AI.OrderLandAllTroops(P, clearOrders: true, Input.CursorPosition);
         }
 
         void TryLandTroop(CombatScreenOrbitListItem item,
                           PlanetGridSquare where = null)
         {
-            if (item.Troop.TryLandTroop(P, where))
+            if (!Player.InvasionBlockedNotEnoughWarmup(P.Owner) && item.Troop.TryLandTroop(P, where))
             {
                 GameAudio.TroopLand();
                 OrbitSL.Remove(item);

--- a/Ship_Game/GameScreens/FleetDesign/FleetButton.cs
+++ b/Ship_Game/GameScreens/FleetDesign/FleetButton.cs
@@ -115,10 +115,10 @@ public class FleetButton : UIPanel
             Ship ship = fleet.Ships[i];
             RectF iconHousing = new(shipSpacingH.X, shipSpacingH.Y, 15, 15);
             shipSpacingH.X += 18f;
-            if (shipSpacingH.X > 237) // 10 Ships per row
+            if (shipSpacingH.X >= x + 180) // 10 Ships per row
             {
                 shipSpacingH.X  = x;
-                shipSpacingH.Y += 18f;
+                shipSpacingH.Y += 16f;
             }
 
             Color statColor = ship.GetStatusColor();

--- a/Ship_Game/Gameplay/Relationship.cs
+++ b/Ship_Game/Gameplay/Relationship.cs
@@ -230,8 +230,8 @@ namespace Ship_Game.Gameplay
 
         public float GetTurnsForFederationWithPlayer(Empire us) => TurnsAbove95Federation(us);
 
-        int TurnsAbove95Federation(Empire us) => (int)(us.PersonalityModifiers.TurnsAbove95FederationNeeded 
-                                                 * (int)(us.Universe.P.GalaxySize + 1) * us.Universe.P.Pace);
+        int TurnsAbove95Federation(Empire us) => ((int)(us.PersonalityModifiers.TurnsAbove95FederationNeeded 
+                                                 * (int)(us.Universe.P.GalaxySize + 1) * us.Universe.P.Pace * 0.5f)).LowerBound(1);
         
         public void SetTreaty(Empire us, TreatyType treatyType, bool value)
         {
@@ -938,7 +938,7 @@ namespace Ship_Game.Gameplay
 
             turnsSinceLastContact = 0; // Try again after 100 turns * Pace
             if ((Trust >= 120 && us.TotalPopBillion < them.TotalPopBillion
-                || Trust >= 100 && us.TotalPopBillion < them.TotalPopBillion / 3)
+                || Trust >= 100 && us.TotalPopBillion < them.TotalPopBillion / 2)
                 && Is3RdPartyBiggerThenUs(us, them))
             {
                 us.Universe.Notifications.AddPeacefulMergerNotification(us, them);
@@ -955,7 +955,7 @@ namespace Ship_Game.Gameplay
                 if (e == us || e == them)
                     continue;
 
-                float ratio = us.IsAtWarWith(e) && averageWarsGrade < 2.5f ? popRatioWar : 10f;
+                float ratio = us.IsAtWarWith(e) && averageWarsGrade < 2.5f ? popRatioWar : 5;
                 if (e.TotalPopBillion / us.TotalPopBillion > ratio) // 3rd party is a potential risk
                     return true;
             }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
@@ -427,8 +427,8 @@ namespace Ship_Game
                 return;
             }
 
-            if (HasExclusiveBlueprints && BuildingList.Any(b => b.IsMilitary && !RequiredInBlueprints(b))
-                || HasBlueprints && !Blueprints.Exclusive && FreeHabitableTiles == 0 && !Blueprints.IsAchievableCompleted)
+            if ((HasExclusiveBlueprints || HasBlueprints && !Blueprints.Exclusive && FreeHabitableTiles == 0 && !Blueprints.IsAchievableCompleted)
+                && BuildingList.Any(b => b.IsMilitary && !RequiredInBlueprints(b)))
             {
                 TryScrapMilitaryBuilding();
             }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Govern.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Govern.cs
@@ -285,7 +285,7 @@ namespace Ship_Game
                 case UpriseBuildingType.AllMilitary: 
                     for (int i = BuildingList.Count - 1; i >= 0; i--)
                     {
-                        Building b = potentialBuildings[i];
+                        Building b = BuildingList[i];
                         if (b.Scrappable && b.IsMilitary)
                         {
                             DestroyBuilding(b);

--- a/Ship_Game/Universe/SolarBodies/PlanetInfoUIElement.cs
+++ b/Ship_Game/Universe/SolarBodies/PlanetInfoUIElement.cs
@@ -501,14 +501,23 @@ namespace Ship_Game
             {
                 if (Player.GetTroopShipForRebase(out Ship troopShip, P.Position, P.Name))
                 {
-                    GameAudio.EchoAffirmative();
-                    troopShip.AI.OrderLandAllTroops(P, clearOrders:true);
-                    if (Player.Universe.Paused) 
-                        Player.Universe.Objects.UpdateLists();
+                    if (!troopShip.AI.OrderLandAllTroops(P, clearOrders: true, input.CursorPosition))
+                    {
+                        GameAudio.NegativeClick();
+                    }
+                    else
+                    {
+                        GameAudio.EchoAffirmative();
+                        if (Player.Universe.Paused)
+                            Player.Universe.Objects.UpdateLists();
+                    }
                 }
                 else
+                {
                     GameAudio.BlipClick();
+                }
             }
+
             if (P.IsResearchable && ExoticRect.HitTest(input.CursorPosition) && input.InGameSelect)
             {
                 if      (Player.AI.HasGoal(g => g.IsResearchStationGoal(P))) Player.AI.CancelResearchStation(P);

--- a/Ship_Game/Universe/SolarBodies/PlanetListScreenItem.cs
+++ b/Ship_Game/Universe/SolarBodies/PlanetListScreenItem.cs
@@ -358,14 +358,23 @@ namespace Ship_Game
         {
             if (Player.GetTroopShipForRebase(out Ship troopShip, Planet.Position, Planet.Name))
             {
+                if (Player.InvasionBlockedNotEnoughWarmup(Planet.Owner))
+                {
+                    ToolTip.CreateFloatingText(GameText.InvasionblockedWarmup, "", Screen.Input.CursorPosition, 3);
+                    GameAudio.NegativeClick();
+                    return;
+                }
+
                 GameAudio.EchoAffirmative();
-                troopShip.AI.OrderLandAllTroops(Planet, clearOrders:true);
+                troopShip.AI.OrderLandAllTroops(Planet, clearOrders: true);
                 Screen.RefreshSendTroopButtonsVisibility();
                 Player.Universe.Objects.UpdateLists();
                 UpdateButtonSendTroops();
             }
             else
+            {
                 GameAudio.NegativeClick();
+            }
         }
 
         void OnSendTroopsRightClick() // cancel one incoming troop

--- a/Ship_Game/Universe/SolarBodies/TroopManager.cs
+++ b/Ship_Game/Universe/SolarBodies/TroopManager.cs
@@ -549,12 +549,13 @@ namespace Ship_Game
 
         float BuildingCombatStrength(Building b)
         {
-            float strength = 0;
-            if (b?.IsAttackable == true)
-            {
+            if (b == null)
+                return 0;
+
+            float strength = b.InvadeInjurePoints * Ground.TileArea / 2f;
+            if (b.IsAttackable)
                 strength += b.CombatStrength;
-                strength += b.InvadeInjurePoints * Ground.TileArea/2f;
-            }
+
             return strength;
         }
 

--- a/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
+++ b/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
@@ -120,7 +120,7 @@ namespace Ship_Game.Universe
                 if (planet.Owner == null || ship.Loyalty.IsAtWarWith(planet.Owner))
                 {
                     // Land troops on unclaimed planets or enemy planets
-                    ship.AI.OrderLandAllTroops(planet, clearOrders);
+                    ship.AI.OrderLandAllTroops(planet, clearOrders, Input.CursorPosition);
                 }
             }
             else

--- a/Ship_Game/Universe/UniverseState_Empires.cs
+++ b/Ship_Game/Universe/UniverseState_Empires.cs
@@ -356,8 +356,6 @@ public partial class UniverseState
 
         DiplomaticTraits dt = ResourceManager.DiplomaticTraits;
         data.DiplomaticPersonality = parent.Random.Item(dt.DiplomaticTraitsList);
-        data.DiplomaticPersonality = parent.Random.Item(dt.DiplomaticTraitsList);
-        data.EconomicPersonality   = parent.Random.Item(dt.EconomicTraitsList);
         data.EconomicPersonality   = parent.Random.Item(dt.EconomicTraitsList);
         data.SpyModifier = data.Traits.SpyMultiplier;
         data.IsRebelFaction  = true;

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -15458,6 +15458,9 @@ UpriseAssetsTheyLost:
 UpriseAllMilitaryBuildings: 
  Id: 6346
  ENG: "All Military Buildings."                   
+InvasionblockedWarmup: 
+ Id: 6347
+ ENG: "Not enough time passed since war started. 10 turns warmup needed."
 IndicatesTheChanceOfEcm:
  Id: 7001
  ENG: "Indicates the % chance of ECM disruption against incoming guided weapons, before the weapon's ECM resistance is deducted. Successful ECM disruption jams targeting and prevents the munition from hitting."

--- a/game/Content/Goods/Goods.yaml
+++ b/game/Content/Goods/Goods.yaml
@@ -43,7 +43,7 @@ Good:
   IsGasGiantMineable: true  
   ExoticBonusType: ShieldRecharge
   MaxBonus: 0.5
-  ConsumptionMultiplier: 0.01
+  ConsumptionMultiplier: 0.008
 Good:
   UID: Luxarium
   RefiningRatio: 0.5
@@ -55,7 +55,7 @@ Good:
   IsGasGiantMineable: true  
   ExoticBonusType: Credits  
   MaxBonus: 0.5
-  ConsumptionMultiplier: 0.1
+  ConsumptionMultiplier: 0.03
 Good:
   UID: Fortifume
   RefiningRatio: 0.5
@@ -67,7 +67,7 @@ Good:
   IsGasGiantMineable: true  
   ExoticBonusType: DamageReduction  
   MaxBonus: 0.5  
-  ConsumptionMultiplier: 0.0005
+  ConsumptionMultiplier: 0.0004
 Good:
   UID: Energon
   RefiningRatio: 0.5
@@ -79,7 +79,7 @@ Good:
   IsGasGiantMineable: true  
   ExoticBonusType: Production  
   MaxBonus: 0.25  
-  ConsumptionMultiplier: 0.05  
+  ConsumptionMultiplier: 0.02  
 Good:
   UID: NanoGas
   RefiningRatio: 0.5


### PR DESCRIPTION
Fix: Slight calc alteration of building str.
Fix: Blueprints military buildings scrap/build loop 
Fix: Fleet buttons drawing only 9 ships per row instead of 10
Fix: AI response taking over rebel planets
Fix: Crash in uprise ops. 
Fix: Guard fleets were deployed on normal difficulty.
Balance: Espionage costs on smaller maps
Balance: Federation parameters
Balance: Do not allow player invasions when a war is started for 10 turns, in order to avoid some troop spam exploits.
Balance: Exotic Resources consumption
@gkapulis 