### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/AI/EmpireAI/EmpireAI.RunMilitaryPlanner.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.RunMilitaryPlanner.cs
@@ -459,34 +459,29 @@ namespace Ship_Game.AI
 
                 public void ScrapAsNeeded(Empire empire)
                 {
-                    if (CurrentCount <= DesiredCount + 1
-                       || CurrentMaintenance <= RoleBuildBudget + PerUnitMaintenanceMax)
+                    if (CurrentCount <= DesiredCount + 1 
+                        || CurrentMaintenance <= RoleBuildBudget + PerUnitMaintenanceMax)
+                    {
+                        WeAreScrapping = false;
                         return;
+                    }
 
+                    WeAreScrapping = true;
                     foreach (var ship in CurrentShips
                         .OrderBy(ship => ship.ShipData.TechsNeeded.Count))
                     {
-                        if(ship.OnLowAlert &&
-                                        (ship.Fleet == null)
-                                        && ship.AI.State != AIState.Scuttle
-                                        && ship.AI.State != AIState.Resupply
-                                        && ship.CanBeScrapped && ship.Active
-                                        && ship.GetMaintCost(empire) > 0)
+                        if (ship.OnLowAlert 
+                            && ship.Fleet == null
+                            && ship.AI.State != AIState.Scuttle
+                            && ship.AI.State != AIState.Resupply
+                            && ship.CanBeScrapped && ship.Active
+                            && ship.GetMaintCost(empire) > 0
+                            && ship.AI.State != AIState.Scrap)
                         {
-                            if (ship.AI.State != AIState.Scrap)
-                            {
-                                if (CurrentCount <= DesiredCount + 1
-                                    && CurrentMaintenance <= RoleBuildBudget + PerUnitMaintenanceMax)
-                                    break;
-                                CurrentCount--;
-                                CurrentMaintenance -= ship.GetMaintCost();
-                                ship.AI.OrderScrapShip();
-                                WeAreScrapping = true;
-                            }
-                            else
-                            {
-                                WeAreScrapping = true;
-                            }
+                            CurrentCount--;
+                            CurrentMaintenance -= ship.GetMaintCost();
+                            ship.AI.OrderScrapShip();
+                            break; // screp one of each role at a time
                         }
                     }
                 }
@@ -535,7 +530,7 @@ namespace Ship_Game.AI
                         case RoleName.cruiser:    return CombatRole.Cruiser;
                         case RoleName.battleship: return CombatRole.Battleship;
                         case RoleName.capital:    return CombatRole.Capital;
-                        default:                           return CombatRole.Disabled;
+                        default:                  return CombatRole.Disabled;
                     }
                 }
             }

--- a/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
@@ -614,8 +614,15 @@ namespace Ship_Game.AI
         public void OrderBuilderReturnHome(Planet planet)
         {
             ClearOrders(priority: true);
-            AddShipGoal(Plan.BuilderReturnHome, AIState.SupplyReturnHome, 
-                planet.GetBuilderShipTargetVector(launch: false, out _), planet, true);
+            if (planet.Owner != null)
+            {
+                AddShipGoal(Plan.BuilderReturnHome, AIState.SupplyReturnHome,
+                    planet.GetBuilderShipTargetVector(launch: false, out _), planet, true);
+            }
+            else
+            {
+                OrderScuttleShip();
+            }
         }
 
         // Move to closest colony and get back some resources

--- a/Ship_Game/Commands/Goals/RemnantEngageEmpire.cs
+++ b/Ship_Game/Commands/Goals/RemnantEngageEmpire.cs
@@ -69,7 +69,7 @@ namespace Ship_Game.Commands.Goals
 
         float FleetStrNoBombers => (Fleet.GetStrength() - Fleet.GetBomberStrength()).LowerBound(0);
 
-        GoalStep ReturnToClosestPortal()
+        GoalStep ReturnToClosestPortalAndReroute()
         {
             if (Fleet.TaskStep < 8)
             {
@@ -209,7 +209,7 @@ namespace Ship_Game.Commands.Goals
                 return Remnants.ReleaseFleet(Fleet, GoalStep.GoalComplete);
 
             if (Remnants.Hibernating)
-                return ReturnToClosestPortal();
+                return ReturnToClosestPortalAndReroute();
 
             int numBombers = Remnants.NumBombersInFleet(Fleet);
             if (BombersLevel > 0 && numBombers < BombersLevel / 2)
@@ -219,7 +219,7 @@ namespace Ship_Game.Commands.Goals
             {
                 if (Fleet.TaskStep <= 7)
                     Owner.IncreaseFleetStrEmpireMultiplier(TargetEmpire);
-                return ReturnToClosestPortal();
+                return ReturnToClosestPortalAndReroute();
             }
 
             if (Fleet.TaskStep != 7 && TargetPlanet?.Owner == TargetEmpire) // Not cleared enemy at target planet yet
@@ -229,13 +229,13 @@ namespace Ship_Game.Commands.Goals
             if (!Remnants.TargetEmpireStillValid(TargetEmpire))
             {
                 if (!Remnants.FindValidTarget(out Empire newVictim))
-                    return ReturnToClosestPortal();
+                    return ReturnToClosestPortalAndReroute();
 
                 TargetEmpire = newVictim;
 
                 // New target is too strong, need to get a new fleet
                 if (Remnants.RequiredAttackFleetStr(TargetEmpire) > Fleet.GetStrength())
-                    return ReturnToClosestPortal();
+                    return ReturnToClosestPortalAndReroute();
             }
 
             if (TargetPlanet == null)
@@ -244,13 +244,13 @@ namespace Ship_Game.Commands.Goals
                 if (!SelectTargetPlanet())
                 {
                     Log.Warning($"Could not find a new Remnant target planet vs {TargetEmpire.Name}. Remnant fleet will return home.");
-                    return ReturnToClosestPortal();
+                    return ReturnToClosestPortalAndReroute();
                 }
             }
 
             // Select a new closest planet
             if (!Remnants.TargetNextPlanet(TargetEmpire, TargetPlanet, Remnants.NumBombersInFleet(Fleet), out Planet nextPlanet))
-                return ReturnToClosestPortal();
+                return ReturnToClosestPortalAndReroute();
 
             Fleet.ClearOrders();
             int changeToStep = TargetPlanet.System == nextPlanet.System ? 5 : 1;

--- a/Ship_Game/Commands/Goals/RemnantEngagements.cs
+++ b/Ship_Game/Commands/Goals/RemnantEngagements.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using SDUtils;
 using Ship_Game.AI;
 using Ship_Game.Data.Serialization;
 using Ship_Game.Ships;
@@ -25,17 +26,17 @@ namespace Ship_Game.Commands.Goals
 
         void EngageEmpire(Ship[] portals)
         {
-            if (!Remnants.CanDoAnotherEngagement())
+            if (!Remnants.TryGetPortalForEngagement(portals, out Array<Ship> availablePortals)
+                || !Remnants.FindValidTarget(out Empire target))
+            {
                 return;
+            }
 
-            if (!Remnants.FindValidTarget(out Empire target))
-                return;
-
-            Ship portal = Remnants.Owner.Random.Item(portals);
+            Ship closestPortal = availablePortals.FindMin(p => p.Position.SqDist(target.WeightedCenter));
             if (Remnants.Story is Remnants.RemnantStory.AncientHelpers)
-                Owner.AI.AddGoal(new RemnantHelpEmpire(Owner, portal, target));
+                Owner.AI.AddGoal(new RemnantHelpEmpire(Owner, closestPortal, target));
             else
-                Owner.AI.AddGoal(new RemnantEngageEmpire(Owner, portal, target));
+                Owner.AI.AddGoal(new RemnantEngageEmpire(Owner, closestPortal, target));
         }
 
         GoalStep CreateFirstPortal()

--- a/Ship_Game/Commands/Goals/RemnantPortal.cs
+++ b/Ship_Game/Commands/Goals/RemnantPortal.cs
@@ -131,7 +131,7 @@ namespace Ship_Game.Commands.Goals
             {
                 float production = (Owner.Universe.StarDate - 1000).LowerBound(Remnants.Level * 100f);
                 production *= Owner.DifficultyModifiers.RemnantResourceMod;
-                production *= (int)(UState.P.GalaxySize + 1) * 4 * UState.P.StarsModifier / UState.ActiveMajorEmpires.Length;
+                production *= (int)(UState.P.GalaxySize + 2) * UState.P.StarsModifier / UState.ActiveMajorEmpires.Length;
                 if (Portal.InCombat && Portal.AI.Target?.System == Portal.System)
                     production *= 0.5f;
                 Remnants.GenerateProduction(production);

--- a/Ship_Game/Debug/Page/RemnantsDebug.cs
+++ b/Ship_Game/Debug/Page/RemnantsDebug.cs
@@ -42,7 +42,7 @@ public class RemnantsDebug : DebugPage
         {
             Empire empire = Universe.MajorEmpires[i];
             if (!empire.IsDefeated)
-                Text.String(empire.EmpireColor, $"{empire.data.Name} - Pop: {empire.TotalPopBillion.String()}, Strength: {empire.CurrentMilitaryStrength.String(0)}");
+                Text.String(empire.EmpireColor, $"{empire.data.Name} - Score: {empire.TotalScore.String()}, Pop: {empire.TotalPopBillion.String()}, Strength: {empire.CurrentMilitaryStrength.String(0)}");
         }
 
         var empiresList = GlobalStats.RestrictAIPlayerInteraction ? Universe.NonPlayerMajorEmpires.Filter(emp => !emp.IsDefeated)
@@ -50,22 +50,19 @@ public class RemnantsDebug : DebugPage
 
         Text.NewLine();
         float averagePop = empiresList.Average(empire => empire.TotalPopBillion);
-        float averageStr = empiresList.Average(empire => empire.CurrentMilitaryStrength);
+        var averageScore = empiresList.Average(empire => empire.TotalScore);
         Text.String($"AI Empire Average Pop:         {averagePop.String(1)}");
-        Text.String($"AI Empire Average Strength: {averageStr.String(0)}");
+        Text.String($"AI Empire Average Score: {averageScore.String(0)}");
 
         Text.NewLine();
-        Empire bestPop  = empiresList.FindMax(empire => empire.TotalPopBillion);
-        Empire bestStr  = empiresList.FindMax(empire => empire.CurrentMilitaryStrength);
-        Empire worstStr = empiresList.FindMin(empire => empire.CurrentMilitaryStrength);
+        Empire bestStr  = empiresList.FindMax(empire => empire.TotalScore);
+        Empire worstStr = empiresList.FindMin(empire => empire.TotalScore);
 
-        float diffFromAverageScore    = bestPop.TotalPopBillion / averagePop.LowerBound(1) * 100;
-        float diffFromAverageStrBest  = bestStr.CurrentMilitaryStrength / averageStr.LowerBound(1) * 100;
-        float diffFromAverageStrWorst = worstStr.CurrentMilitaryStrength / averageStr.LowerBound(1) * 100;
+        var diffFromAverageScoreBest  = bestStr.TotalScore / averageScore.LowerBound(1) * 100;
+        var diffFromAverageScoreWorst = worstStr.TotalScore / averageScore.LowerBound(1) * 100;
 
-        Text.String(bestPop.EmpireColor, $"Highest Pop Empire: {bestPop.data.Name} ({(diffFromAverageScore - 100).String(1)}% above average)");
-        Text.String(bestStr.EmpireColor, $"Strongest Empire:   {bestStr.data.Name} ({(diffFromAverageStrBest - 100).String(1)}% above average)");
-        Text.String(worstStr.EmpireColor, $"Weakest Empire:     {worstStr.data.Name} ({(diffFromAverageStrWorst - 100).String(1)}% below average)");
+        Text.String(bestStr.EmpireColor, $"Strongest Empire:   {bestStr.data.Name} ({(diffFromAverageScoreBest - 100).String(1)}% above average)");
+        Text.String(worstStr.EmpireColor, $"Weakest Empire:     {worstStr.data.Name} ({(diffFromAverageScoreWorst - 100).String(1)}% below average)");
 
         Text.NewLine();
         Text.String("Goals:");

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -113,11 +113,11 @@ namespace Ship_Game
         [StarData] public bool AutoResearch;
         [StarData] public bool AutoBuildResearchStations;
         [StarData] public bool AutoBuildMiningStations;
-        public int TotalScore;
-        public float TechScore;
-        public float ExpansionScore;
-        public float MilitaryScore;
-        public float IndustrialScore;
+        [StarData] public int TotalScore;
+        [StarData] public float TechScore;
+        [StarData] public float ExpansionScore;
+        [StarData] public float MilitaryScore;
+        [StarData] public float IndustrialScore;
 
         // This is the original capital of the empire. It is used in capital elimination and 
         // is used in capital elimination and also to determine if another capital will be moved here if the
@@ -140,8 +140,8 @@ namespace Ship_Game
         public bool CanBuildShipyards { get; private set; }
         public bool CanBuildResearchStations { get; private set; }
         public bool CanBuildMiningStations { get; private set; }
-        public float CurrentMilitaryStrength;
-        public float OffensiveStrength; // No Orbitals
+        [StarData] public float CurrentMilitaryStrength;
+        [StarData] public float OffensiveStrength; // No Orbitals
         [StarData] public LoyaltyLists EmpireShips;
         public float CurrentTroopStrength { get; private set; }
         public Color ThrustColor0;
@@ -2183,7 +2183,7 @@ namespace Ship_Game
 
         void CalculateScore(bool fromSave = false)
         {
-            TechScore = TechEntries.Sum(e => e.Unlocked ? e.TechCost : 0) * 0.01f / Universe.P.Pace;
+            TechScore = TechEntries.Sum(e => e.Unlocked ? e.TechCost : 0) * 0.1f / Universe.P.Pace;
             IndustrialScore = 0;
             ExpansionScore  = 0;
             for (int i = 0; i < OwnedPlanets.Count; i++)
@@ -2193,12 +2193,9 @@ namespace Ship_Game
                 IndustrialScore += p.SumBuildings(b => b.Cost);
             }
             IndustrialScore *= 0.05f;
+            ExpansionScore *= 10;
 
-            if (fromSave)
-                MilitaryScore = data.MilitaryScoreAverage;
-            else
-                MilitaryScore = HelperFunctions.ExponentialMovingAverage(MilitaryScore, CurrentMilitaryStrength);
-
+            MilitaryScore = HelperFunctions.ExponentialMovingAverage(MilitaryScore, CurrentMilitaryStrength*0.01f);
             TotalScore = (int)(MilitaryScore + IndustrialScore + TechScore + ExpansionScore);
         }
 

--- a/Ship_Game/EmpireData.cs
+++ b/Ship_Game/EmpireData.cs
@@ -296,7 +296,6 @@ namespace Ship_Game
         [StarData] public bool IsPirateFaction;
         [StarData] public int PiratePaymentPeriodTurns = 100; 
         [StarData] public int MinimumColoniesForStartPayment = 3;
-        [StarData] public float MilitaryScoreAverage;
 
         // FB - For Remnants
         [StarData] public bool IsRemnantFaction;

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -977,6 +977,10 @@ namespace Ship_Game.Fleets
 
         void DoDeepSpaceInvestigate(MilitaryTask task)
         {
+            float enemyStr = Owner.Threats.GetHostileStrengthAt(task.AO, 100_000);
+            if (EndInvalidTask(!CanTakeThisFight(enemyStr, task)))
+                return;
+
             switch (TaskStep)
             {
                 case 0:
@@ -1006,13 +1010,10 @@ namespace Ship_Game.Fleets
                         AttackEnemyStrengthClumpsInAO(task);
                         TaskStep = 4;
                     }
+
                     break;
                 case 4:
-                    float enemyStr = Owner.Threats.GetHostileStrengthAt(task.AO, 30_000);
                     task.TargetEmpire = Owner.Threats.GetStrongestHostileAt(task.AO, 30_000);
-                    if (EndInvalidTask(!CanTakeThisFight(enemyStr, task)))
-                        return;
-
                     if (enemyStr == 0)
                         task.EndTask();
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -813,7 +813,7 @@ namespace Ship_Game
         public Vector2 GetBuilderShipTargetVector(bool launch, out bool fromShipyard)
         {
             fromShipyard = false;
-            if (Owner != null && Owner.Random.RollDie(1+NumShipyards) > 1)
+            if (Owner.Random.RollDie(1+NumShipyards) > 1)
             {
                 var potentialShipyards = OrbitalStations.Filter(s => s.IsShipyard);
                 if (potentialShipyards.Length > 0)

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -812,9 +812,8 @@ namespace Ship_Game
 
         public Vector2 GetBuilderShipTargetVector(bool launch, out bool fromShipyard)
         {
-
-            fromShipyard= false;
-            if (Owner.Random.RollDie(1+NumShipyards) > 1)
+            fromShipyard = false;
+            if (Owner != null && Owner.Random.RollDie(1+NumShipyards) > 1)
             {
                 var potentialShipyards = OrbitalStations.Filter(s => s.IsShipyard);
                 if (potentialShipyards.Length > 0)

--- a/game/Content/Globals.yaml
+++ b/game/Content/Globals.yaml
@@ -54,7 +54,7 @@ Globals:
   DisableRemnantStory: false
   DisablePirates: false
   AIUsesPlayerDesigns: true
-  EnableRandomizedAIFleetSizes: true # Allows Ai to slightly alter fleet sizes within range specified in FleetBuildRatios.yaml
+  EnableRandomizedAIFleetSizes: false # Allows Ai to slightly alter fleet sizes within range specified in FleetBuildRatios.yaml
 
   # visuals modifiers
   SpaceportScale: 0.5


### PR DESCRIPTION
Fix: Military score and Total score not saved, there for being slowly rebuilt again each game load.
Fix: Empire score calcs.
Fix: Remnant target empire calcs.
Fix: Optimization of AI role count calc and scrap logic. Now scraping 1 ship per role at a time, which allows creation of fleets from existing ships faster.
Fix: additional remnant portals did not start target goals.
Fix: crash with builder ships trying to return home when the planet has no owner anymore.
Fix: AI investigation fleet did not check well enough if they can handle the fight.
Balance: Portal production amount
Workaround: turn off random fleet ratios, for now,  as this might cause scrap loops