### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/AI/CombatTactics/AssaultShipCombat.cs
+++ b/Ship_Game/AI/CombatTactics/AssaultShipCombat.cs
@@ -76,28 +76,6 @@ namespace Ship_Game.AI.CombatTactics
 
             return sendingTroops;
         }
-
-        /// <summary>
-        /// Expand later
-        /// </summary>
-        /// <returns></returns>
-        public bool TryInvadePlanet()
-        {
-            //This is the auto invade feature. FB: this should be expanded to check for building strength and compare troops in ship vs planet
-            if (Owner.SecondsAlive < 2)
-                return false; // Initial Delay in launching shuttles if spawned
-
-            if (Owner == null || !Owner.Carrier.AnyAssaultOpsAvailable || Owner.Loyalty.WeArePirates || Owner.TroopsAreBoardingShip)
-                return false;
-
-            Planet invadeThis = Owner.System?.PlanetList.FindMinFiltered(
-                                owner => owner.Owner != null && owner.Owner != Owner.Loyalty && Owner.Loyalty.IsAtWarWith(owner.Owner),
-                                p => p.Troops.Count);
-            if (invadeThis != null)
-                Owner.Carrier.AssaultPlanet(invadeThis);
-            
-            return true;
-        }
     }
 }
 

--- a/Ship_Game/AI/MissileAI.cs
+++ b/Ship_Game/AI/MissileAI.cs
@@ -68,7 +68,7 @@ namespace Ship_Game.AI
             return ship.Active
                    && !ship.Dying
                    && !ship.IsInWarp
-                   && Missile.Weapon.TargetValid(ship.ShipData.HullRole)
+                   && Missile.Weapon.ShipTargetValid(ship)
                    && Missile.Loyalty.IsEmpireAttackable(ship.Loyalty);
         }
 

--- a/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
@@ -394,7 +394,7 @@ namespace Ship_Game.AI
 
         float GetTargetPriority(Ship tgt)
         {
-            if (tgt.IsInWarp)
+            if (tgt.IsInWarp || tgt.TroopsAreBoardingShip)
                 return 0;
 
             // when selecting enemy targets, we should see how easy they are to kill
@@ -644,7 +644,7 @@ namespace Ship_Game.AI
             }
         }
 
-        void ExitCombatState()
+        public void ExitCombatState()
         {
             if (OrderQueue.TryPeekFirst(out ShipGoal goal) &&
                 goal?.Plan == Plan.DoCombat)

--- a/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
@@ -22,7 +22,7 @@ namespace Ship_Game.AI
             HasPriorityTarget = true;
             ChangeAIState(AIState.Boarding);
             var escortTarget = EscortTarget;
-            if (Owner.TroopCount < 1 || escortTarget == null || !escortTarget.Active || escortTarget.Loyalty == Owner.Loyalty)
+            if (Owner.TroopCount < 1 || escortTarget == null || escortTarget.IsDeadOrDying || escortTarget.Loyalty == Owner.Loyalty)
             {
                 ClearOrders(State);
                 if (Owner.IsHangarShip)
@@ -40,6 +40,7 @@ namespace Ship_Game.AI
             if (distance < escortTarget.Radius + 300f)
             {
                 Owner.TryLandSingleTroopOnShip(escortTarget);
+                Owner.Loyalty.ResetTargetsForShipsTargetingAfterBoarding(escortTarget);
                 OrderReturnToHangar();
             }
             else if (distance > 10000f && Owner.Mothership?.AI.CombatState == CombatState.AssaultShip)

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -1585,7 +1585,7 @@ namespace Ship_Game
                 return false;
 
             Relationship relations = GetRelations(target);
-            return relations.AtWar && relations.TurnsAtWar < 10; 
+            return relations.AtWar && relations.TurnsAtWar < 5; 
         }
 
         public int GetSpyDefense()

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -2675,6 +2675,16 @@ namespace Ship_Game
             }
         }
 
+        public void ResetTargetsForShipsTargetingAfterBoarding(Ship thisShip)
+        {
+            var targetingShips = FindShipsAt(thisShip.Position, 100_000, s => s.InCombat);
+            for (int i = 0; i < targetingShips.Length; i++)
+            {
+                Ship ship = targetingShips[i];
+                ship.AI.ExitCombatState();
+            }
+        }
+
         public void ResetAllTechsAndBonuses()
         // FB - There is a bug here. Some tech bonuses are not reset after they are unlocked
         // For instance - pop growth is not reset

--- a/Ship_Game/Gameplay/Weapon.cs
+++ b/Ship_Game/Gameplay/Weapon.cs
@@ -441,9 +441,9 @@ namespace Ship_Game.Gameplay
         public bool TargetValid(GameObject fireTarget)
         {
             if (fireTarget.Type == GameObjectType.ShipModule)
-                return TargetValid(((ShipModule)fireTarget).GetParent().ShipData.HullRole);
+                return ShipTargetValid(((ShipModule)fireTarget).GetParent());
             if (fireTarget.Type == GameObjectType.Ship)
-                return TargetValid(((Ship)fireTarget).ShipData.HullRole);
+                return ShipTargetValid((Ship)fireTarget);
             return true;
         }
 
@@ -672,9 +672,12 @@ namespace Ship_Game.Gameplay
             return damageModifier;
         }
 
-        public bool TargetValid(RoleName role)
+        public bool ShipTargetValid(Ship ship)
         {
-            switch (role)
+            if (ship.TroopsAreBoardingShip)
+                return false;
+
+            switch (ship.ShipData.HullRole)
             {
                 case RoleName.fighter    when ExcludesFighters:
                 case RoleName.scout      when ExcludesFighters:

--- a/Ship_Game/ShipListInfoUIElement.cs
+++ b/Ship_Game/ShipListInfoUIElement.cs
@@ -174,7 +174,7 @@ namespace Ship_Game
                 Vector2 defPos = new Vector2(DefenseRect.X + DefenseRect.Width + 2, DefenseRect.Y + 11 - Fonts.Arial12Bold.LineSpacing / 2);
                 SpriteBatch spriteBatch = batch;
                 Graphics.Font arial12Bold = Fonts.Arial12Bold;
-                float totalBoardingDefense = HoveredShip.MechanicalBoardingDefense + HoveredShip.TroopBoardingDefense;
+                float totalBoardingDefense = HoveredShip.CurrentMechanicalBoardingDefense + HoveredShip.TroopBoardingDefense;
                 spriteBatch.DrawString(arial12Bold, totalBoardingDefense.String(), defPos, Color.White);
                 text = Fonts.Arial10.ParseText(ShipListScreenItem.GetStatusText(HoveredShip), 155f);
                 Vector2 shipStatus = new Vector2(Selector.Rect.X + Selector.Rect.Width - 168, Housing.Y + 64);

--- a/Ship_Game/Ships/CarrierBays.cs
+++ b/Ship_Game/Ships/CarrierBays.cs
@@ -180,7 +180,7 @@ namespace Ship_Game.Ships
             AllTroopBays.Count(hangar => hangar.Active && hangar.HangarTimer <= 0 && !hangar.IsHangarShipActive);
 
         // this will return the number of assault shuttles in space
-        public int LaunchedAssaultShuttles => AllTroopBays.Count(hangar => hangar.IsHangarShipActive);
+        public int LaunchedAssaultShuttlesWithTroops => AllTroopBays.Count(hangar => hangar.ActiveAssultShipHasTroops);
 
         /// <summary>
         /// Are any of the supply shuttles launched
@@ -195,7 +195,7 @@ namespace Ship_Game.Ships
                 if (Owner == null)
                     return 0;
 
-                return Owner.TroopCount + LaunchedAssaultShuttles;
+                return Owner.TroopCount + LaunchedAssaultShuttlesWithTroops;
             }
         }
 
@@ -382,7 +382,7 @@ namespace Ship_Game.Ships
                 if (Owner == null)
                     return 0;
 
-                int troopsNotInTroopListCount = LaunchedAssaultShuttles;
+                int troopsNotInTroopListCount = LaunchedAssaultShuttlesWithTroops;
                 troopsNotInTroopListCount    += AllTransporters.Sum(sm => sm.TransporterTroopLanding);
 
                 return Owner.TroopCapacity - (Owner.TroopCount + troopsNotInTroopListCount);

--- a/Ship_Game/Ships/Components/LoyaltyChanges.cs
+++ b/Ship_Game/Ships/Components/LoyaltyChanges.cs
@@ -102,6 +102,7 @@ namespace Ship_Game.Ships.Components
             oldLoyalty.TheyKilledOurShip(newLoyalty, ship);
             newLoyalty.WeKilledTheirShip(oldLoyalty, ship);
             SafelyTransferShip(ship, oldLoyalty, newLoyalty);
+            newLoyalty.ResetTargetsForShipsTargetingAfterBoarding(ship);
 
             if (notification)
             {

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -56,7 +56,8 @@ namespace Ship_Game.Ships
         public float EMPDamage { get; private set; }
         [StarData] public float YRotation;
         public float MechanicalBoardingDefense;
-        public float TroopBoardingDefense;
+        [StarData] public float CurrentMechanicalBoardingDefense { get; private set; }
+        public float TroopBoardingDefense { get; private set; }
         public float ECMValue;
         [StarData] public IShipDesign ShipData;
         [StarData] public int Kills;
@@ -159,7 +160,7 @@ namespace Ship_Game.Ships
         public float ResearchPerTurn;
         public float TotalRefining;
 
-        public float BoardingDefenseTotal => MechanicalBoardingDefense + TroopBoardingDefense;
+        public float BoardingDefenseTotal => CurrentMechanicalBoardingDefense + TroopBoardingDefense;
 
         public float FTLModifier { get; private set; } = 1f;
         [StarData] public Planet HomePlanet { get; private set; }
@@ -455,10 +456,10 @@ namespace Ship_Game.Ships
                     first.DamageTroop(this, ref damage);
                 }
             }
-            else if (MechanicalBoardingDefense > 0f)
+            else if (CurrentMechanicalBoardingDefense > 0f)
             {
                 if (Loyalty.Random.RollDice(troopDamageChance*0.1f))
-                    MechanicalBoardingDefense -= 1f;
+                    CurrentMechanicalBoardingDefense -= 1f;
             }
         }
 
@@ -1285,6 +1286,9 @@ namespace Ship_Game.Ships
             // Ship Repair
             if (HealthPercent < 1)
                 Repair(timeSinceLastUpdate);
+
+            if (CurrentMechanicalBoardingDefense < MechanicalBoardingDefense)
+                RepairMechanicalBoardingDefense();
 
             UpdateResupply();
             UpdateTroops(timeSinceLastUpdate);

--- a/Ship_Game/Ships/ShipInfoUIElement.cs
+++ b/Ship_Game/Ships/ShipInfoUIElement.cs
@@ -159,7 +159,7 @@ namespace Ship_Game.Ships
             OBar.Draw(batch);
             batch.Draw(ResourceManager.Texture("UI/icon_shield"), DefenseRect, Color.White);
             var defPos = new Vector2(DefenseRect.X + DefenseRect.Width + 2, DefenseRect.Y + 11 - Fonts.Arial12Bold.LineSpacing / 2);
-            float totalBoardingDefense = s.MechanicalBoardingDefense + s.TroopBoardingDefense;
+            float totalBoardingDefense = s.CurrentMechanicalBoardingDefense + s.TroopBoardingDefense;
             batch.DrawString(Fonts.Arial12Bold, totalBoardingDefense.String(0), defPos, Color.White);
             batch.Draw(ResourceManager.Texture("UI/icon_troop_shipUI"), TroopRect, Color.White);
             DrawTroopStatus(s);

--- a/Ship_Game/Ships/ShipModule.cs
+++ b/Ship_Game/Ships/ShipModule.cs
@@ -319,6 +319,8 @@ namespace Ship_Game.Ships
         }
 
         public bool IsHangarShipActive => TryGetHangarShip(out Ship ship) && ship.Active;
+
+        public bool ActiveAssultShipHasTroops => TryGetHangarShip(out Ship ship) && ship.Active && ship.TroopCount > 0;
         public bool TryGetHangarShipActive(out Ship ship) => TryGetHangarShip(out ship) && ship.Active;
 
         [StarDataConstructor]

--- a/Ship_Game/Ships/ShipStats.cs
+++ b/Ship_Game/Ships/ShipStats.cs
@@ -53,6 +53,8 @@ namespace Ship_Game.Ships
 
             float maxSensorBonus = 0f;
             int activeInternalSlots = 0;
+            bool inCombat = S.InCombat;
+
             S.ActiveInternalModuleSlots = 0;
             S.BonusEMPProtection     = 0f;
             S.PowerStoreMax           = 0f;
@@ -70,7 +72,9 @@ namespace Ship_Game.Ships
             S.TargetingAccuracy       = 0;
             S.ResearchPerTurn         = 0;
             S.TotalRefining           = 0;
-            S.MechanicalBoardingDefense = 0;
+
+            if (!inCombat)
+                S.MechanicalBoardingDefense = 0;
 
             for (int i = 0; i < modules.Length; i++)
             {
@@ -81,6 +85,7 @@ namespace Ship_Game.Ships
 
                 // FB - so destroyed/unpowered modules with repair wont have full repair rate
                 S.RepairRate += module.ActualBonusRepairRate * (active && module.Powered ? 1f : 0.1f);
+
 
                 if (active && (module.Powered || module.PowerDraw <= 0f))
                 {
@@ -98,7 +103,9 @@ namespace Ship_Game.Ships
                     S.ECMValue = Math.Max(S.ECMValue, module.ECM).Clamped(0f, 1f);
                     S.ResearchPerTurn += module.ResearchPerTurn;
                     S.TotalRefining += module.Refining;
-                    S.MechanicalBoardingDefense += module.MechanicalBoardingDefense;
+
+                    if (!inCombat)
+                        S.MechanicalBoardingDefense += module.MechanicalBoardingDefense;
                 }
             }
             

--- a/Ship_Game/Ships/ShipStats.cs
+++ b/Ship_Game/Ships/ShipStats.cs
@@ -53,7 +53,6 @@ namespace Ship_Game.Ships
 
             float maxSensorBonus = 0f;
             int activeInternalSlots = 0;
-            bool inCombat = S.InCombat;
 
             S.ActiveInternalModuleSlots = 0;
             S.BonusEMPProtection     = 0f;
@@ -72,9 +71,7 @@ namespace Ship_Game.Ships
             S.TargetingAccuracy       = 0;
             S.ResearchPerTurn         = 0;
             S.TotalRefining           = 0;
-
-            if (!inCombat)
-                S.MechanicalBoardingDefense = 0;
+            S.MechanicalBoardingDefense = 0;
 
             for (int i = 0; i < modules.Length; i++)
             {
@@ -103,9 +100,7 @@ namespace Ship_Game.Ships
                     S.ECMValue = Math.Max(S.ECMValue, module.ECM).Clamped(0f, 1f);
                     S.ResearchPerTurn += module.ResearchPerTurn;
                     S.TotalRefining += module.Refining;
-
-                    if (!inCombat)
-                        S.MechanicalBoardingDefense += module.MechanicalBoardingDefense;
+                    S.MechanicalBoardingDefense += module.MechanicalBoardingDefense;
                 }
             }
             

--- a/Ship_Game/Ships/Ship_Initialize.cs
+++ b/Ship_Game/Ships/Ship_Initialize.cs
@@ -591,17 +591,17 @@ namespace Ship_Game.Ships
 
         void InitConstantsAfterUpdate(bool fromSave)
         {
+            MechanicalBoardingDefense = MechanicalBoardingDefense.LowerBound(1);
             if (!fromSave)
             {
                 PowerCurrent = PowerStoreMax;
                 InitShieldsPower(Stats.ShieldAmplifyPerShield);
+                CurrentMechanicalBoardingDefense = MechanicalBoardingDefense;
             }
 
             UpdateShields();
             if (ShipData.Role == RoleName.troop)
                 TroopCapacity = 1; // set troopship and assault shuttle not to have 0 TroopCapacity since they have no modules with TroopCapacity
-
-            MechanicalBoardingDefense = MechanicalBoardingDefense.LowerBound(1);
         }
 
         void InitShieldsPower(float shieldAmplify)

--- a/Ship_Game/Ships/Ship_Repair.cs
+++ b/Ship_Game/Ships/Ship_Repair.cs
@@ -86,6 +86,13 @@ public partial class Ship
             PerformRegeneration();
     }
 
+    void RepairMechanicalBoardingDefense()
+    {
+        if (!InCombat)
+            CurrentMechanicalBoardingDefense = (CurrentMechanicalBoardingDefense 
+                + (MechanicalBoardingDefense*0.02f).LowerBound(10)).UpperBound(MechanicalBoardingDefense);
+    }
+
     void PerformRegeneration()
     {
         if (!HasRegeneratingModules)
@@ -110,7 +117,7 @@ public partial class Ship
     /// <param name="repairAmount">How many HP-s to repair</param>
     /// <param name="repairInterval">This repair event interval in seconds, important for correct UI estimation</param>
     /// <param name="repairLevel">Level which improves repair decisions</param>
-    public void ApplyAllRepair(float repairAmount, float repairInterval, int repairLevel)
+    void ApplyAllRepair(float repairAmount, float repairInterval, int repairLevel)
     {
         if (HealthPercent >= 1)
         {

--- a/Ship_Game/Universe/SolarBodies/Planet/Mineable.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Mineable.cs
@@ -25,7 +25,7 @@ namespace Ship_Game
         public SubTexture ExoticResourceIcon => ResourceManager.Texture($"Goods/{CargoId}");
         public float RefiningRatio => ResourceType.RefiningRatio; // How much of the resource is processed per turn
         public ExoticBonusType ExoticBonusType => ResourceType.ExoticBonusType;
-        float MinMiningRadius => P.Radius * 0.5f;
+        float MinMiningRadius => P.Radius * 0.4f;
         public float MaxMiningRadius => P.Radius * 0.7f;
         int NumMiningGoalsFor(Empire empire) => empire.AI.CountGoals(g => g.IsMiningOpsGoal(P));
 

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -15460,7 +15460,7 @@ UpriseAllMilitaryBuildings:
  ENG: "All Military Buildings."                   
 InvasionblockedWarmup: 
  Id: 6347
- ENG: "Not enough time passed since war started. 10 turns warmup needed."
+ ENG: "Not enough time passed since war started. 5 turns warmup needed."
 IndicatesTheChanceOfEcm:
  Id: 7001
  ENG: "Indicates the % chance of ECM disruption against incoming guided weapons, before the weapon's ECM resistance is deducted. Successful ECM disruption jams targeting and prevents the munition from hitting."


### PR DESCRIPTION
Fix: Mining position calc update
Fix: Add CurrentMechanicalBoardingDefense and ability to repair it instead of making it max every 1 second.
Fix: Ships targeting / firing on ships with secondary weapons which are being boarded / boarded successfully
Fix: Correctly count active assault ships launched with troops
Balance: Reduce warmup for invasion to 5 turns.
remove unused code