### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
@@ -200,7 +200,7 @@ namespace Ship_Game.AI
 
             Planet planet = g.TargetPlanet;
             Vector2 wantedPos = g.MovePosition;
-            if (wantedPos.OutsideRadius(Owner.Position, (Owner.CurrentVelocity * 2).UpperBound(500)))
+            if (wantedPos.OutsideRadius(Owner.Position, (Owner.CurrentVelocity * 2).Clamped(50, 500)))
             {
                 ThrustOrWarpToPos(wantedPos, timeStep, Owner.STLSpeedLimit);
                 return;
@@ -218,7 +218,7 @@ namespace Ship_Game.AI
                 OrderReturnToHangar();
             }
             else if (Owner.CargoSpaceFree > planet.Mining.Richness 
-                && Owner.Position.OutsideRadius(planet.Position, planet.Mining.MaxMiningRadius*1.1f))
+                && Owner.Position.OutsideRadius(planet.Position, planet.Mining.MaxMiningRadius*1.5f))
             {
                 OrderMinePlanet(planet);
             }

--- a/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
@@ -200,7 +200,7 @@ namespace Ship_Game.AI
 
             Planet planet = g.TargetPlanet;
             Vector2 wantedPos = g.MovePosition;
-            if (wantedPos.OutsideRadius(Owner.Position, (Owner.CurrentVelocity * 2).Clamped(50, 500)))
+            if (wantedPos.OutsideRadius(Owner.Position, 50))
             {
                 ThrustOrWarpToPos(wantedPos, timeStep, Owner.STLSpeedLimit);
                 return;
@@ -218,7 +218,7 @@ namespace Ship_Game.AI
                 OrderReturnToHangar();
             }
             else if (Owner.CargoSpaceFree > planet.Mining.Richness 
-                && Owner.Position.OutsideRadius(planet.Position, planet.Mining.MaxMiningRadius*1.5f))
+                && Owner.Position.OutsideRadius(planet.Position, planet.Mining.MaxMiningRadius*1.25f))
             {
                 OrderMinePlanet(planet);
             }

--- a/Ship_Game/Ships/LaunchShip.cs
+++ b/Ship_Game/Ships/LaunchShip.cs
@@ -283,7 +283,7 @@ namespace Ship_Game.Ships
                 scale = (1 - (Progress * TotalDuration / TotalDuration) * 0.7f).LowerBound(0.3f);
                 posZ = EndPosZ * Progress;
                 Owner.XRotation = (InitialRotationDegX - (Progress * InitialRotationDegX)).ToRadians();
-                float speedLimitFactor = ((1 - Progress) * 2).Clamped(0.25f, MaxSpeedMultiplier);
+                float speedLimitFactor = ((1 - Progress) * 2).Clamped(0.5f, MaxSpeedMultiplier);
                 Owner.SetSTLSpeedLimit(Owner.MaxSTLSpeed * speedLimitFactor);
                 if (Progress <= 0.2)
                 {

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -853,6 +853,8 @@ namespace Ship_Game.Ships
             return ShipSO;
         }
 
+        public bool HasSO => ShipSO != null;
+
         public void ReturnHome()
         {
             AI.OrderReturnHome();

--- a/Ship_Game/Universe/SolarBodies/Planet/Mineable.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Mineable.cs
@@ -26,7 +26,7 @@ namespace Ship_Game
         public float RefiningRatio => ResourceType.RefiningRatio; // How much of the resource is processed per turn
         public ExoticBonusType ExoticBonusType => ResourceType.ExoticBonusType;
         float MinMiningRadius => P.Radius * 0.4f;
-        public float MaxMiningRadius => P.Radius * 0.7f;
+        public float MaxMiningRadius => P.Radius * 0.6f;
         int NumMiningGoalsFor(Empire empire) => empire.AI.CountGoals(g => g.IsMiningOpsGoal(P));
 
         public Vector2 GetMinePos()

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
@@ -750,13 +750,10 @@ namespace Ship_Game
                 Ship ship = ships[i];
                 if (ship.InFrustum && ship.InPlayerSensorRange)
                 {
-                    if (!ship.IsLaunching)
-                    {
-                        if ((viewState > UnivScreenState.PlanetView || ShowingFTLOverlay) && !IsCinematicModeEnabled)
+                        if ((viewState > UnivScreenState.ShipView || ShowingFTLOverlay || !ship.HasSO) && !IsCinematicModeEnabled)
                             DrawTacticalIcon(ship);
 
                         DrawOverlay(ship);
-                    }
 
                     if (SelectedShip == ship || SelectedShips.Contains(ship))
                     {


### PR DESCRIPTION
Fix: Increase zoom level where ships' tactical icons are displayed. 
Fix: Show tactical icon if the ship model cannot be seen due to lack of memory.
Fix: Better mining logic for mining ships