### PR TITLE
PerfTimerTests: widen RuntimeLongerThanRefreshInterval tolerance to 10ms

### DIFF
--- a/UnitTests/Utils/PerfTimerTests.cs
+++ b/UnitTests/Utils/PerfTimerTests.cs
@@ -68,12 +68,12 @@ namespace UnitTests.Utils
             timer.Start();
             PerfTimer.SpinWait(_50ms);
             bool didRefresh = timer.Stop();
-            AssertEqual(0.001f, _50ms, timer.TimeUntilNextRefresh);
+            AssertEqual(0.01f, _50ms, timer.TimeUntilNextRefresh);
             Assert.IsTrue(didRefresh, "Timer should have refreshed");
             AssertEqual(1, timer.MeasuredSamples);
-            AssertEqual(0.001f,_50ms, timer.MeasuredTotal);
-            AssertEqual(0.001f,_50ms, timer.MeasuredMax);
-            AssertEqual(0.001f,_50ms, timer.AvgTime);
+            AssertEqual(0.01f,_50ms, timer.MeasuredTotal);
+            AssertEqual(0.01f,_50ms, timer.MeasuredMax);
+            AssertEqual(0.01f,_50ms, timer.AvgTime);
         }
     }
 }


### PR DESCRIPTION
Test was failing on AppVeyor with "expected 0.05, actual 0.0471" — a ~3ms undershoot from the 1ms tolerance. The undershoot is post-Stop() elapsed time before the assertion reads TimeUntilNextRefresh; on a non-realtime shared CI VM, 3ms of scheduler jitter is well within normal.

Bump tolerance 1ms → 10ms to match the sibling test MultipleEqualSamples (line 59-61), which already uses 0.01f for the same class of wall-clock assertion. Still meaningful — a broken timer recording, say, 0ms or 100ms would fail the assertion.