### PR TITLE
Mars 1.51

### DIFF
--- a/Ship_Game/AI/EmpireAI/Budget.cs
+++ b/Ship_Game/AI/EmpireAI/Budget.cs
@@ -61,7 +61,7 @@ namespace Ship_Game.AI.Budget
             TotalAlloc     = GrdDefAlloc + SpcDefAlloc + CivilianAlloc;
         }
 
-        public float CivilianTolerance => (-CivilianAlloc * 0.1f).RoundToFractionOf10();
+        public float CivilianTolerance => (CivilianAlloc * 0.1f).RoundToFractionOf10().LowerBound(0.1f);
 
         public float GroundDefTolerance => (-GrdDefAlloc * 0.1f).RoundToFractionOf10();
 

--- a/Ship_Game/AI/EmpireAI/Budget.cs
+++ b/Ship_Game/AI/EmpireAI/Budget.cs
@@ -45,7 +45,7 @@ namespace Ship_Game.AI.Budget
             float defenseBudget = EmpireDefenseBudget * defenseRatio;
             float groundRatio   = MilitaryBuildingsBudgetRatio();
             float orbitalRatio  = 1 - groundRatio;
-            float civBudget     = EmpireColonizationBudget * EmpireRatio + P.GetColonyDebtTolerance() + P.TerraformBudget;
+            float civBudget     = EmpireColonizationBudget * EmpireRatio + P.GetColonyInitialBudgetTolerance() + P.TerraformBudget;
             float grdBudget     = defenseBudget * groundRatio;
             if (!Owner.isPlayer && P.System.HostileForcesPresent(Owner))
                 grdBudget *= 3; // Try to add more temp ground defense to clear enemies
@@ -60,6 +60,12 @@ namespace Ship_Game.AI.Budget
             TotalRemaining = RemainingSpaceDef + RemainingGroundDef + RemainingCivilian; // total remaining budget for this planet
             TotalAlloc     = GrdDefAlloc + SpcDefAlloc + CivilianAlloc;
         }
+
+        public float CivilianTolerance => (-CivilianAlloc * 0.1f).RoundToFractionOf10();
+
+        public float GroundDefTolerance => (-GrdDefAlloc * 0.1f).RoundToFractionOf10();
+
+        public float SpaceDefTolerance => (-SpcDefAlloc * 0.1f).RoundToFractionOf10();
 
         public void UpdateManualUI()
         {

--- a/Ship_Game/AI/EmpireAI/EmpireAI.RunEconomicPlanner.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.RunEconomicPlanner.cs
@@ -45,9 +45,6 @@ namespace Ship_Game.AI
         public bool SafeToRush => CreditRating > 0.8f;
         public bool SafeToRushColonyShips => OwnerEmpire.IsExpansionists ? CreditRating > 0.5f : CreditRating > 0.6f;
 
-        // Empire spaceDefensive Reserves high enough to support fractional build budgets
-        public bool EmpireCanSupportSpcDefense => DefenseBudget > OwnerEmpire.TotalOrbitalMaintenance && CreditRating > 0.9f;
-
         /// <summary>
         /// This is the budgeted amount of money that will be available to empire looking over 20 years.
         /// </summary>

--- a/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
@@ -614,7 +614,7 @@ namespace Ship_Game.AI
             return Owner.SensorRange;
         }
 
-        void EnterCombatState(AIState combatState)
+        void EnterCombatState(AIState combatState, bool pushToFront = true)
         {
             if (!Owner.InCombat)
             {
@@ -634,7 +634,7 @@ namespace Ship_Game.AI
                 default:
                     if (!FindGoal(Plan.DoCombat, out ShipGoal _))
                     {
-                        AddShipGoal(Plan.DoCombat, combatState, pushToFront: true);
+                        AddShipGoal(Plan.DoCombat, combatState, pushToFront);
                     }
                     break;
 

--- a/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
@@ -694,7 +694,7 @@ namespace Ship_Game.AI
                         Owner.Mothership.LoadCargo(cargoId, Owner.GetOtherCargo(cargoId).UpperBound(maxToload));
                     }
                 }
-
+                Owner.Carrier.ScuttleHangarShips();
                 Owner.Mothership.ChangeOrdnance(Owner.ShipRetrievalOrd); // Get back the ordnance it took to launch the ship
                 Owner.QueueTotalRemoval();
                 

--- a/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
@@ -5,7 +5,6 @@ using Ship_Game.ExtensionMethods;
 using Ship_Game.Gameplay;
 using Ship_Game.Ships;
 using Ship_Game.Ships.AI;
-using Ship_Game.Ships.Components;
 using static Ship_Game.AI.ShipAI;
 using Vector2 = SDGraphics.Vector2;
 
@@ -116,18 +115,29 @@ namespace Ship_Game.AI
 
             Intercepting = true;
             ClearWayPoints();
-            Target = toAttack;
             IgnoreCombat = false;
 
             //HACK. To fix this all the fleet tasks that use attackspecifictarget must be changed
             //if they also use hold position to keep ships from moving.
             if (!Owner.Loyalty.isPlayer)
                 CombatState = Owner.ShipData.DefaultCombatState;
-            TargetQueue.Add(toAttack);
-            HasPriorityTarget = true;
-
             ClearOrders();
-            EnterCombatState(AIState.AttackTarget);
+            bool overshot = false;
+            if (Owner.Loyalty.isPlayer && Owner.IsInWarp)
+            {
+                Vector2 correcedPos = HelperFunctions.GetWarpOvershootMovePosWithAudio(Owner, PotentialTargets, toAttack.Position);
+                if (correcedPos != toAttack.Position)
+                {
+                    OrderMoveToNoStop(correcedPos, Owner.Direction, AIState.MoveTo, MoveOrder.Regular);
+                    SetPriorityOrder(false);
+                    overshot = true;
+                }
+            }
+
+            TargetQueue.Add(toAttack);
+            Target = toAttack;
+            HasPriorityTarget = true;
+            EnterCombatState(AIState.AttackTarget, pushToFront: !overshot);
         }
 
         public void OrderBombardPlanet(Planet toBombard, bool clearOrders)

--- a/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
@@ -602,6 +602,7 @@ namespace Ship_Game.AI
         public void OrderReturnToHangar()
         {
             ClearOrders(AIState.ReturnToHangar, priority: true);
+            Owner.Carrier.RecoverFighters();
             AddShipGoal(Plan.ReturnToHangar, AIState.ReturnToHangar);
         }
 

--- a/Ship_Game/EmpireDifficultyModifers.cs
+++ b/Ship_Game/EmpireDifficultyModifers.cs
@@ -113,7 +113,7 @@
                     WarSneakiness        = 0;
                     HullTechMultiplier   = 1f;
                     MiningOpsTurnsPerRun = 10;
-                    RemnantPortalCreationMod = 10;
+                    RemnantPortalCreationMod = 12;
                     CombatShipGoalsPerPlanet = 3;
                     break;
                 case GameDifficulty.Hard:
@@ -148,7 +148,7 @@
                     WarSneakiness        = 10;
                     HullTechMultiplier   = 0.85f;
                     MiningOpsTurnsPerRun = 7;
-                    RemnantPortalCreationMod = 6;
+                    RemnantPortalCreationMod = 10;
                     CombatShipGoalsPerPlanet = 4;
                     if (!empire.isPlayer)
                     {
@@ -194,7 +194,7 @@
                     WarSneakiness        = 25;
                     HullTechMultiplier   = 0.7f;
                     MiningOpsTurnsPerRun = 5;
-                    RemnantPortalCreationMod = 5;
+                    RemnantPortalCreationMod = 6;
                     CombatShipGoalsPerPlanet = 5;
                     if (!empire.isPlayer)
                     {
@@ -242,7 +242,7 @@
                     WarSneakiness        = 40;
                     HullTechMultiplier   = 0.6f;
                     MiningOpsTurnsPerRun = 3;
-                    RemnantPortalCreationMod = 4;
+                    RemnantPortalCreationMod = 5;
                     CombatShipGoalsPerPlanet = 6;
                     if (!empire.isPlayer)
                     {

--- a/Ship_Game/Empire_Trade.cs
+++ b/Ship_Game/Empire_Trade.cs
@@ -109,9 +109,9 @@ namespace Ship_Game
             // Cybernetic factions never touch Food trade. Filthy Opteris are disgusted by protein-bugs. Ironic.
             if (tradeState.HasFreeFreighters && (!isPlayer || Universe.P.AllowPlayerInterTrade))
             {
-                Ship[] idleFrieghters = tradeState.IdleFreighters.ToArr();
+                Ship[] idleFreighters = tradeState.IdleFreighters.ToArr();
                 tradeState = new(this, true);
-                tradeState.SetIdleFreighters(idleFrieghters);
+                tradeState.SetIdleFreighters(idleFreighters);
                 var interTradePlanets = TradingEmpiresPlanetList();
                 if (interTradePlanets.Count > 0)
                 {

--- a/Ship_Game/Empire_Trade.cs
+++ b/Ship_Game/Empire_Trade.cs
@@ -143,7 +143,7 @@ namespace Ship_Game
 
             public TradeState(Empire owner,  bool interTrade)
             {
-                IdleFreighters = new Ship[0];
+                IdleFreighters = Array.Empty<Ship>();
                 State = EmpireIdleFreighters.Fetch;
                 InterTrade = interTrade;
                 Owner = owner;
@@ -303,7 +303,7 @@ namespace Ship_Game
                 return;
 
             // Order importing planets to balance freighters distribution
-            Planet[] importingPlanets = new Planet[0]; 
+            Planet[] importingPlanets = Array.Empty<Planet>();
             if (state.HasImportPlanetOf(goods))
             {
                 importingPlanets = importPlanetList.Filter(p => p.FreeGoodsImportSlots(goods) > 0);
@@ -318,7 +318,7 @@ namespace Ship_Game
                 return;
             }
 
-            Planet[] exportingPlanets = new Planet[0];
+            Planet[] exportingPlanets = Array.Empty<Planet>();
             if (state.HasExportPlanetOf(goods))
             {
                 // TODO: maybe use IEnumerable generators for these?

--- a/Ship_Game/Empire_Trade.cs
+++ b/Ship_Game/Empire_Trade.cs
@@ -77,43 +77,180 @@ namespace Ship_Game
             AllTimeTradeIncome      += (int)taxedGoods;
         }
 
-        // once per turn 
+        // once per turn with 3 passes if possible
         void DispatchBuildAndScrapFreighters()
         {
             UpdateTradeTreaties();
+            TradeState tradeState = new(this, false);
+            for (int i = 1; i <= 3; i++)
+            {
+                if (tradeState.NoFreeFreighters)
+                    break;
+
+                if (NonCybernetic)
+                    DispatchOrBuildFreighters(Goods.Food, OwnedPlanets, false, ref tradeState);
+
+                float popRatio = TotalPopBillion / MaxPopBillion;
+                float productionFirstChance = popRatio * (NonCybernetic ? 200 : 300);
+                if (Random.RollDice(productionFirstChance))
+                {
+                    DispatchOrBuildFreighters(Goods.Production, OwnedPlanets, false, ref tradeState);
+                    DispatchOrBuildFreighters(Goods.Colonists, OwnedPlanets, false, ref tradeState);
+                }
+                else
+                {
+                    DispatchOrBuildFreighters(Goods.Colonists, OwnedPlanets, false, ref tradeState);
+                    DispatchOrBuildFreighters(Goods.Production, OwnedPlanets, false, ref tradeState);
+                }
+
+                tradeState.UpdatePlanetsTradeGoods();
+            }
 
             // Cybernetic factions never touch Food trade. Filthy Opteris are disgusted by protein-bugs. Ironic.
-            if (NonCybernetic)
-                DispatchOrBuildFreighters(Goods.Food, OwnedPlanets, false);
-
-            float popRatio              = TotalPopBillion / MaxPopBillion;
-            float productionFirstChance = popRatio * (NonCybernetic ? 200 : 300);
-            if (Random.RollDice(productionFirstChance))
+            if (tradeState.HasFreeFreighters && (!isPlayer || Universe.P.AllowPlayerInterTrade))
             {
-                DispatchOrBuildFreighters(Goods.Production, OwnedPlanets, false);
-                DispatchOrBuildFreighters(Goods.Colonists, OwnedPlanets, false);
-            }
-            else
-            {
-                DispatchOrBuildFreighters(Goods.Colonists, OwnedPlanets, false);
-                DispatchOrBuildFreighters(Goods.Production, OwnedPlanets, false);
-            }
-
-            if (!isPlayer || Universe.P.AllowPlayerInterTrade)
-            {
+                Ship[] idleFrieghters = tradeState.IdleFreighters.ToArr();
+                tradeState = new(this, true);
+                tradeState.SetIdleFreighters(idleFrieghters);
                 var interTradePlanets = TradingEmpiresPlanetList();
                 if (interTradePlanets.Count > 0)
                 {
                     // export stuff to Empires which have trade treaties with us
                     if (NonCybernetic)
-                        DispatchOrBuildFreighters(Goods.Food, interTradePlanets, true);
+                        DispatchOrBuildFreighters(Goods.Food, interTradePlanets, true, ref tradeState);
 
-                    DispatchOrBuildFreighters(Goods.Production, interTradePlanets, true);
+                    DispatchOrBuildFreighters(Goods.Production, interTradePlanets, true, ref tradeState);
                 }
             }
 
             UpdateFreighterTimersAndScrap();
         }
+
+        struct TradeState
+        {
+            readonly bool InterTrade;
+            public Ship[] IdleFreighters {get; private set; }
+            public EmpireIdleFreighters State { get; private set; }
+            bool BuildFreighterRequested;
+            readonly Empire Owner;
+            HashSet<Planet> PlanetsNeedUpdate = new();
+            public bool HasImportingFoodPlanets { get; private set; } = true;
+            public bool HasImportingProductionPlanets { get; private set; } = true;
+            public bool HasImportingColonistsPlanets { get; private set; } = true;
+            public bool HasExportingFoodPlanets { get; private set; } = true;
+            public bool HasExportingProductionPlanets { get; private set; } = true;
+            public bool HasExportingColonistsPlanets { get; private set; } = true;
+
+            public TradeState(Empire owner,  bool interTrade)
+            {
+                IdleFreighters = new Ship[0];
+                State = EmpireIdleFreighters.Fetch;
+                InterTrade = interTrade;
+                Owner = owner;
+            }
+
+            public Ship[] FetchIdleFreightersOrBuild()
+            {
+                if (State == EmpireIdleFreighters.Fetch)
+                {
+                    IdleFreighters = Owner.GetIdleFreighters(InterTrade);
+                    SetIdleFreightesState();
+                    if (IdleFreighters.Length == 0)
+                        BuildFreighter();
+                }
+
+                return IdleFreighters;
+            }
+
+            public void SetIdleFreighters(Ship[] freighters)
+            {
+                IdleFreighters = freighters;
+                SetIdleFreightesState();
+            }
+
+            public void SetIdleFreightesState()
+            {
+                if (IdleFreighters.Length > 0)
+                    State = EmpireIdleFreighters.SomeIdle;
+                else
+                    State = EmpireIdleFreighters.None;
+            }
+
+            public void BuildFreighter()
+            {
+                if (!BuildFreighterRequested && !InterTrade)
+                {
+                    BuildFreighterRequested = true;
+                    Owner.BuildFreighter();
+                }
+            }
+
+            public void AddToPlanetsNeedUpdate(Planet import, Planet export)
+            {
+                PlanetsNeedUpdate.Add(import);
+                PlanetsNeedUpdate.Add(export);
+            }
+
+            public void UpdatePlanetsTradeGoods()
+            {
+                foreach (Planet p in PlanetsNeedUpdate)
+                    p.UpdateIncomingTradeGoods();
+
+                PlanetsNeedUpdate = new();
+            }
+
+            public void SetNoImportPlanetOf(Goods goods)
+            {
+                switch (goods)
+                {
+                    case Goods.Food:       HasImportingFoodPlanets       = false; break;
+                    case Goods.Production: HasImportingProductionPlanets = false; break;
+                    case Goods.Colonists:  HasImportingColonistsPlanets  = false; break;
+                }
+            }
+
+            public void SetNoExportPlanetOf(Goods goods)
+            {
+                switch (goods)
+                {
+                    case Goods.Food:       HasExportingFoodPlanets       = false; break;
+                    case Goods.Production: HasExportingProductionPlanets = false; break;
+                    case Goods.Colonists:  HasExportingColonistsPlanets  = false; break;
+                }
+            }
+
+            public bool HasImportPlanetOf(Goods goods)
+            {
+                return goods switch
+                {
+                    Goods.Food       => HasImportingFoodPlanets,
+                    Goods.Production => HasImportingProductionPlanets,
+                    Goods.Colonists  => HasImportingColonistsPlanets,
+                };
+            }
+
+            public bool HasExportPlanetOf(Goods goods)
+            {
+                return goods switch
+                {
+                    Goods.Food       => HasExportingFoodPlanets,
+                    Goods.Production => HasExportingProductionPlanets,
+                    Goods.Colonists  => HasExportingColonistsPlanets,
+                };
+            }
+
+            public bool NoFreeFreighters => State == EmpireIdleFreighters.None;
+            public bool HasFreeFreighters => State == EmpireIdleFreighters.SomeIdle;
+            public bool ShouldFetchIdleFreighters => State == EmpireIdleFreighters.Fetch;
+        }
+
+        enum EmpireIdleFreighters
+        {
+            Fetch,
+            SomeIdle,
+            None,
+        }
+
 
         void UpdateFreighterTimersAndScrap()
         {
@@ -160,26 +297,46 @@ namespace Ship_Game
             return GetTradeParameters(goods, idleFreighters, targetStation, exportingPlanets, out exportAndFreighter);
         }
 
-        void DispatchOrBuildFreighters(Goods goods, Array<Planet> importPlanetList, bool interTrade)
+        void DispatchOrBuildFreighters(Goods goods, Array<Planet> importPlanetList, bool interTrade, ref TradeState state)
         {
+            if (state.NoFreeFreighters)
+                return;
+
             // Order importing planets to balance freighters distribution
-            Planet[] importingPlanets = importPlanetList.Filter(p => p.FreeGoodsImportSlots(goods) > 0);
-            if (importingPlanets.Length == 0)
-                return;
-
-            // TODO: maybe use IEnumerable generators for these?
-            Planet[] exportingPlanets = OwnedPlanets.Filter(p => p.FreeGoodsExportSlots(goods) > 0);
-            if (exportingPlanets.Length == 0)
-                return;
-
-            Ship[] idleFreighters = GetIdleFreighters(interTrade);
-            if (idleFreighters.Length == 0) // Need trade for auto trade but no freighters found
+            Planet[] importingPlanets = new Planet[0]; 
+            if (state.HasImportPlanetOf(goods))
             {
-                if (!interTrade) 
-                    BuildFreighter();
-
+                importingPlanets = importPlanetList.Filter(p => p.FreeGoodsImportSlots(goods) > 0);
+                if (importingPlanets.Length == 0)
+                {
+                    state.SetNoImportPlanetOf(goods);
+                    return;
+                }
+            }
+            else
+            {
                 return;
             }
+
+            Planet[] exportingPlanets = new Planet[0];
+            if (state.HasExportPlanetOf(goods))
+            {
+                // TODO: maybe use IEnumerable generators for these?
+                exportingPlanets = OwnedPlanets.Filter(p => p.FreeGoodsExportSlots(goods) > 0);
+                if (exportingPlanets.Length == 0)
+                {
+                    state.SetNoExportPlanetOf(goods);
+                    return;
+                }
+            }
+            else
+            {
+                return;
+            }
+
+            Ship[] idleFreighters = state.FetchIdleFreightersOrBuild();
+            if (state.NoFreeFreighters) // Need trade for auto trade but no freighters found
+                return;
 
             importingPlanets.Sort(p => p.GetCachedIncomingCargoPriority(goods));
 
@@ -198,8 +355,12 @@ namespace Ship_Game
                     // Remove the export planet from the exporting list if no more export slots left
                     if (exportPlanet.FreeGoodsExportSlots(goods) == 0)
                         exportingPlanets.Remove(exportPlanet, out exportingPlanets);
+
+                    state.AddToPlanetsNeedUpdate(importPlanet, exportPlanet);
                 }
             }
+
+            state.SetIdleFreighters(idleFreighters);
         }
 
         Ship[] GetIdleFreighters(bool interTrade)

--- a/Ship_Game/ExtensionMethods/HelperFunctions.cs
+++ b/Ship_Game/ExtensionMethods/HelperFunctions.cs
@@ -322,12 +322,6 @@ namespace Ship_Game
             float minimumDistance = (ships.Count * 100).LowerBound(5000);
             float minimumDistanceInBattle = (minimumDistance * 2).LowerBound(5000);
             var enemyShipsTooClose = enemyShips.Filter(s => s.Position.Distance(pos) <= minimumDistance);
-            /*if (ships.Any(s => s.IsInWarp && enemyShips.Any(enemy => enemy.Position.Distance(s.Position) < minimumDistance)))
-            {
-                GameAudio.NegativeClick();
-                return pos;
-            }*/
-
             if (ships.All(s => s.InFrustum && !s.IsInWarp && s.Position.Distance(pos) < minimumDistanceInBattle) || enemyShipsTooClose.Length == 0)
             {
                 GameAudio.AffirmativeClick();
@@ -357,6 +351,37 @@ namespace Ship_Game
             float distanceNeeded = minimumDistance + FarthestEnemyPos.Distance(ship.Position);
             Vector2 corrected = ship.Position + ship.Direction * distanceNeeded;
             return corrected;
+        }
+
+        static public bool CanExitWarpForChangingDirectionByCommand(Ship[] ships, Ship[] enemyShips)
+        {
+            if (enemyShips.Length == 0)
+                return true;
+
+            float minimumDistance = 5000f;
+            if (ships.Any(s => s.IsInWarp && enemyShips.Any(enemy => enemy.Position.Distance(s.Position) < minimumDistance)))
+                return false;
+
+            return true;
+        }
+
+        static public Ship[] GetAllPotentialTargetsIfInWarp(Array<Ship> ships)
+        {
+            Array<Ship> potentialTargets = new();
+            if (!ships.Any(s => s.IsInWarp))
+                return [];
+
+            for (int i = 0; i < ships.Count; ++i)
+            {
+                Ship ship = ships[i];
+                for (int j = 0; j < ship.AI.PotentialTargets.Length; j++)
+                {
+                    Ship target = ship.AI.PotentialTargets[j];
+                    potentialTargets.AddUniqueRef(target);
+                }
+            }
+
+            return potentialTargets.ToArray();
         }
     }
 }

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -213,9 +213,11 @@ namespace Ship_Game.Fleets
             }
         }
 
-        public void ClearPatrol()
+        public void ClearPatrol(bool clearOrders = true)
         {
-            ClearOrders();
+            if (clearOrders) 
+                ClearOrders();
+
             Patrol = null;
         }
 

--- a/Ship_Game/Remnants.cs
+++ b/Ship_Game/Remnants.cs
@@ -640,7 +640,7 @@ namespace Ship_Game
 
         public int GetNumBombersNeeded(Planet planet)
         {
-            if (Level == 1)
+            if (Level <= 3)
                 return 0;
 
             RemnantShipType bomberType = GetBomberType(out int numBombers);
@@ -661,16 +661,16 @@ namespace Ship_Game
         {
             numBombers = (int)(Level * Owner.DifficultyModifiers.RemnantNumBombers);
 
-            if (Level <= 5)
+            if (Level <= 6)
             {
                 numBombers *= (Level-1).LowerBound(1);
                 return RemnantShipType.BomberLight;
             }
 
-            if (Level <= 9)
+            if (Level <= 12)
                 return RemnantShipType.BomberMedium;
 
-            // Level 10 and above
+            // Level 12 and above
             numBombers /= 2;
             return RemnantShipType.Bomber;
         }
@@ -942,7 +942,10 @@ namespace Ship_Game
         public void GenerateProduction(float amount)
         {
             if (Hibernating)
-                amount *= 0.2f;
+                amount *= 0.05f;
+
+            if (Owner.AI.CountGoals(g => g.Type == GoalType.RemnantPortal) > 1)
+                amount = amount * 0.75f;
 
             if (DefenseProduction < MaxDefenseProduction)
             {

--- a/Ship_Game/Ships/Ship_Movement.cs
+++ b/Ship_Game/Ships/Ship_Movement.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using SDGraphics;
+﻿using SDGraphics;
 using SDUtils;
 using Ship_Game.Universe;
+using System;
 using Vector2 = SDGraphics.Vector2;
 
 namespace Ship_Game.Ships

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
@@ -49,10 +49,10 @@ namespace Ship_Game
                    && colony.P == this;
         }
 
-        void BuildAndScrapCivilianBuildings(float budget)
+        void BuildAndScrapCivilianBuildings(float budget, float tolerance)
         {
             UpdateGovernorPriorities();
-            bool overBudget = budget < -0.1f;
+            bool overBudget = budget < tolerance;
             if (overBudget || Blueprints?.ShouldScrapNonRequiredBuilding() == true)
             {
                 // We must scrap something to bring us above of our debt tolerance

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
@@ -52,26 +52,26 @@ namespace Ship_Game
         void BuildAndScrapCivilianBuildings(float budget, float tolerance)
         {
             UpdateGovernorPriorities();
-            bool overBudget = budget < tolerance;
+            bool overBudget = budget < (-tolerance);
             if (overBudget || Blueprints?.ShouldScrapNonRequiredBuilding() == true)
             {
                 // We must scrap something to bring us above of our debt tolerance
                 // or we can try scrap buildings not in blueprints
                 TryScrapBuilding(overBudget);
                 if (!overBudget) // we can try to build something if we have blueprints
-                    BuildOrReplaceBuilding(budget, overBudget);
+                    BuildOrReplaceBuilding(budget, tolerance, overBudget);
             }
             else
             {
-                BuildOrReplaceBuilding(budget, overBudget);
+                BuildOrReplaceBuilding(budget, tolerance, overBudget);
                 if (!TryBuildBiospheres(budget, out bool shouldScrapBiospheres) && shouldScrapBiospheres)
                     TryScrapBiospheres(); // Build or scrap Biospheres if needed
             }
         }
 
-        void BuildOrReplaceBuilding(float budget, bool overBudget)
+        void BuildOrReplaceBuilding(float budget, float tolerance, bool overBudget)
         {
-            if (TryCancelOverBudgetCivilianBuilding(budget))
+            if (TryCancelOverBudgetCivilianBuilding(budget + tolerance))
                 return;
 
             if (FreeHabitableTiles > 0)

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Govern.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Govern.cs
@@ -117,7 +117,7 @@ namespace Ship_Game
 
         public float CivilianBuildingsMaintenance  => Money.Maintenance - GroundDefMaintenance;
 
-        public float GetColonyDebtTolerance()
+        public float GetColonyInitialBudgetTolerance()
         {
             if (Owner == null || GovernorOff || MaxPopBillionNoBuildingBonus >= 5f || PopulationBillion > 5f)
                 return 0;
@@ -138,14 +138,13 @@ namespace Ship_Game
             return total.LowerBound(0);
         }
 
-        //New Build Logic by Gretman, modified by Fat Bastard
         void BuildAndScrapBuildings(PlanetBudget colonyBudget)
         {
             if (OwnerIsPlayer && SpecializedTradeHub)
                 return;
 
-            BuildAndScrapCivilianBuildings(colonyBudget.RemainingCivilian);
-            BuildAndScrapMilitaryBuildings(colonyBudget.RemainingGroundDef);
+            BuildAndScrapCivilianBuildings(colonyBudget.RemainingCivilian, colonyBudget.CivilianTolerance);
+            BuildAndScrapMilitaryBuildings(colonyBudget.RemainingGroundDef, colonyBudget.GroundDefTolerance);
         }
 
         // returns the amount of production to spend in the build queue based on import/export state

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Govern.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Govern.cs
@@ -72,38 +72,38 @@ namespace Ship_Game
                 case ColonyType.Core:
                     BuildAndScrapBuildings(Budget);
                     AssignCoreWorldWorkers();
-                    DetermineFoodState(0.2f, 0.5f); // Start Importing if stores drop below 20%, and stop importing once stores are above 50%.
-                    DetermineProdState(0.2f, 0.5f); // Start Exporting if stores are above 50%, but dont stop exporting unless stores drop below 25%.
+                    DetermineFoodState(0.2f, 0.5f);
+                    DetermineProdState(0.2f, 0.5f);
                     break;
                 case ColonyType.Industrial:
                     BuildAndScrapBuildings(Budget);
                     // Farm to 30% storage, then devote the rest to Work, then to research when that starts to fill up
                     AssignOtherWorldsWorkers(0.33f, 1, 0, 2);
-                    DetermineFoodState(0.75f, 0.99f);    // Start Importing if food drops below 75%, and stop importing once stores reach 100%. Will only export food due to excess FlatFood.
+                    DetermineFoodState(0.75f, 0.99f);
                     if (NonCybernetic)
-                        DetermineProdState(0f, 0.5f); // Never import (unless constructing something) Start exporting at 50%, and dont stop unless below 25%.
+                        DetermineProdState(0f, 0.5f);
                     else
-                        DetermineProdState(0.2f, 0.66f); // Start Importing if prod drops below 20%, stop importing at 40%. Start exporting at 66%, and dont stop unless below 33%.
+                        DetermineProdState(0.2f, 0.66f);
 
                     break;
                 case ColonyType.Research:
                     //This governor will rely on imports, focusing on research as long as no one is starving
                     BuildAndScrapBuildings(Budget);
                     AssignOtherWorldsWorkers(0.15f, 0.15f, 0, 0);
-                    DetermineFoodState(0.75f, 0.99f); // Import if either drops below 75%, and stop importing once stores reach 100%.
-                    DetermineProdState(0.25f, 0.99f); // This planet will export when stores reach 100%
+                    DetermineFoodState(0.75f, 0.95f);
+                    DetermineProdState(0.25f, 0.95f);
                     break;
                 case ColonyType.Agricultural:
                     BuildAndScrapBuildings(Budget);
                     AssignOtherWorldsWorkers(1, 0.333f, Storage.Max - Storage.Food , 0);
-                    DetermineFoodState(0.1f, 0.2f);  // Start Importing if food drops below 10%, export at 20% and above.
-                    DetermineProdState(0.25f, 0.99f); // Start Importing if prod drops below 25%, and stop importing once stores reach 100%. Will only export prod due to excess FlatProd.
+                    DetermineFoodState(0.1f, 0.2f);
+                    DetermineProdState(0.25f, 0.95f);
                     break;
                 case ColonyType.Military:
                     BuildAndScrapBuildings(Budget);
                     AssignOtherWorldsWorkers(0.3f, 0.7f, 0, 1.5f);
                     DetermineFoodState(0.75f, 1f); // Import if either drops below 75%, and stop importing once stores reach 95%.
-                    DetermineProdState(0.75f, 0.99f); // This planet will only export Food or Prod due to excess FlatFood or FlatProd
+                    DetermineProdState(0.75f, 0.95f); // This planet will only export Food or Prod due to excess FlatFood or FlatProd
                     break;
             }
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Resources.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Resources.cs
@@ -166,7 +166,7 @@ namespace Ship_Game
 
             // This will allow a buffer for import / export, so they dont constantly switch between them
             if      (ShortOnFood() || belowImportThreshold)   FS = GoodState.IMPORT; 
-            else if (Food.NetMaxPotential < 0 && ratio > 0.9) FS = GoodState.STORE;  // We are negative on food prodution but have a lot of food
+            else if (Food.NetMaxPotential < 0 && ratio > 0.9) FS = GoodState.STORE;  // We are negative on food production but have a lot of food
             else if (ratio > exportThreshold)                 FS = GoodState.EXPORT; // Until we get back to the Threshold, then export
             else                                              FS = GoodState.STORE;  // We are between our thresholds
         }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Resources.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Resources.cs
@@ -159,25 +159,16 @@ namespace Ship_Game
                 return;
             }
 
-            if (Food.FlatBonus > PopulationBillion) // Account for possible overproduction from FlatFood
-            {
-                float offsetAmount = (Food.FlatBonus - PopulationBillion) * 0.05f;
-                offsetAmount       = offsetAmount.Clamped(0.00f, 0.15f);
-                importThreshold    = (importThreshold - offsetAmount).Clamped(0.1f, 1f);
-                exportThreshold    = (exportThreshold - offsetAmount).Clamped(0.1f, 1f);
-            }
-
             float ratio               = Storage.FoodRatio;
             bool belowImportThreshold = ratio < importThreshold 
                                         && CType != ColonyType.Agricultural
                                         && Food.NetFlatBonus < Consumption;
 
             // This will allow a buffer for import / export, so they dont constantly switch between them
-            if      (ShortOnFood() || belowImportThreshold)                  FS = GoodState.IMPORT; 
-            else if (Food.NetMaxPotential + Food.NetFlatBonus < 0)           FS = GoodState.STORE; // We are struggling to produce food but not short on food
-            else if (FS == GoodState.IMPORT && ratio >= importThreshold * 2) FS = GoodState.STORE;  // Until you reach 2x importThreshold, then switch to Store
-            else if (FS == GoodState.EXPORT && ratio <= exportThreshold / 2) FS = GoodState.STORE;  // If we were exporting, and drop below half exportThreshold, stop exporting
-            else if (ratio > exportThreshold)                                FS = GoodState.EXPORT; // Until we get back to the Threshold, then export
+            if      (ShortOnFood() || belowImportThreshold)   FS = GoodState.IMPORT; 
+            else if (Food.NetMaxPotential < 0 && ratio > 0.9) FS = GoodState.STORE;  // We are negative on food prodution but have a lot of food
+            else if (ratio > exportThreshold)                 FS = GoodState.EXPORT; // Until we get back to the Threshold, then export
+            else                                              FS = GoodState.STORE;  // We are between our thresholds
         }
 
         void DetermineProdState(float importThreshold, float exportThreshold)
@@ -207,9 +198,7 @@ namespace Ship_Game
             }
 
             float ratio = Storage.ProdRatio;
-            if (ratio < importThreshold) PS = GoodState.IMPORT;
-            else if (PS == GoodState.IMPORT && ratio >= importThreshold * 2) PS = GoodState.STORE;
-            else if (PS == GoodState.EXPORT && ratio <= exportThreshold / 2) PS = GoodState.STORE;
+            if (ratio < importThreshold)      PS = GoodState.IMPORT;
             else if (ratio > exportThreshold) PS = GoodState.EXPORT;
         }
     }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
@@ -69,7 +69,7 @@ namespace Ship_Game
         public int NumFreightersPickingUpFood { get; private set; }
         public int NumFreightersPickingUpProd { get; private set; }
 
-        void UpdateIncomingTradeGoods()
+        public void UpdateIncomingTradeGoods()
         {
             // synchronization point
             // TODO: this might not be needed if Empires are updated after Ships parallel update

--- a/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
+++ b/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
@@ -35,11 +35,20 @@ namespace Ship_Game.Universe
 
         public bool RightClickOnShip(Ship selectedShip, Ship targetShip)
         {
-            if (targetShip == null || selectedShip == targetShip || !selectedShip.PlayerShipCanTakeFleetOrders(forAttack: true))
-                return false;
-
-            if (targetShip.Loyalty == Universe.Player)
+            if (targetShip == null 
+                || selectedShip == targetShip 
+                || !selectedShip.PlayerShipCanTakeFleetOrders(forAttack: true))
             {
+                return false; 
+            }
+
+            if (targetShip.Loyalty.isPlayer)
+            {
+                if (!HelperFunctions.CanExitWarpForChangingDirectionByCommand([selectedShip], selectedShip.AI.PotentialTargets))
+                {
+                    GameAudio.NegativeClick();
+                    return false;
+                }
                 if (selectedShip.DesignRole == RoleName.troop)
                 {
                     if (targetShip.TroopCount < targetShip.TroopCapacity)
@@ -48,7 +57,9 @@ namespace Ship_Game.Universe
                         selectedShip.AI.AddEscortGoal(targetShip);
                 }
                 else
+                {
                     selectedShip.AI.AddEscortGoal(targetShip);
+                }
             }
             else if (selectedShip.DesignRole == RoleName.troop)
                 selectedShip.AI.OrderTroopToBoardShip(targetShip);
@@ -63,12 +74,14 @@ namespace Ship_Game.Universe
         public void RightClickOnPlanet(Ship ship, Planet planet, bool audio = false)
         {
             Log.Assert(planet != null, "RightClickOnPlanet: planet cannot be null!");
-            if (ship.IsConstructor || ship.IsPlatformOrStation || ship.IsSubspaceProjector)
+            if (ship.IsConstructor 
+                || ship.IsPlatformOrStation 
+                || ship.IsSubspaceProjector 
+                || !HelperFunctions.CanExitWarpForChangingDirectionByCommand([ship], ship.AI.PotentialTargets))
             {
                 if (audio)
-                {
                     GameAudio.NegativeClick();
-                }
+
                 return;
             }
 
@@ -163,8 +176,9 @@ namespace Ship_Game.Universe
 
         public bool AttackSpecificShip(Ship ship, Ship target)
         {
-            if (ship.IsConstructor ||
-                ship.IsSupplyShuttle)
+            if (ship.IsConstructor 
+                || ship.IsSupplyShuttle 
+                || !HelperFunctions.CanExitWarpForChangingDirectionByCommand([ship], ship.AI.PotentialTargets))
             {
                 GameAudio.NegativeClick();
                 return false;
@@ -255,7 +269,7 @@ namespace Ship_Game.Universe
 
         public void MoveShipToLocation(Ship[] enemyShips, Vector2 pos, Vector2 direction, Ship ship)
         {
-            if (ship.IsPlatformOrStation)
+            if (ship.IsPlatformOrStation || !HelperFunctions.CanExitWarpForChangingDirectionByCommand([ship], enemyShips))
             {
                 GameAudio.NegativeClick();
                 return;

--- a/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
+++ b/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
@@ -276,7 +276,6 @@ namespace Ship_Game.Universe
 
             Vector2 corrected = HelperFunctions.GetCorrectedMovePosWithAudio(fleet.Ships, enemyShips, movePosition);
             fleet.MoveTo(corrected, facingDir, GetMoveOrderType());
-            return;
         }
 
         void ResetShipsTargetAndPriorityOrders(Ship ship)

--- a/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
+++ b/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
@@ -248,12 +248,9 @@ namespace Ship_Game.Universe
             if (QueueFleetMovement(movePosition, facingDir, fleet))
                 return;
 
-            foreach (var ship in fleet.Ships)
-                if (ship.PlayerShipCanTakeFleetOrders())
-                    ship.AI.ClearOrders();
-
-            Vector2 correctedPos = GetCorrectedMovePosWithAudio(fleet.Ships, enemyShips, movePosition);
-            fleet.MoveTo(correctedPos, facingDir, GetMoveOrderType());
+            Vector2 corrected = HelperFunctions.GetCorrectedMovePosWithAudio(fleet.Ships, enemyShips, movePosition);
+            fleet.MoveTo(corrected, facingDir, GetMoveOrderType());
+            return;
         }
 
         public void MoveShipToLocation(Ship[] enemyShips, Vector2 pos, Vector2 direction, Ship ship)
@@ -264,28 +261,8 @@ namespace Ship_Game.Universe
                 return;
             }
 
-            Vector2 correctedPos = GetCorrectedMovePosWithAudio([ship], enemyShips, pos);
-            ship.AI.OrderMoveTo(correctedPos, direction, GetMoveOrderType());
-        }
-
-        public Vector2 GetCorrectedMovePosWithAudio(Array<Ship> ships, Ship[] enemyShips, Vector2 pos)
-        {
-            float minimumDistance = (ships.Count * 100).LowerBound(5000);
-            float minimumDistanceInBattle = (minimumDistance * 2).LowerBound(5000);
-            var enemyShipsTooClose = enemyShips.Filter(s => s.Position.Distance(pos) <= minimumDistance);
-            if (ships.All(s => s.InFrustum && s.Position.Distance(pos) < minimumDistanceInBattle) || enemyShipsTooClose.Length == 0)
-            {
-                GameAudio.AffirmativeClick();
-                return pos;
-            }
-
-            GameAudio.SmallServo(); // Notify player that order was not exactly followed 
-            Ship closestEnemy = enemyShipsTooClose.FindMin(s => s.Position.Distance(pos));
-            Vector2 closestEnemySPos = closestEnemy.Position;
-            float distanceNeeded = minimumDistance - closestEnemySPos.Distance(pos);
-            Vector2 directionToProjectedPos = closestEnemySPos.DirectionToTarget(pos);
-            Vector2 corrected = pos + directionToProjectedPos*distanceNeeded;
-            return corrected;
+            Vector2 corrected = HelperFunctions.GetCorrectedMovePosWithAudio([ship], enemyShips, pos);
+            ship.AI.OrderMoveTo(pos, direction, GetMoveOrderType());
         }
     }
 }

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.ShipGroupMove.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.ShipGroupMove.cs
@@ -233,7 +233,7 @@ namespace Ship_Game
                 if (CurrentGroup == null)
                     return; // projection is not valid YET, come back next update
 
-                Vector2 correctedPos = ShipCommands.GetCorrectedMovePosWithAudio(CurrentGroup.Ships, enemyShips, CurrentGroup.ProjectedPos);
+                Vector2 correctedPos = HelperFunctions.GetCorrectedMovePosWithAudio(CurrentGroup.Ships, enemyShips, CurrentGroup.ProjectedPos);
                 Log.Info("MoveShipGroupToMouse (CurrentGroup)");
                 CurrentGroup.MoveTo(correctedPos, CurrentGroup.ProjectedDirection, moveType);
                 return;
@@ -248,7 +248,7 @@ namespace Ship_Game
                 Vector2 fleetCenter = ShipGroup.GetAveragePosition(SelectedShipList);
                 Vector2 direction = fleetCenter.DirectionToTarget(finalPos);
                 CurrentGroup = new ShipGroup(SelectedShipList, finalPos, finalPos, direction, Player);
-                Vector2 correctedPos = ShipCommands.GetCorrectedMovePosWithAudio(CurrentGroup.Ships, enemyShips, CurrentGroup.ProjectedPos);
+                Vector2 correctedPos = HelperFunctions.GetCorrectedMovePosWithAudio(CurrentGroup.Ships, enemyShips, CurrentGroup.ProjectedPos);
                 Log.Info("MoveShipGroupToMouse (NEW)");
                 CurrentGroup.MoveTo(correctedPos, direction, moveType);
             }
@@ -257,7 +257,7 @@ namespace Ship_Game
                 Log.Info("MoveShipGroupToMouse (existing)");
                 Ship centerMost = CurrentGroup.GetClosestShipTo(CurrentGroup.AveragePosition(force: true));
                 Vector2 finalDir = GetDirectionToFinalPos(centerMost, finalPos);
-                Vector2 correctedPos = ShipCommands.GetCorrectedMovePosWithAudio(CurrentGroup.Ships, enemyShips, finalPos);
+                Vector2 correctedPos = HelperFunctions.GetCorrectedMovePosWithAudio(CurrentGroup.Ships, enemyShips, finalPos);
                 CurrentGroup.MoveTo(correctedPos, finalDir, moveType);
             }
         }

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.ShipGroupMove.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.ShipGroupMove.cs
@@ -135,7 +135,7 @@ namespace Ship_Game
                 {
                     if (UnselectableShip())
                         return;
-                    if  (SelectedShip.Position.Distance(shipClicked.Position) > 7500f
+                    if (SelectedShip.Position.Distance(shipClicked.Position) > 7500f
                         && !HelperFunctions.CanExitWarpForChangingDirectionByCommand([SelectedShip], SelectedShip.AI.PotentialTargets))
                     {
                         GameAudio.NegativeClick();

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.ShipGroupMove.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.ShipGroupMove.cs
@@ -135,6 +135,13 @@ namespace Ship_Game
                 {
                     if (UnselectableShip())
                         return;
+                    if  (SelectedShip.Position.Distance(shipClicked.Position) > 7500f
+                        && !HelperFunctions.CanExitWarpForChangingDirectionByCommand([SelectedShip], SelectedShip.AI.PotentialTargets))
+                    {
+                        GameAudio.NegativeClick();
+                        return;
+                    }
+
                     GameAudio.AffirmativeClick();
                     ShipCommands.AttackSpecificShip(SelectedShip, shipClicked);
                 }
@@ -193,7 +200,7 @@ namespace Ship_Game
             if (fleet.Ships.Count == 0) 
                 return;
 
-            bool attackSingleEnemyShip = targetShip != null && !targetShip.Loyalty.isPlayer == true;
+            bool attackSingleEnemyShip = targetShip != null && !targetShip.Loyalty.isPlayer;
             Ship[] enemyShips = targetPlanet == null && (targetShip == null || attackSingleEnemyShip)
                 ?  GetVisibleEnemyShipsInScreen() 
                 : HelperFunctions.GetAllPotentialTargetsIfInWarp(fleet.Ships);
@@ -206,7 +213,7 @@ namespace Ship_Game
                 return;
             }
 
-            fleet.ClearPatrol();
+            fleet.ClearPatrol(clearOrders: false);
             if (wasProjecting)
             {
                 ShipCommands.MoveFleetToLocation(enemyShips, targetShip, targetPlanet, Project.FleetCenter, Project.Direction, fleet);


### PR DESCRIPTION
- AI: Implement over budget tolerance for civilian, ground defense and space defense. At 100% budget nothing will be built and if budget goes over 110% due to treasury depletion, stuff will be scrapped
- AI: Trade - run 3 times per turn with smarter short circuits and with dynamic reference to idle freighters list to save CPU.
- Fix: When a ship is ordered to return to hangar, if its a carrier, order its fighters as well.
- Fix: When entering back into the hangar, if its a carrier, scuttle all fighters which have not made it yet back into this carrier.
- Fix: Do not allow ships do drop out of warp on top of enemy ships when an attack order is given mid warp. Ship will over shoot and then drop out of warp.
- Fix: Do not allow change directions for fleets and groups if it means ships will drop out of warp near enemy ships