### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/Commands/Goals/RemnantHelpEmpire.cs
+++ b/Ship_Game/Commands/Goals/RemnantHelpEmpire.cs
@@ -150,7 +150,7 @@ namespace Ship_Game.Commands.Goals
             if (Fleet.TaskStep == 10) // Arrived back to portal
                 return Remnants.ReleaseFleet(Fleet, GoalStep.GoalComplete);
 
-            if (Remnants.Hibernating)
+            if (TargetPlanet == null || Remnants.Hibernating)
                 return ReturnToClosestPortal();
 
             if (TargetPlanet.Owner != TargetEmpire) // Planet was conquered by another empire

--- a/Ship_Game/Commands/Goals/RemnantHelpEmpire.cs
+++ b/Ship_Game/Commands/Goals/RemnantHelpEmpire.cs
@@ -179,7 +179,7 @@ namespace Ship_Game.Commands.Goals
                     Fleet.FleetTask.SetTargetPlanetAsAO(TargetPlanet);
                 
                 // New target is too strong, need to get a new fleet
-                if (Remnants.RequiredAttackFleetStr(TargetEmpire) > Fleet.GetStrength())
+                if (TargetPlanet == null || Remnants.RequiredAttackFleetStr(TargetEmpire) > Fleet.GetStrength())
                     return ReturnToClosestPortal();
             }
 

--- a/Ship_Game/GameScreens/ColonyBlueprints/BlueprintsChainListItem.cs
+++ b/Ship_Game/GameScreens/ColonyBlueprints/BlueprintsChainListItem.cs
@@ -14,7 +14,7 @@ namespace Ship_Game
         {
             BlueprintsName = template.Name;
             Info = template.Exclusive ? Localizer.Token(GameText.ExclusiveBlueprints) : "";
-            IconColor = BlueprintsScreen.GetBlueprintsIconColor(template);
+            IconColor = BlueprintsScreen.GetBlueprintsIconColor(template.ColonyType);
             if (template.ColonyType != Planet.ColonyType.Colony)
             {
                 Info = Info.NotEmpty() ? $"{Info} | Switch to: {template.ColonyType}"

--- a/Ship_Game/GameScreens/ColonyBlueprints/BlueprintsScreen.cs
+++ b/Ship_Game/GameScreens/ColonyBlueprints/BlueprintsScreen.cs
@@ -610,9 +610,9 @@ namespace Ship_Game
             return null; // default: use Plan Statistics
         }
 
-        public static Color GetBlueprintsIconColor(BlueprintsTemplate template)
+        public static Color GetBlueprintsIconColor(Planet.ColonyType colonyType)
         {
-            switch (template.ColonyType)
+            switch (colonyType)
             {
                 case Planet.ColonyType.Research:     return Color.CornflowerBlue;
                 case Planet.ColonyType.Industrial:   return Color.Orange;

--- a/Ship_Game/GameScreens/ColonyBlueprints/LoadBlueprintsToColonyScreen.cs
+++ b/Ship_Game/GameScreens/ColonyBlueprints/LoadBlueprintsToColonyScreen.cs
@@ -35,7 +35,7 @@ public sealed class LoadBlueprintsToColonyScreen : SaveLoadBlueprintsScreen
                                         : $"Switch to: {blueprints.ColonyType}";
 
         string title2 = blueprints.LinkTo.NotEmpty() ? $"Linked to: {blueprints.LinkTo}" : "";
-        Color color = BlueprintsScreen.GetBlueprintsIconColor(blueprints);
+        Color color = BlueprintsScreen.GetBlueprintsIconColor(blueprints.ColonyType);
         return new(null, blueprints, blueprints.Name, title1, title2, "", BlueprintsIcon, color) 
         { FileNameColor = color };
     }

--- a/Ship_Game/GameScreens/ColonyBlueprints/SaveLoadBlueprintsScreen.cs
+++ b/Ship_Game/GameScreens/ColonyBlueprints/SaveLoadBlueprintsScreen.cs
@@ -145,7 +145,7 @@ public class SaveLoadBlueprintsScreen : GenericLoadSaveScreen
         }
 
         string title2 = blueprints.Validated && blueprints.LinkTo.NotEmpty() ? $"Linked to: {blueprints.LinkTo}" : "";
-        Color color = BlueprintsScreen.GetBlueprintsIconColor(blueprints);
+        Color color = BlueprintsScreen.GetBlueprintsIconColor(blueprints.ColonyType);
         return new(info, blueprints, blueprints.Name, title1, title2, "", BlueprintsIcon, color)
         { Enabled = blueprints.Validated, InfoColor = infoColor, FileNameColor = color };
     }

--- a/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
@@ -130,14 +130,14 @@ namespace Ship_Game
             {
                 if (pgs.Building.PlusFlatFoodAmount > 0f || pgs.Building.PlusFoodPerColonist > 0f)
                 {
-                    numFood += pgs.Building.PlusFoodPerColonist * P.PopulationBillion * P.Food.Percent;
+                    numFood += pgs.Building.PlusFoodPerColonist * P.PopulationBillion * P.Food.Percent * P.Fertility;
                     numFood += pgs.Building.PlusFlatFoodAmount;
                 }
 
                 if (pgs.Building.PlusFlatProductionAmount > 0f || pgs.Building.PlusProdPerColonist > 0f)
                 {
                     numProd += pgs.Building.PlusFlatProductionAmount;
-                    numProd += pgs.Building.PlusProdPerColonist * P.PopulationBillion * P.Prod.Percent;
+                    numProd += pgs.Building.PlusProdPerColonist * P.PopulationBillion * P.Prod.Percent * P.MineralRichness;
                 }
 
                 if (pgs.Building.PlusProdPerRichness > 0f)

--- a/Ship_Game/GameScreens/ColonyScreen/GovernorDetailsComponent.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/GovernorDetailsComponent.cs
@@ -23,6 +23,7 @@ namespace Ship_Game
         Empire Player => Planet.Universe.Player;
         private DrawableSprite PortraitSprite;
         private UIPanel Portrait;
+        UIPanel BluePrintsIcon;
         private UILabel WorldType, WorldDescription;
         DropOptions<Planet.ColonyType> ColonyTypeList;
         private UICheckBox GovOrbitals, AutoTroops, GovNoScrap, Quarantine, ManualOrbitals, GovGround, SpecializedTradeHub, Prioritized;
@@ -116,9 +117,10 @@ namespace Ship_Game
             PortraitSprite = DrawableSprite.SubTex(ResourceManager.RootContent, $"Portraits/{Planet.Owner.data.PortraitName}");
 
             Portrait         = Add(new UIPanel(PortraitSprite));
+            BluePrintsIcon   = Add(new UIPanel(ResourceManager.Texture("NewUI/blueprints")));
             WorldType        = Add(new UILabel(Planet.WorldType, FontBig));
             WorldDescription = Add(new UILabel(Font12));
-            ColonyBlueprints = Add(new UILabel(GameText.ColonyBlueprintsTitle, FontBig, Color.White));
+            ColonyBlueprints = Add(new UILabel(GameText.ColonyBlueprintsTitle, FontBig, Color.Wheat));
             BlueprintsName   = Add(new UILabel("", FontBig, Color.Gold));
             BlueprintsCompletionLbl = Add(new UILabel(GameText.Completion, Font, Color.Wheat));
             BlueprintsAchiveable    = Add(new UILabel(GameText.Achievable, Font, Color.Gray));
@@ -143,7 +145,7 @@ namespace Ship_Game
             SpecializedTradeHub.OnChange = cb => { Planet.SetSpecializedTradeHub(cb.Checked); };
             SpecializedTradeHub.TextColor = Quarantine.TextColor = Prioritized.TextColor = Color.Gray;
             Quarantine.CheckedTextColor = Color.Red;
-            Prioritized.CheckedTextColor = Color.Green;
+            Prioritized.CheckedTextColor = Color.Purple;
 
             Garrison        = Slider(200, 200, 160, 40, GameText.GarrisonSize, 0, 25,Planet.GarrisonSize);
             ManualPlatforms = Slider(200, 200, 120, 40, GameText.ManualLimit, 0, 15, Planet.WantedPlatforms);
@@ -255,12 +257,17 @@ namespace Ship_Game
             base.PerformLayout();
         }
 
+        Color BlueprintsColor => Planet.HasBlueprints ? BlueprintsScreen.GetBlueprintsIconColor(Planet.Blueprints.ColonyType) : Color.White;
+
         public override void PerformLayout()
         {
             float aspect  = PortraitSprite.Size.X / PortraitSprite.Size.Y;
             float height  = (float)Math.Round(Height * 0.6f);
             Portrait.Size = new Vector2((float)Math.Round(aspect*height), height);
             Portrait.Pos  = new Vector2(X + 10, Y + 30);
+            BluePrintsIcon.Size = new Vector2(40, 40);
+            BluePrintsIcon.Pos  = Portrait.Pos;
+            BluePrintsIcon.Color = BlueprintsName.Color = BlueprintsColor;
 
             WorldType.Pos           = new Vector2(Portrait.Right + 10, Portrait.Y);
             ColonyTypeList.Pos      = new Vector2(WorldType.X, Portrait.Y + 21);
@@ -407,6 +414,7 @@ namespace Ship_Game
 
         void UpdateBlueprintsChanged()
         {
+            BlueprintsName.Color = BluePrintsIcon.Color = BlueprintsColor;
             BlueprintsName.Text = Planet.HasBlueprints ? Planet.Blueprints.Name : "";
             BlueprintsGovChange.Text = Planet.HasBlueprints && Planet.Blueprints.ColonyType != Planet.ColonyType.Colony
                 ? BlueprintsGovChange.Text = $"{Localizer.Token(GameText.GovernorChangedTo)} {Planet.Blueprints.ColonyType}"
@@ -424,6 +432,7 @@ namespace Ship_Game
                 WorldDescription.Visible   = GovernorTabView && Planet.OwnerIsPlayer;
                 ColonyTypeList.Visible     = GovernorTabView && Planet.OwnerIsPlayer;
                 Portrait.Visible           = GovernorTabView;
+                BluePrintsIcon.Visible     = Portrait.Visible && Planet.HasBlueprints;
                 WorldType.Visible          = GovernorTabView;
                 Quarantine.Visible         = GovernorTabView && Planet.OwnerIsPlayer;
                 Prioritized.Visible        = Quarantine.Visible && Planet.HasSpacePort;

--- a/Ship_Game/GameScreens/LinkBlueprintsScreen.cs
+++ b/Ship_Game/GameScreens/LinkBlueprintsScreen.cs
@@ -52,7 +52,7 @@ public sealed class LinkBlueprintsScreen : SaveLoadBlueprintsScreen
             infoColor = Color.Red;
         }
 
-        Color color = BlueprintsScreen.GetBlueprintsIconColor(blueprints);
+        Color color = BlueprintsScreen.GetBlueprintsIconColor(blueprints.ColonyType);
         return new(null, blueprints, blueprints.Name, title1, title2, "", BlueprintsIcon, color) 
         { Enabled = infoColor == Color.White, InfoColor = infoColor, FileNameColor = color };
     }

--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignScreenInput.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignScreenInput.cs
@@ -384,7 +384,7 @@ namespace Ship_Game
         {
             if (!DisplayedBulkReplacementHint && ModuleGrid.RepeatedReplaceActionsThreshold())
             {
-                ToolTip.CreateFloatingText(GameText.YouCanUseShiftClick, "", pos, 10);
+                ToolTip.CreateFloatingText(GameText.YouCanUseShiftClick, "", pos, 5);
                 DisplayedBulkReplacementHint = true;
             }
         }

--- a/Ship_Game/GameScreens/Universe/ColoniesListItem.cs
+++ b/Ship_Game/GameScreens/Universe/ColoniesListItem.cs
@@ -234,7 +234,18 @@ namespace Ship_Game
             Rectangle planetIconRect = new Rectangle(PlanetNameRect.X + 5, PlanetNameRect.Y + 25, PlanetNameRect.Height - 50, PlanetNameRect.Height - 50);
             batch.Draw(P.PlanetTexture, planetIconRect, Color.White);
             if (P.PrioritizedPort)
-                batch.DrawString(Fonts.Arial10, GameText.PrioritizedPort, new Vector2(planetIconRect.X, planetIconRect.Bottom + 8), Color.Green);
+            {
+                batch.DrawString(Fonts.Arial12, GameText.PrioritizedPort,
+                    new Vector2(planetIconRect.X + planetIconRect.Width + 10, planetIconRect.Top - 22), Screen.ApplyCurrentAlphaToColor(Color.Purple));
+            }
+
+            if (P.HasBlueprints) 
+            {
+                var color = BlueprintsScreen.GetBlueprintsIconColor(P.Blueprints.ColonyType);
+                batch.DrawString(Fonts.Arial12, P.Blueprints.Name, new Vector2(planetIconRect.X + planetIconRect.Width+10, planetIconRect.Bottom+5), color);
+                batch.Draw(ResourceManager.Texture("NewUI/blueprints"), 
+                    new Vector2(planetIconRect.X+2, planetIconRect.Bottom), new Vector2(25, 25), color);
+            }
 
             var cursor = new Vector2(PopRect.X + PopRect.Width - 5, PlanetNameRect.Y + PlanetNameRect.Height / 2 - Fonts.Arial12.LineSpacing / 2);
             float population = P.PopulationBillion;

--- a/Ship_Game/Universe/SolarBodies/ColonyBlueprints.cs
+++ b/Ship_Game/Universe/SolarBodies/ColonyBlueprints.cs
@@ -117,7 +117,7 @@ namespace Ship_Game.Universe.SolarBodies
             {
                 foreach (Building b in P.Buildings)
                 {
-                    if (b.IsSuitableForBlueprints && IsNotRequired(b) && Owner.IsBuildingUnlocked(b.Name))
+                    if (b.IsSuitableForBlueprints && IsNotRequired(b))
                         return true;
                 }
 


### PR DESCRIPTION
Fix: Crash in remnant goal logic.
Fix: Blueprints not removing locked buildings.
Fix: colony food/production visual representation was not accurate when production/fertility were not 1.
Fix: Reduce bulk replacement tool tip time to 5 seconds.
QOL: Add Blueprints icon to governor portrait and empire management screen and change prioritized port color to purple.