### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/AI/ExpansionAI/ExpansionPlanner.cs
+++ b/Ship_Game/AI/ExpansionAI/ExpansionPlanner.cs
@@ -24,7 +24,7 @@ namespace Ship_Game.AI.ExpansionAI
         public ExpansionPlanner(Empire empire)
         {
             Owner = empire;
-            SetMaxSystemsToCheckedDiv(Owner.IsExpansionists ? 4 : 6);
+            SetMaxSystemsToCheckedDiv(Owner.IsExpansionists ? 8 : 10);
             ResetExpandSearchTimer();
         }
 

--- a/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
@@ -219,6 +219,7 @@ namespace Ship_Game.AI
             }
             else if (Owner.CargoSpaceFree > planet.Mining.Richness 
                 && Owner.Position.OutsideRadius(planet.Position, planet.Mining.MaxMiningRadius*1.25f))
+
             {
                 OrderMinePlanet(planet);
             }

--- a/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
@@ -219,7 +219,6 @@ namespace Ship_Game.AI
             }
             else if (Owner.CargoSpaceFree > planet.Mining.Richness 
                 && Owner.Position.OutsideRadius(planet.Position, planet.Mining.MaxMiningRadius*1.25f))
-
             {
                 OrderMinePlanet(planet);
             }

--- a/Ship_Game/Commands/Goals/RemnantEngageEmpire.cs
+++ b/Ship_Game/Commands/Goals/RemnantEngageEmpire.cs
@@ -219,7 +219,8 @@ namespace Ship_Game.Commands.Goals
             if (Fleet.TaskStep != 7 && TargetPlanet?.Owner == TargetEmpire) // Not cleared enemy at target planet yet
                 return GoalStep.TryAgain;
 
-            if (!Remnants.TargetEmpireStillValid(TargetEmpire))
+            if (!Remnants.TargetEmpireStillValid(TargetEmpire, 
+                stickToSameRandomTarget: TargetPlanet?.System.HasPlanetsOwnedBy(TargetEmpire) == true))
             {
                 if (!Remnants.FindValidTarget(out Empire newVictim))
                     return ReturnToClosestPortalAndReroute();

--- a/Ship_Game/Commands/Goals/ScrapShip.cs
+++ b/Ship_Game/Commands/Goals/ScrapShip.cs
@@ -59,6 +59,22 @@ namespace Ship_Game.Commands.Goals  // Created by Fat Bastard
             if (!OldShipOnPlan)
                 return GoalStep.GoalFailed;
 
+            if (!PlanetBuildingAt.Safe)
+            {
+                OldShip.AI.ClearOrders();
+                if (!Owner.FindPlanetToScrapIn(OldShip, out Planet buildAt))
+                {
+                    return GoalStep.GoalFailed;
+                }
+                else
+                {
+                    PlanetBuildingAt = buildAt;
+                    OldShip.AI.IgnoreCombat = true;
+                    OldShip.AI.OrderMoveAndScrap(buildAt);
+                }
+            }
+
+
             if (OldShip.Position.InRadius(PlanetBuildingAt.Position, PlanetBuildingAt.Radius + 300f))
                 return GoalStep.GoToNextStep;
 

--- a/Ship_Game/EmpireDifficultyModifers.cs
+++ b/Ship_Game/EmpireDifficultyModifers.cs
@@ -97,7 +97,7 @@
                     ExpansionMultiplier  = 1.0f;
                     ExpansionCheckInterval = 7; // every 7 turns
                     MinStartingColonies  = 3;
-                    ExpandSearchTurns    = 50;
+                    ExpandSearchTurns    = 200;
                     RemnantTurnsLevelUp  = 350;
                     RemnantResourceMod   = 0.5f;
                     RemnantNumBombers    = 0.75f;
@@ -132,7 +132,7 @@
                     ExpansionMultiplier  = 0.5f;
                     ExpansionCheckInterval = 5; // every 5 turns
                     MinStartingColonies  = 5;
-                    ExpandSearchTurns    = 30;
+                    ExpandSearchTurns    = 150;
                     RemnantTurnsLevelUp  = 325;
                     RemnantResourceMod   = 1f;
                     RemnantNumBombers    = 1f;
@@ -178,7 +178,7 @@
                     ExpansionMultiplier  = 0.25f; 
                     ExpansionCheckInterval = 3; // every 3 turns
                     MinStartingColonies  = 6;
-                    ExpandSearchTurns    = 20;
+                    ExpandSearchTurns    = 100;
                     RemnantTurnsLevelUp  = 300;
                     RemnantResourceMod   = 1.5f;
                     RemnantNumBombers    = 1.25f;
@@ -226,7 +226,7 @@
                     ExpansionMultiplier  = 0.1f; // 10x lower threshold, Insane AI can expand as much as it wants!
                     ExpansionCheckInterval = 1; // every turn, there is no limit!
                     MinStartingColonies  = 6;
-                    ExpandSearchTurns    = 20;
+                    ExpandSearchTurns    = 100;
                     RemnantTurnsLevelUp  = 275;
                     RemnantResourceMod   = 2f;
                     RemnantNumBombers    = 1.5f;

--- a/Ship_Game/Empire_RallyPlanets.cs
+++ b/Ship_Game/Empire_RallyPlanets.cs
@@ -317,7 +317,7 @@ public sealed partial class Empire
         }
 
         var scrapGoals = AI.FindGoals(g => g.Type == GoalType.ScrapShip);
-        var potentialPlanets = OwnedPlanets.SortedDescending(p => p.MissingProdHereForScrap(scrapGoals)).TakeItems(5);
+        var potentialPlanets = SafePlanets.SortedDescending(p => p.MissingProdHereForScrap(scrapGoals)).TakeItems(5);
         if (potentialPlanets.Length == 0)
             return false;
 

--- a/Ship_Game/Remnants.cs
+++ b/Ship_Game/Remnants.cs
@@ -386,13 +386,13 @@ namespace Ship_Game
             return targetEmpire.GetPlanets().FindMin(p => p.Position.SqDist(fleetPos));
         }
 
-        public bool TargetEmpireStillValid(Empire currentTarget)
+        public bool TargetEmpireStillValid(Empire currentTarget, bool stickToSameRandomTarget = true)
         {
             if (Hibernating)
                 return false;
 
             if (UsingRandomTargets() && !currentTarget.IsDefeated)
-                return true;
+                return stickToSameRandomTarget;
 
             FindValidTarget(out Empire expectedTarget);
             return expectedTarget == currentTarget;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
@@ -180,9 +180,7 @@ namespace Ship_Game
 
         public void GenerateNewHomeWorld(RandomBase random, Empire owner, SolarSystemData.Ring data = null)
         {
-            PlanetType type = data?.WhichPlanet > 0 ? ResourceManager.Planets.PlanetOrRandom(data.WhichPlanet) 
-                                                    : ResourceManager.Planets.RandomPlanet(owner.data.PreferredEnvPlanet);
-
+            PlanetType type = GetPLanetType();
             float scale = 1f * owner.data.Traits.HomeworldSizeMultiplier; // base max pop is affected by scale
             InitPlanetType(type, scale, fromSave: false);
             SetOwner(owner);
@@ -204,6 +202,13 @@ namespace Ship_Game
 
             UpdateDevelopmentLevel();
             CreateHomeWorldBuildings();
+
+            PlanetType GetPLanetType()
+            {
+                PlanetType traitPreferredType   = ResourceManager.Planets.RandomPlanet(owner.data.PreferredEnvPlanet);
+                PlanetType xmlDataPreferredtype = data?.WhichPlanet > 0 ? ResourceManager.Planets.PlanetOrRandom(data.WhichPlanet) : null;
+                return xmlDataPreferredtype?.Category == traitPreferredType.Category ? xmlDataPreferredtype : traitPreferredType;
+            }
         }
 
         void SetTileHabitability(RandomBase random, float tileChance, out int numHabitableTiles)


### PR DESCRIPTION
Fix: Better mining logic
Fix: Improve remnant random empire target selection. 
Fix: Expansion AI -increase system selection divider and increase search radius increase time.
Fix: selecting a trait preferred env should overwrite scripted starting planet env.
Fix: Scrap Ship - do not select unsafe planets as target planets for scrap.
Fix: Scrap Ship - change target planet if current target planet is not safe anymore.