### PR TITLE
Mars 1.50

### DIFF
--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -90,7 +90,6 @@ namespace Ship_Game
 
         [StarData] public bool isPlayer;
         [StarData] public bool IsDefeated { get; private set; }
-
         public float TotalShipMaintenance { get; private set; }
         public float TotalWarShipMaintenance { get; private set; }
         public float TotalCivShipMaintenance { get; private set; }
@@ -99,6 +98,7 @@ namespace Ship_Game
         public float TotalMaintenanceInScrap { get; private set; }
         public float TotalTroopShipMaintenance { get; private set; }
         public float NetPlanetIncomes { get; private set; }
+        public float ExoticCreditsBonus { get; private set; } = 1;
         public float TroopCostOnPlanets { get; private set; } // Maintenance in all Owned planets
         public float TroopInSpaceFoodNeeds { get; private set; }
         public float TotalFoodPerColonist { get; private set; }
@@ -1345,20 +1345,9 @@ namespace Ship_Game
             UpdateNetPlanetIncomes();
             UpdateShipMaintenance();
             UpdatePlanetStorageStats();
-            float incomeFromExoticBonus = GetIncomeFromExoticBonus();
-            float remainingMoney = MoneyAfterLeech(NetIncome + incomeFromExoticBonus);
             EspionageCostLastTurn = LegacyEspionageEnabled ? 0 : GetEspionageCost();
+            float remainingMoney = MoneyAfterLeech(NetIncome);
             AddMoney(remainingMoney - EspionageCostLastTurn);
-        }
-
-        float GetIncomeFromExoticBonus()
-        {
-            float exoticBonus = GetStaticExoticBonusMuliplier(ExoticBonusType.Credits);
-            exoticBonus = NetPlanetIncomes < 0 ? 1 / exoticBonus : exoticBonus;
-            float planetIncomeWithBonus = NetPlanetIncomes > 0 
-                ? NetPlanetIncomes*exoticBonus - NetPlanetIncomes
-                : NetPlanetIncomes * exoticBonus;
-            return planetIncomeWithBonus;
         }
 
         float MoneyAfterLeech(float money)
@@ -1396,6 +1385,7 @@ namespace Ship_Game
             PotentialIncome               = 0;
             TotalFoodPerColonist          = 0;
 
+            ExoticCreditsBonus = GetStaticExoticBonusMuliplier(ExoticBonusType.Credits);
             for (int i = 0; i < OwnedPlanets.Count; i++)
             {
                 Planet p = OwnedPlanets[i];

--- a/Ship_Game/GameScreens/DiplomacyScreen/RelationshipsDiagramScreen.cs
+++ b/Ship_Game/GameScreens/DiplomacyScreen/RelationshipsDiagramScreen.cs
@@ -176,12 +176,22 @@ namespace Ship_Game.GameScreens.DiplomacyScreen
                 else if (rel.Treaty_NAPact)
                     DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorNap);
             }
+<<<<<<< HEAD
 
             if (rel.AtWar)
                 DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorWar, thickness: 3);
             else if (rel.Treaty_Alliance)
                 DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorAlly, thickness: 3);
             
+=======
+            else
+            {
+                if (rel.AtWar)
+                    DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorWar, thickness: 3);
+                else if (rel.Treaty_Alliance)
+                    DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorAlly, thickness: 3);
+            }
+>>>>>>> 90cccf444 (Fix: Always display trade lines in relationship  cross reference if the trade treaties checkbox is checked.)
         }
 
         void DrawPeerLine(SpriteBatch batch, Vector2 pos1, Vector2 pos2, Color color, int thickness = 1)

--- a/Ship_Game/GameScreens/DiplomacyScreen/RelationshipsDiagramScreen.cs
+++ b/Ship_Game/GameScreens/DiplomacyScreen/RelationshipsDiagramScreen.cs
@@ -176,22 +176,11 @@ namespace Ship_Game.GameScreens.DiplomacyScreen
                 else if (rel.Treaty_NAPact)
                     DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorNap);
             }
-<<<<<<< HEAD
 
             if (rel.AtWar)
                 DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorWar, thickness: 3);
             else if (rel.Treaty_Alliance)
                 DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorAlly, thickness: 3);
-            
-=======
-            else
-            {
-                if (rel.AtWar)
-                    DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorWar, thickness: 3);
-                else if (rel.Treaty_Alliance)
-                    DrawPeerLine(batch, us.LinkPos, peer.LinkPos, ColorAlly, thickness: 3);
-            }
->>>>>>> 90cccf444 (Fix: Always display trade lines in relationship  cross reference if the trade treaties checkbox is checked.)
         }
 
         void DrawPeerLine(SpriteBatch batch, Vector2 pos1, Vector2 pos2, Color color, int thickness = 1)

--- a/Ship_Game/Universe/InfluenceTree.cs
+++ b/Ship_Game/Universe/InfluenceTree.cs
@@ -35,7 +35,7 @@ namespace Ship_Game.Universe
             WorldOrigin = -(universeWidth/2);
 
             CellSize = (float)Math.Floor(projectorRadius * 1.5f * 1000) / 1000;
-            Size = (int)Math.Ceiling(WorldSize / CellSize);
+            Size = (int)Math.Ceiling(WorldSize / CellSize) + 1;
 
             Clear();
         }

--- a/Ship_Game/Universe/SolarBodies/ColonyResource.cs
+++ b/Ship_Game/Universe/SolarBodies/ColonyResource.cs
@@ -327,7 +327,8 @@ namespace Ship_Game.Universe.SolarBodies
             TaxRate     *= taxRateMultiplier;
             Maintenance *= Planet.Owner.data.Traits.MaintMultiplier;
 
-            GrossRevenue = ((Planet.PopulationBillion * IncomePerColonist) + IncomeFromBuildings) * TaxRate;
+            float grossRevenue = ((Planet.PopulationBillion * IncomePerColonist) + IncomeFromBuildings) * TaxRate;
+            GrossRevenue = grossRevenue > 0 ? grossRevenue * Planet.Owner.ExoticCreditsBonus : grossRevenue;
             NetRevenue   = GrossRevenue - Maintenance;
 
             // Needed for empire treasury goal

--- a/game/Content/Goods/Goods.yaml
+++ b/game/Content/Goods/Goods.yaml
@@ -55,7 +55,7 @@ Good:
   IsGasGiantMineable: true  
   ExoticBonusType: Credits  
   MaxBonus: 0.5
-  ConsumptionMultiplier: 0.03
+  ConsumptionMultiplier: 0.12
 Good:
   UID: Fortifume
   RefiningRatio: 0.5


### PR DESCRIPTION
Fix: Positive x and y edge systems were not having influence cells
Balance: Switched Luxarium to affect the gross credit income instead of the net income per planet.