### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/AI/ShipAI/ShipAI.Goods.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Goods.cs
@@ -144,7 +144,7 @@ namespace Ship_Game.AI
                                                   : FreighterPriority.ExcessCargoLeft;
                                                     
             Owner.Loyalty.IncreaseFastVsBigFreighterRatio(freighterPriority);
-            importPlanet.Mend(-5); // Helping with planet repair/heal troops/buildings
+            importPlanet.Mend(2); // Helping with planet repair/heal troops/buildings
 
             Planet toOrbit = importPlanet;
             if (toOrbit.TradeBlocked || Owner.Loyalty != toOrbit.Owner)

--- a/Ship_Game/AI/ShipAI/ShipAI.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.cs
@@ -367,7 +367,7 @@ namespace Ship_Game.AI
             Planet nearestRallyPoint = null;
             switch (resupplyReason)
             {
-                case ResupplyReason.LowOrdnanceCombat:
+                case ResupplyReason.LowOrdnanceCombatOrDepleted:
                 case ResupplyReason.LowOrdnanceNonCombat:
                     Ship supplyShip = NearBySupplyShip;
                     if (supplyShip != null && State != AIState.ResupplyEscort)

--- a/Ship_Game/Espionage/InfiltrationOpsRebellion.cs
+++ b/Ship_Game/Espionage/InfiltrationOpsRebellion.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using SDGraphics;
 using SDUtils;
 using Ship_Game.Data.Serialization;
 using Ship_Game.Ships;
@@ -33,17 +34,17 @@ namespace Ship_Game
             Espionage espionage = Owner.GetEspionage(Them);
             var potentials = Them.GetPlanets().Sorted(p => p.PopulationBillion).TakeItems(5);
             Planet targetPlanet = Them.Random.Item(potentials);
-            int numRebels = 5 + targetPlanet.GetDefendingTroopCount() + targetPlanet.NumMilitaryBuildings;
+            int numRebels = (targetPlanet.GetDefendingTroopCount() + targetPlanet.NumMilitaryBuildings - 2).LowerBound(2);
             float takeoverOrbitalChance = 50;
 
             switch (result)
             {
                 case InfiltrationOpsResult.Phenomenal:
-                    numRebels += 7;
+                    numRebels += 5;
                     takeoverOrbitalChance = 100;
                     break;
                 case InfiltrationOpsResult.GreatSuccess:
-                    numRebels += 3;
+                    numRebels += 2;
                     takeoverOrbitalChance = 75;
                     break;
                 case InfiltrationOpsResult.Success:

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -969,7 +969,7 @@ namespace Ship_Game.Fleets
             bool combatEffective   = StillCombatEffective(task);
             bool remnantsTargeting = !Owner.WeAreRemnants
                 && CommandShip?.System == task.TargetPlanet.System
-                && Owner.Universe.Remnants.AnyActiveFleetsTargetingSystem(task.TargetPlanet.System);
+                && Owner.Universe.Remnants.Remnants.HostileTargetingSystem(task.TargetPlanet.System);
 
             EndInvalidTask(remnantsTargeting 
                            || !MajorityTroopShipsAreInWell(task.TargetPlanet) && (!invasionEffective || !combatEffective));
@@ -1610,7 +1610,7 @@ namespace Ship_Game.Fleets
 
             bool remnantsTargeting = !Owner.WeAreRemnants
                 && CommandShip?.System == task.TargetPlanet.System
-                && Owner.Universe.Remnants.AnyActiveFleetsTargetingSystem(task.TargetPlanet.System);
+                && Owner.Universe.Remnants.Remnants.HostileTargetingSystem(task.TargetPlanet.System);
 
             if (EndInvalidTask(task.TargetPlanet.Owner == null || remnantsTargeting || !StillCombatEffective(task)))
                 return;

--- a/Ship_Game/GameScreens/DiplomacyScreen/RelationshipsDiagramScreen.cs
+++ b/Ship_Game/GameScreens/DiplomacyScreen/RelationshipsDiagramScreen.cs
@@ -157,7 +157,7 @@ namespace Ship_Game.GameScreens.DiplomacyScreen
         void DrawTreatyPeerLines(SpriteBatch batch, Peer us, Peer peer)
         {
             Relationship rel = us.Empire.GetRelationsOrNull(peer.Empire);
-            if (rel == null || rel.AtWar || rel.Treaty_Alliance)
+            if (rel == null)
                 return;
 
             if (rel.Treaty_Peace)
@@ -176,13 +176,12 @@ namespace Ship_Game.GameScreens.DiplomacyScreen
                 else if (rel.Treaty_NAPact)
                     DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorNap);
             }
-            else
-            {
-                if (rel.AtWar)
-                    DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorWar, thickness: 3);
-                else if (rel.Treaty_Alliance)
-                    DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorAlly, thickness: 3);
-            }
+
+            if (rel.AtWar)
+                DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorWar, thickness: 3);
+            else if (rel.Treaty_Alliance)
+                DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorAlly, thickness: 3);
+            
         }
 
         void DrawPeerLine(SpriteBatch batch, Vector2 pos1, Vector2 pos2, Color color, int thickness = 1)

--- a/Ship_Game/GameScreens/DiplomacyScreen/RelationshipsDiagramScreen.cs
+++ b/Ship_Game/GameScreens/DiplomacyScreen/RelationshipsDiagramScreen.cs
@@ -135,19 +135,10 @@ namespace Ship_Game.GameScreens.DiplomacyScreen
         void DrawRelations(SpriteBatch batch)
         {
             Peer[] knownPeers = Peers.Filter(p => p.IntelLevel > 0);
-            if (!ViewOnlyWarsOrAllies)
-            {
-                foreach (Peer us in knownPeers)
-                    foreach (Peer peer in Peers)
-                        if (ShowPeer(us.Empire, peer.Empire)) 
-                            DrawPeerLinesNoWarOrAlliance(batch, us, peer);
-            }
-
-            // Drawing War/Alliance on top of all other lines
             foreach (Peer us in knownPeers)
                 foreach (Peer peer in Peers)
-                    if (ShowPeer(us.Empire, peer.Empire))
-                        DrawPeerLinesWarOrAlliance(batch, us, peer);
+                    if (ShowPeer(us.Empire, peer.Empire)) 
+                        DrawTreatyPeerLines(batch, us, peer);
 
             foreach (Peer empire in Peers)
             {
@@ -163,7 +154,7 @@ namespace Ship_Game.GameScreens.DiplomacyScreen
                               && (SelectedEmpire == null || SelectedEmpire == us || SelectedEmpire == peer);
         }
 
-        void DrawPeerLinesNoWarOrAlliance(SpriteBatch batch, Peer us, Peer peer)
+        void DrawTreatyPeerLines(SpriteBatch batch, Peer us, Peer peer)
         {
             Relationship rel = us.Empire.GetRelationsOrNull(peer.Empire);
             if (rel == null || rel.AtWar || rel.Treaty_Alliance)
@@ -175,25 +166,23 @@ namespace Ship_Game.GameScreens.DiplomacyScreen
                 return;
             }
 
-            if (rel.Treaty_OpenBorders)
-                DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorBorders);
-            else if (rel.Treaty_NAPact)
-                DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorNap);
-
             if (ViewTradeTreaties && rel.Treaty_Trade)
                 DrawPeerLine(batch, us.TradePos, peer.TradePos, ColorTrade);
-        }
 
-        void DrawPeerLinesWarOrAlliance(SpriteBatch batch, Peer source, Peer peer)
-        {
-            Relationship rel = source.Empire.GetRelationsOrNull(peer.Empire);
-            if (rel == null)
-                return;
-
-            if (rel.AtWar)
-                DrawPeerLine(batch, source.LinkPos, peer.LinkPos, ColorWar, thickness: 3);
-            else if (rel.Treaty_Alliance)
-                DrawPeerLine(batch, source.LinkPos, peer.LinkPos, ColorAlly, thickness: 3);
+            if (!ViewOnlyWarsOrAllies)
+            {
+                if (rel.Treaty_OpenBorders)
+                    DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorBorders);
+                else if (rel.Treaty_NAPact)
+                    DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorNap);
+            }
+            else
+            {
+                if (rel.AtWar)
+                    DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorWar, thickness: 3);
+                else if (rel.Treaty_Alliance)
+                    DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorAlly, thickness: 3);
+            }
         }
 
         void DrawPeerLine(SpriteBatch batch, Vector2 pos1, Vector2 pos2, Color color, int thickness = 1)

--- a/Ship_Game/Remnants.cs
+++ b/Ship_Game/Remnants.cs
@@ -619,6 +619,14 @@ namespace Ship_Game
                                max: str * effectiveLevel / MaxLevel);
         }
 
+        public bool HostileTargetingSystem(SolarSystem solarSystem)
+        {
+            if (Story == RemnantStory.AncientHelpers)
+                return false; 
+
+            return Owner.AnyActiveFleetsTargetingSystem(solarSystem);
+        }
+
         public void CallGuardians(Ship portal) // One guarding from each relevant system
         {
             foreach (SolarSystem system in portal.Universe.Systems)

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -65,7 +65,7 @@ namespace Ship_Game.Ships
         public bool EnginesKnockedOut;
         public float InhibitionRadius;
         public bool IsPlatform;
-        public bool IsGuardian; // Remnant Guardian created at game start
+        public bool IsGuardian; // All Remnant ships are guardians
         SceneObject ShipSO;
         public bool ManualHangarOverride;
         [StarData] public Ship Mothership;

--- a/Ship_Game/Ships/ShipInfoUIElement.cs
+++ b/Ship_Game/Ships/ShipInfoUIElement.cs
@@ -385,10 +385,10 @@ namespace Ship_Game.Ships
                         }
                         break;
                     case ResupplyReason.LowOrdnanceNonCombat:
-                    case ResupplyReason.LowOrdnanceCombat:      text = "Ammo Reserves Critical";           break;
-                    case ResupplyReason.NoCommand:              text = "No Command, Cannot Attack";        break;
-                    case ResupplyReason.FighterReactorsDamaged: text = "Reactors Damaged";                 break;
-                    case ResupplyReason.LowHealth:              text = "Structural Integrity Compromised"; break;
+                    case ResupplyReason.LowOrdnanceCombatOrDepleted: text = "Ammo Reserves Critical";           break;
+                    case ResupplyReason.NoCommand:                   text = "No Command, Cannot Attack";        break;
+                    case ResupplyReason.FighterReactorsDamaged:      text = "Reactors Damaged";                 break;
+                    case ResupplyReason.LowHealth:                   text = "Structural Integrity Compromised"; break;
                     case ResupplyReason.LowTroops:
                         text = "Need Troops";
                         int numTroopRebasing = ship.NumTroopsRebasingHere;

--- a/Ship_Game/Ships/ShipResupply.cs
+++ b/Ship_Game/Ships/ShipResupply.cs
@@ -85,7 +85,7 @@ namespace Ship_Game.Ships
                 || Ship.IsSingleTroopShip
                 || Ship.IsSupplyShuttle
                 || Ship.Carrier.HasSupplyShuttlesInSpace
-                || (Ship.AI.HasPriorityOrder || Ship.AI.HasPriorityTarget) && Ship.AI.State != AIState.Bombard && !Ship.Resupplying)
+                || Ship.AI.HasPriorityOrder && Ship.AI.State != AIState.Bombard && !Ship.Resupplying)
             {
                 return ResupplyReason.NotNeeded;
             }
@@ -100,7 +100,7 @@ namespace Ship_Game.Ships
 
             if (ResupplyNeededLowOrdnance())
             {
-                if (InCombat)
+                if (InCombat || Ship.OrdnancePercent < OrdnanceThresholdCombat)
                     return ResupplyReason.LowOrdnanceCombat;
 
                 return Ship.IsPlatformOrStation ? ResupplyReason.RequestResupplyForOrbital 

--- a/Ship_Game/Ships/ShipResupply.cs
+++ b/Ship_Game/Ships/ShipResupply.cs
@@ -101,7 +101,7 @@ namespace Ship_Game.Ships
             if (ResupplyNeededLowOrdnance())
             {
                 if (InCombat || Ship.OrdnancePercent < OrdnanceThresholdCombat)
-                    return ResupplyReason.LowOrdnanceCombat;
+                    return ResupplyReason.LowOrdnanceCombatOrDepleted;
 
                 return Ship.IsPlatformOrStation ? ResupplyReason.RequestResupplyForOrbital 
                                                 : ResupplyReason.LowOrdnanceNonCombat;
@@ -317,7 +317,7 @@ namespace Ship_Game.Ships
     {
         NotNeeded,
         LowHealth,
-        LowOrdnanceCombat,
+        LowOrdnanceCombatOrDepleted,
         LowOrdnanceNonCombat,
         LowTroops,
         FighterReactorsDamaged,

--- a/Ship_Game/Ships/Ship_Rendering.cs
+++ b/Ship_Game/Ships/Ship_Rendering.cs
@@ -297,7 +297,9 @@ namespace Ship_Game.Ships
             }
             else if (viewState <= UniverseScreen.UnivScreenState.ShipView)
             {
-                DrawTactical(us, pos, radius, 16f, 8f);
+                if  (!HasSO)
+                    DrawTactical(us, pos, radius, radius, radius*1.8f);
+
                 DrawStatusIcons(us, radius, pos);
             }
         }

--- a/Ship_Game/Ships/Ship_Rendering.cs
+++ b/Ship_Game/Ships/Ship_Rendering.cs
@@ -297,7 +297,7 @@ namespace Ship_Game.Ships
             }
             else if (viewState <= UniverseScreen.UnivScreenState.ShipView)
             {
-                if  (!HasSO)
+                if (!HasSO)
                     DrawTactical(us, pos, radius, radius, radius*1.8f);
 
                 DrawStatusIcons(us, radius, pos);

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -72,7 +72,7 @@ namespace Ship_Game
 
         [StarData] public Mineable Mining;
         [StarData] public float SensorRange { get; private set; }
-        public bool SpaceCombatNearPlanet { get; private set; } // FB - warning - this will be false if there is owner for the planet
+        public bool SpaceCombatNearPlanet { get; private set; } // FB - warning - this will be false if there is no owner for the planet
         public float ColonyValue { get; private set; }
         public float ExcessGoodsIncome { get; private set; } // FB - excess goods tax for empire to collect
         public float SpaceDefMaintenance { get; private set; }
@@ -597,7 +597,7 @@ namespace Ship_Game
                 PlanetUpdatePerTurnTimer = Universe.P.TurnTimer;
                 UpdateBaseFertility();
                 UpdateDynamicBuildings();
-                Mend(((int)InfraStructure + Level).Clamped(1, 10));
+                Mend(SpaceCombatNearPlanet || RecentCombat ? 1 : (int)(InfraStructure + Level).Clamped(1, 10));
             }
 
             Troops.Update(timeStep);
@@ -883,6 +883,7 @@ namespace Ship_Game
             if (ShieldStrengthCurrent == 0 && Shield != null)
                 Shield = null;
         }
+
         public bool CanRepairOrHeal()
         {
             return BombingIntensity == 0 || Random.RollDice(100 - BombingIntensity);

--- a/Ship_Game/Universe/SolarBodies/SolarSystemBody.cs
+++ b/Ship_Game/Universe/SolarBodies/SolarSystemBody.cs
@@ -68,7 +68,7 @@ namespace Ship_Game
             DamageBuildings(hardDamage, bomb.ShipLevel);
             TryCreateVolcano(hardDamage);
             Surface.ApplyBombEnvEffects(popKilled, envDamage, bomb.Owner); // Fertility and pop loss
-            Surface.AddBombingIntensity(hardDamage);
+            Surface.AddBombingIntensity(hardDamage*2);
         }
 
         void TryCreateVolcano(int hardDamage)

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
@@ -750,7 +750,7 @@ namespace Ship_Game
                 Ship ship = ships[i];
                 if (ship.InFrustum && ship.InPlayerSensorRange)
                 {
-                        if ((viewState > UnivScreenState.ShipView || ShowingFTLOverlay || !ship.HasSO) && !IsCinematicModeEnabled)
+                        if (!IsCinematicModeEnabled)
                             DrawTacticalIcon(ship);
 
                         DrawOverlay(ship);
@@ -820,7 +820,6 @@ namespace Ship_Game
         void DrawTacticalIcon(Ship ship)
         {
             if (!LookingAtPlanet && (!ship.IsSubspaceProjector || ShowingFTLOverlay))  
-                                  
             {
                 ship.DrawTacticalIcon(this, viewState);
             }

--- a/UnitTests/Ships/CarrierTests.cs
+++ b/UnitTests/Ships/CarrierTests.cs
@@ -216,7 +216,7 @@ namespace UnitTests.Ships
 
             // NOTE: This requires Carrier to have low ordnance production capability
             ResupplyReason resupplyReason = Carrier.Supply.Resupply();
-            AssertEqual(resupplyReason, ResupplyReason.LowOrdnanceNonCombat, "Carrier should want to resupply non combat");
+            AssertEqual(resupplyReason, ResupplyReason.LowOrdnanceCombatOrDepleted, "Carrier should want to resupply depleted");
 
             Carrier.ChangeOrdnance(Carrier.OrdinanceMax); // add all ordnance
             AssertEqual(Carrier.Ordinance, Carrier.OrdinanceMax, "Carrier ordnance storage should be full");

--- a/UnitTests/Ships/TestResupplyLogic.cs
+++ b/UnitTests/Ships/TestResupplyLogic.cs
@@ -49,7 +49,7 @@ namespace UnitTests.Ships
 
             OurShip.ChangeOrdnance(-OurShip.OrdinanceMax);
             resupplyReason = OurShip.Supply.Resupply();
-            Assert.IsTrue(resupplyReason == ResupplyReason.LowOrdnanceNonCombat, "Ship should need resupply for low ordnance not in combat");
+            Assert.IsTrue(resupplyReason == ResupplyReason.LowOrdnanceCombatOrDepleted, "Ship should need resupply for low ordnance depleted");
             OurShip.AI.ProcessResupply(resupplyReason);
             Assert.IsTrue(OurShip.AI.IgnoreCombat, "Ship should ignore combat after processing resupply");
             Assert.IsTrue(OurShip.AI.HasPriorityOrder, "Ship should have a priority order when resupplying");
@@ -88,7 +88,7 @@ namespace UnitTests.Ships
 
             OurShip.ChangeOrdnance(-2); // Now go below he combat threshold
             resupplyReason = OurShip.Supply.Resupply();
-            Assert.IsTrue(resupplyReason == ResupplyReason.LowOrdnanceCombat, "Ship should need resupply if ordnance below combat threshold");
+            Assert.IsTrue(resupplyReason == ResupplyReason.LowOrdnanceCombatOrDepleted, "Ship should need resupply if ordnance below combat threshold");
         }
 
         [TestMethod]

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -12303,8 +12303,8 @@ EmpireRelationships:
  UKR: "Перехресні посилання на імперські відносини"
 ViewWarsOrAlliancesName:
  Id: 4350
- ENG: "View Wars or Alliances"
- UKR: "Переглянути війни або альянси"
+ ENG: "View Only Wars or Alliances"
+ UKR: "Перегляньте лише війни чи союзи"
 ViewWarsOrAlliancesTip:
  Id: 4351
  ENG: "Filters out non War or Alliances links"

--- a/game/Content/ShipDesigns/Remnant/Ancient Assimilator.design
+++ b/game/Content/ShipDesigns/Remnant/Ancient Assimilator.design
@@ -12,6 +12,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=1
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=AncientArmor_3x3;AncientArmor_2x2;Sensor1x2;AncientArmor_1x1;LaserCannon;EnergyPDRapid;MarineBarracks6x3;EnergyPDHeavy;TroopAssaultBay;AdvAmplifier;EMPTurret3x3;AncientShield_3x3;Amplifier;Bridge;SiphonBeam2x3;Main Engineering;ThalaronBeam2x3;AncientReactorMed;AncientShield2kw;RemnantSmallReactor;Reinforced Bulkhead;TractorBeamTurret2x2;Internal Bulkhead;RemnantEngine1;RemnantEngine3
 Modules=131

--- a/game/Content/ShipDesigns/Remnant/Ancient Battleship.design
+++ b/game/Content/ShipDesigns/Remnant/Ancient Battleship.design
@@ -11,6 +11,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=3
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=AncientArmor_3x3;AncientArmor_2x2;EnergyPDRapid;Amplifier;Pulse Capacitor;AncientArmor_1x1;HVTurret_3x3;AncientShield_3x3;RemnantSmallFuelCell;IonCannon1x3;QTCannon;DisintegratorArray;Bridge;MarineBarracks2x2;RemnantPort;Main Engineering;Sensor1x2;RemnantNuker;AncientReactorMed;RemnantEngine1;WarpEngine_3x3;RemnantEngine3
 Modules=102

--- a/game/Content/ShipDesigns/Remnant/Ancient Bomber.design
+++ b/game/Content/ShipDesigns/Remnant/Ancient Bomber.design
@@ -12,6 +12,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=1
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=Crystal Armor Large;Crystal Armor Med;PhasorTurret2x2;RemnantSmallFuelCell;MarineBarracks2x2;NuclearBombBay2x2;AncientShield_3x3;PolaronTurret4x4;Bridge;AncientReactorMed;LaserCannon;Main Engineering;Fabricator;IonCannon1x3;Crystal Armor Small;RemnantSmallReactor;EnergyPDHeavy;RemnantEngine1;RemnantEngine3
 Modules=125

--- a/game/Content/ShipDesigns/Remnant/Ancient Carrier.design
+++ b/game/Content/ShipDesigns/Remnant/Ancient Carrier.design
@@ -12,6 +12,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=3
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=AncientArmor_3x3;AncientArmor_2x2;AncientShield2kw;AncientArmor_1x1;Amplifier;Raider Bay;RemnantNuker;FighterBay;Bridge;RemnantHV2x3;Main Engineering;AncientShield_3x3;OrdnanceLockerSmall;RemnantSmallFuelCell;Fabricator;AncientReactorMed;EnergyPDHeavy;EnergyPDRapid;RemnantEngine1;WarpEngine_1x1;DarkMatterCannon_1x2;RemnantEngine3
 Modules=116

--- a/game/Content/ShipDesigns/Remnant/Ancient Cruiser.design
+++ b/game/Content/ShipDesigns/Remnant/Ancient Cruiser.design
@@ -12,6 +12,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=1
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=CompositeAlloys Large;CompositeAlloys Med;AdvancedCellSmall;Pulse Capacitor;BosonTransmiter;PhasorTurret2x2;AdvancedCellMed;MarineBarracks2x2;CompositeAlloys Small;PolaronTurret4x4;RemnantSmallReactor;AncientShield_3x3;DisintegratorArray;AncientReactorMed;Bridge;EnergyPDHeavy;EnergyPDRapid;RemnantEngine1;RemnantEngine3
 Modules=135

--- a/game/Content/ShipDesigns/Remnant/Ancient Frigate.design
+++ b/game/Content/ShipDesigns/Remnant/Ancient Frigate.design
@@ -12,6 +12,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=0.05
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=PlaSteelArmorMed;PlaSteelArmorSmall;FusionTurret2x2;RemnantSmallFuelCell;RemnantDrisruptor_2x2;AncientShield2kw;EnergyPDHeavy;EnergyPDRapid;IonCannon1x3;AncientReactorMed;Reinforced Bulkhead;MarineBarracks2x2;RemnantSmallReactor;Bridge;RemnantEngine1;RemnantEngine2
 Modules=78

--- a/game/Content/ShipDesigns/Remnant/Ancient Torpedo Cruiser.design
+++ b/game/Content/ShipDesigns/Remnant/Ancient Torpedo Cruiser.design
@@ -12,6 +12,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=1
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=AncientArmor_3x3;AncientArmor_2x2;EnergyPDHeavy;Amplifier;EnergyPDRapid;Pulse Capacitor;AncientArmor_1x1;QTCannon;RemnantHV2x3;RemnantSmallFuelCell;AncientShield_3x3;Fabricator;IonCannon1x3;Bridge;MarineBarracks2x2;DarkMatterCannon_1x2;Main Engineering;Sensor1x2;RemnantNuker;AncientReactorMed;RemnantEngine1;WarpEngine_3x3;RemnantEngine3
 Modules=93

--- a/game/Content/ShipDesigns/Remnant/Battle Drone.design
+++ b/game/Content/ShipDesigns/Remnant/Battle Drone.design
@@ -11,6 +11,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=0.03
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=AncientArmor_1x1;RemnantDrisruptor_2x2;Amplifier;Cockpit;AncientShield2kw;AncientReactorMed;RemnantEngine1;RemnantEngine2
 Modules=23

--- a/game/Content/ShipDesigns/Remnant/Beam Drone.design
+++ b/game/Content/ShipDesigns/Remnant/Beam Drone.design
@@ -11,6 +11,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=0.03
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=AncientArmor_1x1;Amplifier;Cockpit;FusionTurret2x2;IonCannon1x2;AncientShield2kw;LaserCannon;AncientReactorMed;RemnantEngine1;RemnantEngine2
 Modules=27

--- a/game/Content/ShipDesigns/Remnant/Behemoth.design
+++ b/game/Content/ShipDesigns/Remnant/Behemoth.design
@@ -11,6 +11,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=20
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=AncientArmorV2_1x1;AncientArmorV2_3x3;AncientArmorV2_2x2;REDisintegratorArray;RemnantSmallReactor;Maneuvering_Thruster_1x4;BosonTransmiter;LRMmk3;AntiMatterReactor;EMPTurret2x2;ConventionalTorpedo;RepairDrone;AdvancedCellSmall;Main Engineering;Inertial Damper;RemnantNuker;Phalanx PD;Internal Bulkhead;CanopyShield;FlakAA Cannon;Warp Inhibitor;PolaronTurret3x3;Aegis;Crystal Armor Small;PolaronTurret4x4;AdvancedCellMed;CIC;MarineBarracks6x3;OrdnanceLockerSmall;RemnantPort;AdvAmplifier;OrdnanceLocker;Pulse Capacitor;SubspaceSensors;RemnantEngine4
 Modules=1025

--- a/game/Content/ShipDesigns/Remnant/Captured Gunship.design
+++ b/game/Content/ShipDesigns/Remnant/Captured Gunship.design
@@ -12,6 +12,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=0.03
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=SteelArmorSmall;Sensor1x2;DarkMatterCannon_1x2;AncientShield2kw;RemnantSmallReactor;AncientReactorMed;Cockpit;RemnantEngine2
 Modules=27

--- a/game/Content/ShipDesigns/Remnant/Heavy Drone.design
+++ b/game/Content/ShipDesigns/Remnant/Heavy Drone.design
@@ -11,6 +11,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=0.03
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=PlaSteelArmorSmall;Amplifier;Cockpit;RemnantHV2x3;AncientShield2kw;AncientReactorMed;RemnantEngine1;RemnantEngine2
 Modules=25

--- a/game/Content/ShipDesigns/Remnant/Hvy Drone Mk IV.design
+++ b/game/Content/ShipDesigns/Remnant/Hvy Drone Mk IV.design
@@ -12,6 +12,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=0.03
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=AncientArmor_1x1;Amplifier;RemnantDrisruptor_2x2;AncientShield2kw;AncientReactorMed;Cockpit;RemnantEngine2
 Modules=26

--- a/game/Content/ShipDesigns/Remnant/Light Ancient Bomber.design
+++ b/game/Content/ShipDesigns/Remnant/Light Ancient Bomber.design
@@ -12,6 +12,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=0.03
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=PlaSteelArmorSmall;OrdnanceLockerSmall;NuclearBombBay2x2;DarkMatterCannon_1x2;AncientShield2kw;Amplifier;AncientReactorMed;Cockpit;RemnantEngine2
 Modules=24

--- a/game/Content/ShipDesigns/Remnant/Medium Ancient Bomber.design
+++ b/game/Content/ShipDesigns/Remnant/Medium Ancient Bomber.design
@@ -12,6 +12,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=0.05
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=AncientArmor_2x2;AncientArmor_1x1;RemnantDrisruptor_2x2;RemnantHV2x3;NuclearBombBay2x2;AncientReactorMed;AdvAmplifier;AdvancedCellSmall;Cockpit;AncientShield2kw;Fabricator;Bridge;LaserCannon;Ceramic Armor Small;RemnantEngine2;RemnantEngine1
 Modules=74

--- a/game/Content/ShipDesigns/Remnant/Remnant Exterminator.design
+++ b/game/Content/ShipDesigns/Remnant/Remnant Exterminator.design
@@ -11,6 +11,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=3
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=Crystal Armor Small;Crystal Armor Large;AdvancedCellSmall;Crystal Armor Med;PhasorTurret3x3;Pulse Capacitor;LRMmk3;BosonTransmiter;AncientShield_3x3;RemnantNuker;SubspaceSensors;Raider Bay;PolaronTurret4x4;REDisintegratorArray;AdvancedCellMed;OrdnanceLockerSmall;LargeFabricator;Main Engineering;RemnantSmallReactor;Reinforced Bulkhead;CIC;OrdnanceLocker;AntiMatterReactor;PolaronTurret3x3;PhasorTurret4x4;Internal Bulkhead;RemnantHV2x3;PhasorTurret2x2;Bridge;MarineBarracks6x3;EnergyPDRapid;RemnantEngine1;RepairDrone;EnergyPDHeavy;RemnantEngine4;RemnantEngine3
 Modules=380

--- a/game/Content/ShipDesigns/Remnant/Remnant Inhibitor.design
+++ b/game/Content/ShipDesigns/Remnant/Remnant Inhibitor.design
@@ -12,6 +12,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=1
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=Crystal Armor Large;Crystal Armor Med;RemnantNuker;Ceramic Armor Med;Crystal Armor Small;RemnantSmallFuelCell;PhasorTurret3x3;AncientShield_3x3;Ceramic Armor Small;PhasorTurret2x2;PhotonTurret4x4;Warp Inhibitor;AdvancedCellMed;Bridge;Main Engineering;RemnantSmallReactor;OrdnanceLockerSmall;EnergyPDHeavy;AncientReactorMed;Fabricator;EnergyPDRapid;RemnantEngine4
 Modules=113

--- a/game/Content/ShipDesigns/Remnant/Remnant Mothership.design
+++ b/game/Content/ShipDesigns/Remnant/Remnant Mothership.design
@@ -11,6 +11,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=5
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=Crystal Armor Small;Crystal Armor Med;Crystal Armor Large;PolaronTurret4x4;OrdnanceLockerSmall;RemnantNuker;LRMmk2;MarineBarracks6x3;SubspaceSensors;EnergyPDHeavy;AdvancedCellMed;Main Engineering;AncientShield_3x3;EMPTurret3x3;Pulse Capacitor;AdvancedCellSmall;REDisintegratorArray;Sickbay;AdvAmplifier;AncientArmor_1x1;Reinforced Bulkhead;TroopAssaultBay;AntiMatterReactor;DarkMatterCannon_1x2;CanopyShield;RemnantPort;RepairDrone;BosonTransmiter;RemnantHV2x3;CIC;Bridge;PhasorTurret3x3;HVTurret_3x3;Engine;AncientShield2kw;RemnantEngine2;RemnantEngine3;IonCannon1x3;RemnantEngine4;EnergyPDRapid
 Modules=374

--- a/game/Content/ShipDesigns/Remnant/Remnant Portal.design
+++ b/game/Content/ShipDesigns/Remnant/Remnant Portal.design
@@ -11,6 +11,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=20
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=AncientArmorV2_3x3;AncientArmorV2_1x1;AdvancedCellMed;REAegis;AdvancedCellSmall;PhasorTurret2x2;AncientShield2kw;ArmoredMissile;Pulse Capacitor;OrdnanceLocker;PolaronTurret3x3;BosonTransmiter;MarineBarracks8x4;RemnantPort;AncientShield_3x3;OrdnanceLockerSmall;LaserCannon;PlasmaThrower;Phalanx PD;CanopyShield;Main Engineering;PolaronTurret4x4;Amplifier;AncientArmorV2_2x2;Fabricator;RepairDrone;CIC;AntiMatterReactor;AdvAmplifier;EMPTurret3x3;PowerConduit;PhotonTurret3x3;Internal Bulkhead;Crystal Armor Small;SubspaceSensors;LargeOrdStorage
 Modules=791

--- a/game/Content/ShipDesigns/Remnant/Remnant Slaver.design
+++ b/game/Content/ShipDesigns/Remnant/Remnant Slaver.design
@@ -12,6 +12,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=1
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=CompositeAlloys Large;CompositeAlloys Med;RemnantSmallFuelCell;CompositeAlloys Small;Pulse Capacitor;AdvAmplifier;LaserCannon;TroopAssaultBay;PowerConduit;BosonTransmiter;AncientShield_3x3;EMPTurret3x3;SiphonBeam2x3;Bridge;AncientReactorMed;MarineBarracks6x3;ThalaronBeam2x3;Amplifier;AncientShield2kw;EMPTurret2x2;Engine;WarpEngine_3x3;RemnantEngine3
 Modules=131

--- a/game/Content/ShipDesigns/Remnant/Support Drone.design
+++ b/game/Content/ShipDesigns/Remnant/Support Drone.design
@@ -12,6 +12,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=0.03
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=RepairDrone;AncientArmor_1x1;RemnantDrisruptor_2x2;AncientReactorMed;Cockpit;OrdnanceLockerSmall;AncientShield2kw;RemnantEngine1;RemnantEngine2
 Modules=23

--- a/game/Content/ShipDesigns/Remnant/Xeno Fighter.design
+++ b/game/Content/ShipDesigns/Remnant/Xeno Fighter.design
@@ -12,6 +12,7 @@ HangarDesignation=General
 IsShipyard=false
 IsOrbitalDefense=false
 IsCarrierOnly=false
+FixedUpkeep=0.01
 # Maps module UIDs to Index, first UID has index 0
 ModuleUIDs=DarkMatterCannon_1x2;PlaSteelArmorSmall;Cockpit;RemnantSmallReactor;Fighter Shield;RemnantEngine1;Amplifier
 Modules=12


### PR DESCRIPTION
Fix: Always display trade lines in relationship cross reference if the trade treaties checkbox is checked.
Fix: No ship status icon drawn. 
Fix: ships with very low ordnance could take players command to return to attack
Fix: Planets chance of repairing building and heal troops was increasing too fast while in combat.
Balance: Intensity of Espionage Rebellions
Fix: AI fleets disengage if remnant helpers target the system they are attacking.
Fix: Fixed Upkeep cost for remnant ships for RemnantHelpers story