### PR TITLE
Jupiter 1.60/fixes2

### DIFF
--- a/Ship_Game/Bomb.cs
+++ b/Ship_Game/Bomb.cs
@@ -32,6 +32,12 @@ namespace Ship_Game
         public readonly SubTexture Texture;
         public readonly StaticMesh Model;
 
+        // Set inside Update when the bomb should be retired (impact or miss).
+        // The sim loop in UniverseScreen.UpdateGame.cs does the actual
+        // BombList.RemoveAt — keeps BombList mutation single-threaded relative
+        // to the main-thread DrawBombs reader.
+        public bool Dead { get; private set; }
+
         public Bomb(Vector3 position, Empire empire, string weaponName, int shipLevel, float shipHealthPercent)
         {
             Owner = empire;
@@ -60,7 +66,7 @@ namespace Ship_Game
         void DoImpact()
         {
             TargetPlanet.DropBomb(this);
-            Owner.Universe.Screen.BombList.Remove(this);
+            Dead = true;
         }
 
         private void SurfaceImpactEffects()
@@ -131,12 +137,23 @@ namespace Ship_Game
             Vector3 planetPos = TargetPlanet.Position3D;
             float impactRadius = TargetPlanet.ShieldStrengthCurrent > 0f ? 100f : 30f;
             if (Position.InRadius(planetPos, PlanetRadius + impactRadius))
+            {
                 DoImpact();
-
+                return;
+            }
 
             // fiery trail radius:
-            if (!Position.InRadius(planetPos, PlanetRadius + 1000f))
+            bool insideTrailZone = Position.InRadius(planetPos, PlanetRadius + 1000f);
+            if (!insideTrailZone)
+            {
+                // If TrailEmitter already exists, the bomb was inside the trail
+                // zone on a previous frame and has now exited without hitting —
+                // it missed. Mark it dead so the mesh doesn't keep drawing
+                // forever as the bomb sails off into space.
+                if (TrailEmitter != null)
+                    Dead = true;
                 return;
+            }
 
             if (TrailEmitter == null)
             {

--- a/Ship_Game/Bomb.cs
+++ b/Ship_Game/Bomb.cs
@@ -142,27 +142,31 @@ namespace Ship_Game
                 return;
             }
 
-            // fiery trail radius:
-            bool insideTrailZone = Position.InRadius(planetPos, PlanetRadius + 1000f);
-            if (!insideTrailZone)
+            // Miss detection: dot product of (planet - bomb) with velocity
+            // tells us which side of closest-approach we're on. Positive ⇒
+            // still approaching; negative ⇒ already past. The radius gate
+            // (PlanetRadius + 500) keeps the bomb visible until it's clearly
+            // past the planet, otherwise it would vanish while still
+            // alongside the surface for big planets.
+            if ((planetPos - Position).Dot(Velocity) < 0f &&
+                !Position.InRadius(planetPos, PlanetRadius + 500f))
             {
-                // If TrailEmitter already exists, the bomb was inside the trail
-                // zone on a previous frame and has now exited without hitting —
-                // it missed. Mark it dead so the mesh doesn't keep drawing
-                // forever as the bomb sails off into space.
-                if (TrailEmitter != null)
-                    Dead = true;
+                Dead = true;
                 return;
             }
 
-            if (TrailEmitter == null)
+            // Inside the fiery-trail radius? Start / continue the trail emitters.
+            if (Position.InRadius(planetPos, PlanetRadius + 1000f))
             {
-                Velocity *= 0.65f;
-                TrailEmitter     = Owner.Universe.Screen.Particles.ProjectileTrail.NewEmitter(500f, Position);
-                FireTrailEmitter = Owner.Universe.Screen.Particles.FireTrail.NewEmitter(500f, Position);
+                if (TrailEmitter == null)
+                {
+                    Velocity *= 0.65f;
+                    TrailEmitter     = Owner.Universe.Screen.Particles.ProjectileTrail.NewEmitter(500f, Position);
+                    FireTrailEmitter = Owner.Universe.Screen.Particles.FireTrail.NewEmitter(500f, Position);
+                }
+                TrailEmitter.Update(timeStep.FixedTime, Position);
+                FireTrailEmitter.Update(timeStep.FixedTime, Position);
             }
-            TrailEmitter.Update(timeStep.FixedTime, Position);
-            FireTrailEmitter.Update(timeStep.FixedTime, Position);
         }
     }
 }

--- a/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen.cs
+++ b/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen.cs
@@ -16,6 +16,9 @@ using System.Linq;
 using Ship_Game.Data.Yaml;
 using System.IO;
 using Ship_Game.GameScreens.FleetDesign;
+using SynapseGaming.LightingSystem.Lights;
+// SunBurn + MonoGame both define DirectionalLight; we want SunBurn's here.
+using DirectionalLight = SynapseGaming.LightingSystem.Lights.DirectionalLight;
 
 // ReSharper disable once CheckNamespace
 namespace Ship_Game
@@ -158,6 +161,50 @@ namespace Ship_Game
         public override void BecameActive()
         {
             AssignLightRig(LightRigIdentity.FleetDesign);
+            SetupFleetDesignLighting();
+        }
+
+        // Post-migration AssignLightRig is a stub — it clears all lights and
+        // submits none (the SunBurn .lightRig content type was discontinued,
+        // see MIGRATION_LIMITATIONS entry #7). Without an explicit rig the
+        // fleet view renders unlit, so ship hulls read dim and flat-spec.
+        // Mirrors the 3-directional Key / Fill / Back rig + ambient that
+        // ShipDesignScreen uses (SetupShipyardLighting).
+        void SetupFleetDesignLighting()
+        {
+            AddLight(new DirectionalLight
+            {
+                Name         = "FleetDesign Key",
+                Direction    = new Vector3(-0.5265408f, -0.5735765f, -0.6275069f),
+                DiffuseColor = new Vector3(1f, 1f, 1f),
+                Intensity    = 1.75f,
+                Enabled      = true,
+            }, dynamic: false);
+
+            AddLight(new DirectionalLight
+            {
+                Name         = "FleetDesign Fill",
+                Direction    = new Vector3(0.7198464f, 0.3420201f, 0.6040227f),
+                DiffuseColor = new Vector3(0.85f, 0.88f, 0.92f),
+                Intensity    = 0.8f,
+                Enabled      = true,
+            }, dynamic: false);
+
+            AddLight(new DirectionalLight
+            {
+                Name         = "FleetDesign Back",
+                Direction    = new Vector3(0.4545195f, -0.7660444f, 0.4545195f),
+                DiffuseColor = new Vector3(0.3231373f, 0.3607844f, 0.3937255f),
+                Intensity    = 0.5f,
+                Enabled      = true,
+            }, dynamic: false);
+
+            AddLight(new AmbientLight
+            {
+                Name         = "FleetDesign Ambient",
+                DiffuseColor = Color.White.ToVector3(),
+                Intensity    = 0.15f,
+            }, dynamic: false);
         }
 
         // We opened another screen like Shipyard, or just exited this screen

--- a/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_Draw.cs
+++ b/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_Draw.cs
@@ -204,10 +204,38 @@ namespace Ship_Game
                 SubTexture nodeTexture = ResourceManager.Texture("UI/node");
                 FleetDataNode node = SelectedNodeList[0];
 
-                float radius = (node.Ship?.SensorRange ?? 500000) * OperationalRadius.RelativeValue;
+                // The Operational Radius slider's relative/absolute semantic
+                // is currently inconsistent with how OrdersRadius is stored
+                // elsewhere in Fleet.cs (absolute world units). Sidestep that
+                // for now and just visualize the ship's actual SensorRange
+                // until the slider is reworked.
+                //
+                // In the Fleet Design screen, node.Ship is usually null —
+                // designs are templates, not live instances. Fall back to the
+                // ship template (same pattern as DrawFleetNode) so different
+                // designs show different sensor halos.
+                Ship ship = node.Ship;
+                if (ship == null && !ResourceManager.GetShipTemplate(node.ShipName, out ship))
+                    return;
+                float radius = ship.SensorRange;
                 (Vector2 screenPos, float screenRadius) = GetPosAndRadiusOnScreen(node.RelativeFleetOffset, radius);
                 RectF nodeRect = new(screenPos, screenRadius * 2, screenRadius * 2);
+
+                // UI/node is stored non-premultiplied (most consumers use
+                // additive / SourceAlphaSaturation blends). Default
+                // SpriteBatch.AlphaBlend is the premul formula in MonoGame
+                // (dst = src.rgb + dst*(1-srcA)) — so an alpha=0 outer ring
+                // leaks its RGB into the destination. With the rect sized to
+                // ship sensor range projected to screen (often larger than
+                // the viewport) that ring floods the whole screen green.
+                // Switch this single draw to Additive (src*srcA + dst), which
+                // zeroes out alpha=0 pixels naturally and matches how the
+                // FOW / shield / fogmap consumers handle the same texture.
+                batch.SafeEnd();
+                batch.SafeBegin(SpriteBlendMode.Additive);
                 batch.Draw(nodeTexture, nodeRect, NeonGreen, 0f, nodeTexture.CenterF);
+                batch.SafeEnd();
+                batch.SafeBegin();
             }
         }
 

--- a/Ship_Game/GameScreens/MainMenu/AutoUpdateChecker.cs
+++ b/Ship_Game/GameScreens/MainMenu/AutoUpdateChecker.cs
@@ -275,22 +275,28 @@ public class AutoUpdateChecker : UIElementContainer
                 string teamAndRepo = RegexExtractTeamAndRepo(downloadUrl, "\\/([\\w-]+\\/[\\w-]+)\\/releases");
                 string apiBase = $"https://api.github.com/repos/{teamAndRepo}/releases";
 
-                // Vanilla: hit /releases (array of all published) and pick the
-                // highest-version release. If its major.minor differs from the
-                // current install, route to the cross-major popup
-                // (file-gated by game/upgrade-url.txt). Otherwise treat it as
-                // an in-game patch candidate. This decouples the release line
-                // from GitHub's "Set as latest" flag — a hotfix can be
-                // published not-as-latest without breaking discovery for new
-                // installs, and the latest flag stays free to point at a
-                // legacy line (e.g. mars-1.51 for older binaries that still
-                // hit /releases/latest from pre-Jupiter code).
+                // Both vanilla and mods now hit /releases (array of all
+                // published) and filter by vanilla's current major.minor line.
                 //
-                // Mods: keep the legacy /releases/latest path. Mods don't
-                // follow the same versioning discipline and changing their
-                // behavior would affect every mod author's existing release
-                // setup.
-                Version currentLine = !isMod ? TryParseCurrentVanillaLine() : null;
+                // Vanilla: pick the highest-version release. If its major.minor
+                // differs from the current install, route to the cross-major
+                // popup (file-gated by game/upgrade-url.txt). Otherwise treat
+                // it as an in-game patch candidate. This decouples the release
+                // line from GitHub's "Set as latest" flag — a hotfix can be
+                // published not-as-latest without breaking discovery, and the
+                // latest flag stays free to point at a legacy line.
+                //
+                // Mods: pick the highest-version release whose tag matches
+                // vanilla's major.minor (mods now version-align with vanilla
+                // as v<major>.<minor>.NNNN). Pre-releases skipped via
+                // TrySelectMaxVersionRelease. Fallback: if the installed mod
+                // version doesn't parse to vanilla's line (legacy free-form
+                // version), any matching mod release is promoted as an update
+                // so users on old mod versions get a path forward.
+                //
+                // Dev builds (currentLine == null) fall back to /releases/latest
+                // for both — degraded but functional.
+                Version currentLine = TryParseCurrentVanillaLine();
                 if (currentLine != null)
                     info = GetLatestVersionInfoGitHub(apiBase, isMod, currentLine);
                 else
@@ -328,10 +334,14 @@ public class AutoUpdateChecker : UIElementContainer
         Log.Write($"AutoUpdater: latest  {latestVersion}");
         Log.Write($"AutoUpdater: current {currentVersion}");
 
-        // Mods: keep legacy ordinal compare. Mod authors don't follow a strict
-        // numeric scheme and the major-upgrade popup path is vanilla-only.
+        // Mods are now version-aligned with vanilla (v<major>.<minor>.NNNN).
+        // Strip the optional 'v' prefix and compare numerically. Fallback:
+        // when the installed mod version doesn't parse to vanilla's line
+        // (legacy free-form Version string, or a different major.minor),
+        // promote the candidate as an update so users on old mod versions
+        // get a one-click path to the new aligned line.
         if (isMod)
-            return string.CompareOrdinal(latestVersion, currentVersion) > 0;
+            return IsModLatestNewer(latestVersion, currentVersion);
 
         switch (ClassifyVanillaUpdate(latestVersion, currentVersion))
         {
@@ -349,6 +359,34 @@ public class AutoUpdateChecker : UIElementContainer
             default:
                 return false;
         }
+    }
+
+    // Pure: decide whether a candidate mod release supersedes the installed
+    // mod version. Both sides are stripped of an optional 'v' prefix and
+    // parsed via System.Version. When both parse and share major.minor, do
+    // a direct numeric compare. Otherwise fallback: promote the candidate
+    // (the installed mod is on a legacy free-form Version or a different
+    // major.minor line and should be upgraded to the new aligned release).
+    public static bool IsModLatestNewer(string latestVersion, string currentVersion)
+    {
+        string latest = StripVPrefix(latestVersion);
+        if (!Version.TryParse(latest, out var newV))
+        {
+            // Candidate itself unparseable — should not happen post
+            // TrySelectMaxVersionRelease but keep the bailout for safety.
+            Log.Warning($"AutoUpdater: mod latest version '{latestVersion}' unparseable, skipping");
+            return false;
+        }
+
+        string current = StripVPrefix(currentVersion);
+        if (Version.TryParse(current, out var curV)
+            && curV.Major == newV.Major && curV.Minor == newV.Minor)
+        {
+            return newV > curV;
+        }
+
+        Log.Write($"AutoUpdater: mod fallback — current '{currentVersion}' doesn't align with latest '{latestVersion}', promoting");
+        return true;
     }
 
     public enum UpdateAvailability
@@ -456,6 +494,15 @@ public class AutoUpdateChecker : UIElementContainer
     static string ExtractVersionPartFromTag(string tagName)
         => tagName.Split('-').FindMax(s => s.Count(c => c == '.')); // part-v1.2.4-withmostdots
 
+    // Strip optional leading 'v'/'V' so Version.TryParse can consume tags
+    // like `v1.60.0014` (mod convention: v<major>.<minor>.NNNN).
+    static string StripVPrefix(string s)
+    {
+        if (s.IsEmpty()) return s;
+        char first = s[0];
+        return (first == 'v' || first == 'V') ? s.Substring(1) : s;
+    }
+
     ReleaseInfo? GetLatestVersionInfoGitHub(string url, bool isMod, Version currentLine)
     {
         string jsonText = DownloadWithCancel(url, AsyncTask, timeout: TimeSpan.FromSeconds(30));
@@ -475,31 +522,51 @@ public class AutoUpdateChecker : UIElementContainer
                 Log.Warning("AutoUpdater: /releases array returned but no currentLine — refusing to guess");
                 return null;
             }
-            if (!TrySelectMaxVersionRelease(doc.RootElement, predicate: null, out JsonElement maxOverall, out Version maxOverallVer))
+
+            if (isMod)
             {
-                Log.Write("AutoUpdater: /releases empty or no parseable versions");
-                return null;
-            }
-            // Cross-major: highest published release is on a different line than
-            // current install. Route through the popup (file-gated by
-            // game/upgrade-url.txt) and skip the in-game patcher — major bumps
-            // can't be applied as a file-drop.
-            if (maxOverallVer.Major != currentLine.Major || maxOverallVer.Minor != currentLine.Minor)
-            {
-                string overallTag = maxOverall.GetProperty("tag_name").GetString();
-                string overallVersion = ExtractVersionPartFromTag(overallTag);
-                string overallCodename = ExtractCodenameFromTag(overallTag);
-                string currentVer = GlobalStats.Version.Split(' ').First();
-                if (ClassifyVanillaUpdate(overallVersion, currentVer) == UpdateAvailability.CrossMajor)
+                // Mods filter to vanilla's major.minor line upfront. No
+                // cross-major popup for mods — the popup is vanilla-only,
+                // and a mod release that doesn't match the current vanilla
+                // line just isn't relevant (it's for a different BlackBox
+                // major, the user must upgrade vanilla first).
+                bool ModLinePredicate(Version v) =>
+                    v.Major == currentLine.Major && v.Minor == currentLine.Minor;
+                if (!TrySelectMaxVersionRelease(doc.RootElement, ModLinePredicate, out JsonElement modBest, out _))
                 {
-                    Log.Write($"AutoUpdater: cross-major upgrade detected: {currentVer} -> {overallVersion}");
-                    NotifyMajorUpgradeIfConfigured(overallVersion, overallCodename);
+                    Log.Write($"AutoUpdater: no mod releases match vanilla line {currentLine.Major}.{currentLine.Minor}");
+                    return null;
                 }
-                return null;
+                latestRelease = modBest;
             }
-            // Same line: max-overall is also the max-in-line, use it as the
-            // in-game patch candidate.
-            latestRelease = maxOverall;
+            else
+            {
+                if (!TrySelectMaxVersionRelease(doc.RootElement, predicate: null, out JsonElement maxOverall, out Version maxOverallVer))
+                {
+                    Log.Write("AutoUpdater: /releases empty or no parseable versions");
+                    return null;
+                }
+                // Cross-major: highest published release is on a different
+                // line than current install. Route through the popup
+                // (file-gated by game/upgrade-url.txt) and skip the in-game
+                // patcher — major bumps can't be applied as a file-drop.
+                if (maxOverallVer.Major != currentLine.Major || maxOverallVer.Minor != currentLine.Minor)
+                {
+                    string overallTag = maxOverall.GetProperty("tag_name").GetString();
+                    string overallVersion = ExtractVersionPartFromTag(overallTag);
+                    string overallCodename = ExtractCodenameFromTag(overallTag);
+                    string currentVer = GlobalStats.Version.Split(' ').First();
+                    if (ClassifyVanillaUpdate(overallVersion, currentVer) == UpdateAvailability.CrossMajor)
+                    {
+                        Log.Write($"AutoUpdater: cross-major upgrade detected: {currentVer} -> {overallVersion}");
+                        NotifyMajorUpgradeIfConfigured(overallVersion, overallCodename);
+                    }
+                    return null;
+                }
+                // Same line: max-overall is also the max-in-line, use it as
+                // the in-game patch candidate.
+                latestRelease = maxOverall;
+            }
         }
         else
         {
@@ -560,7 +627,7 @@ public class AutoUpdateChecker : UIElementContainer
             string tag = tagEl.GetString();
             if (tag.IsEmpty())
                 continue;
-            string verPart = ExtractVersionPartFromTag(tag);
+            string verPart = StripVPrefix(ExtractVersionPartFromTag(tag));
             if (verPart.IsEmpty() || !Version.TryParse(verPart, out var v))
                 continue;
             if (predicate != null && !predicate(v))

--- a/Ship_Game/GameScreens/MainMenu/MainMenuScreen.cs
+++ b/Ship_Game/GameScreens/MainMenu/MainMenuScreen.cs
@@ -80,10 +80,11 @@ namespace Ship_Game.GameScreens.MainMenu
             if (list.Find("tutorials", out UIButton tutorials)) tutorials.OnClick = Tutorials_Clicked;
             if (list.Find("load_game", out UIButton loadGame))  loadGame.OnClick  = LoadGame_Clicked;
             if (list.Find("options",   out UIButton options))   options.OnClick   = Options_Clicked;
-            if (list.Find("mods",      out UIButton mods))      mods.OnClick    = Mods_Clicked;
-            if (list.Find("sandbox",   out UIButton sandbox))   sandbox.OnClick = DevSandbox_Clicked;
-            if (list.Find("info",      out UIButton info))      info.OnClick    = Info_Clicked;
-            if (list.Find("exit",      out UIButton exit))      exit.OnClick    = Exit_Clicked;
+            if (list.Find("mods",      out UIButton mods))      mods.OnClick      = Mods_Clicked;
+            if (list.Find("sandbox",   out UIButton sandbox))   sandbox.OnClick   = DevSandbox_Clicked;
+            if (list.Find("info",      out UIButton info))      info.OnClick      = Info_Clicked;
+            if (list.Find("support",   out UIButton support))   support.OnClick   = Support_Clicked;
+            if (list.Find("exit",      out UIButton exit))      exit.OnClick      = Exit_Clicked;
             list.PerformLayout();
 
             // Animate the buttons in and out
@@ -165,6 +166,7 @@ namespace Ship_Game.GameScreens.MainMenu
         void Options_Clicked(UIButton button)   => ScreenManager.AddScreen(new OptionsScreen(this));
         void Mods_Clicked(UIButton button)      => ScreenManager.AddScreen(new ModManager(this));
         void Info_Clicked(UIButton button)      => ScreenManager.AddScreen(new InGameWiki(this));
+        void Support_Clicked(UIButton button) => ScreenManager.AddScreen(new SupportBlackbox(this));
         void DevSandbox_Clicked(UIButton button)=> ScreenManager.GoToScreen(new DeveloperSandbox(), clear3DObjects: true);
         void Exit_Clicked(UIButton button)      => ExitScreen();
 

--- a/Ship_Game/GameScreens/MainMenu/SupportBlackbox.cs
+++ b/Ship_Game/GameScreens/MainMenu/SupportBlackbox.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Diagnostics;
+using Microsoft.Xna.Framework.Graphics;
+using Color = Microsoft.Xna.Framework.Color;
+using SDGraphics;
+using Vector2 = SDGraphics.Vector2;
+
+namespace Ship_Game.GameScreens.MainMenu
+{
+    // Main-menu popup that explains BlackBox and links to Ko-fi.
+    // Uses the standard PopupWindow chrome (same as InGameWiki) — title bar
+    // with built-in Close X, middle blurb, body paragraph, and a single
+    // affirmative button that opens the URL in the default browser via
+    // shell-exec.
+    public sealed class SupportBlackbox : PopupWindow
+    {
+        const string KofiUrl = "https://ko-fi.com/teamstardrive";
+
+        const string BodyText =
+            "StarDrive BlackBox is a community-driven revival of StarDrive, " +
+            "rebuilt and maintained by a small volunteer team in their spare " +
+            "time.\n\n" +
+            "If you've enjoyed playing and want to support continued " +
+            "development, you can contribute via Ko-fi. Every bit helps keep " +
+            "the lights on.";
+
+        string WrappedBody;
+
+        public SupportBlackbox(GameScreen parent) : base(parent, width: 520, height: 360)
+        {
+            IsPopup           = true;
+            TransitionOnTime  = 0.25f;
+            TransitionOffTime = 0.25f;
+
+            TitleText  = "Support BlackBox";
+            MiddleText = "Help keep StarDrive BlackBox alive";
+        }
+
+        public override void LoadContent()
+        {
+            base.LoadContent();
+
+            // Wrap to the popup body width minus a small inset on each side.
+            float wrapWidth = BottomBigFill.Width - 24f;
+            WrappedBody = Fonts.Arial14Bold.ParseText(BodyText, wrapWidth);
+
+            // Bottom-center the affirmative button inside the body area.
+            // Military style is texture-driven, ~168px wide.
+            float btnX = BottomBigFill.CenterX() - 84;
+            float btnY = BottomBigFill.Bottom - 30;
+            Button(ButtonStyle.Military, btnX, btnY, "Support", _ => OpenKofi());
+        }
+
+        public override void Draw(SpriteBatch batch, DrawTimes elapsed)
+        {
+            ScreenManager.FadeBackBufferToBlack(TransitionAlpha * 2 / 3);
+            base.Draw(batch, elapsed);
+
+            batch.SafeBegin();
+            batch.DrawString(Fonts.Arial14Bold, WrappedBody, BodyTextStart, Color.White);
+            batch.SafeEnd();
+        }
+
+        static void OpenKofi()
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo(KofiUrl) { UseShellExecute = true });
+            }
+            catch (Exception ex)
+            {
+                Log.Warning($"SupportBlackbox: failed to open '{KofiUrl}': {ex.Message}");
+            }
+        }
+    }
+}

--- a/Ship_Game/SpriteSystem/SpriteExtensions.cs
+++ b/Ship_Game/SpriteSystem/SpriteExtensions.cs
@@ -19,6 +19,11 @@ namespace Ship_Game
         None,
         AlphaBlend,
         Additive,
+        // XNA classic AlphaBlend formula (src*srcA + dst*(1-srcA)). Use for
+        // non-premultiplied source textures where you want the gradient
+        // preserved AND no over-brightness on overlap. MonoGame's default
+        // AlphaBlend assumes premul source.
+        NonPremultiplied,
     }
 
     public static class SpriteExtensions
@@ -309,10 +314,11 @@ namespace Ship_Game
         // SpriteBatch implicitly saves/restores GraphicsDevice render state per Begin/End.
         static BlendState ToBlendState(SpriteBlendMode mode) => mode switch
         {
-            SpriteBlendMode.Additive   => BlendState.Additive,
-            SpriteBlendMode.AlphaBlend => BlendState.AlphaBlend,
-            SpriteBlendMode.None       => BlendState.Opaque,
-            _                          => BlendState.AlphaBlend,
+            SpriteBlendMode.Additive         => BlendState.Additive,
+            SpriteBlendMode.AlphaBlend       => BlendState.AlphaBlend,
+            SpriteBlendMode.None             => BlendState.Opaque,
+            SpriteBlendMode.NonPremultiplied => BlendState.NonPremultiplied,
+            _                                => BlendState.AlphaBlend,
         };
 
         public static bool SafeBegin(this SpriteBatch batch, SpriteBlendMode blendMode)

--- a/Ship_Game/SpriteSystem/TextureInfo.cs
+++ b/Ship_Game/SpriteSystem/TextureInfo.cs
@@ -141,6 +141,12 @@ namespace Ship_Game.SpriteSystem
                     // the DXT5 fast path below — banding is invisible against
                     // the noisy art content, and PNG encoding is ~20× slower
                     // per nopack texture on full-rebuild.
+                    //
+                    // Stored non-premultiplied. Most consumers of UI/node use
+                    // additive or SourceAlphaSaturation blends which want
+                    // non-premul source; the only AlphaBlend consumers
+                    // (FleetDesign sensor halo, FOW sensor highlights) must
+                    // pre-multiply their tint at the call site.
                     ImageUtils.SaveAsPng(pngPath, Width, Height, color);
                     return pngPath;
                 }

--- a/Ship_Game/Universe/MiniMap.cs
+++ b/Ship_Game/Universe/MiniMap.cs
@@ -310,7 +310,7 @@ namespace Ship_Game
                 
                 {
                     float radius = Math.Min(0.09f, nodeRad);
-                    // Empire-colored gradient halo (alpha 150).
+                    // Empire-colored gradient halo (alpha 80).
                     batch.Draw(Node1, nodePos, ec, 0f, nodeOrigin, radius, SpriteEffects.None, 1f);
                     // Black-tinted gradient overlay to dim the surroundings.
                     batch.Draw(Node1, nodePos, transparentBlack, 0f, nodeOrigin, nodeRad, SpriteEffects.None, 1f);

--- a/Ship_Game/Universe/MiniMap.cs
+++ b/Ship_Game/Universe/MiniMap.cs
@@ -106,9 +106,23 @@ namespace Ship_Game
 
             try
             {
+                // UI/node1 is stored non-premultiplied in the §4.6 #7
+                // lossless-alpha cache. The colored Node1 draws here leak
+                // through alpha=0 outer pixels under MonoGame's default
+                // premul AlphaBlend, which makes the nodes appear as
+                // hard-edged blobs instead of soft gradients. NonPremultiplied
+                // is the XNA-classic AlphaBlend formula (src*srcA + dst*(1-srcA))
+                // — alpha=0 contributes 0 (gradient preserved) and overlapping
+                // nodes blend smoothly without the Additive over-brightness.
+                batch.SafeEnd();
+                batch.SafeBegin(SpriteBlendMode.NonPremultiplied);
+
                 DrawMinimapInfluenceNodes(batch);
                 DrawSelected(batch, Player);
                 DrawWarnings(batch);
+
+                batch.SafeEnd();
+                batch.SafeBegin();
             }
             catch (Exception e)
             {
@@ -251,7 +265,11 @@ namespace Ship_Game
 
                 bool combat = false;
                 float intensity = 0.005f;
-                var ec = new Color(empire.EmpireColor, 150);
+                // Halo alpha kept low (~30%) so overlapping nodes stay
+                // readable under NonPremultiplied blend — at higher alpha
+                // the territory layer would saturate the sensor halos
+                // underneath into a single uniform blob.
+                var ec = new Color(empire.EmpireColor, 80);
                 if (empire.isPlayer)
                 {
                     if (node.Source is Ship ship)
@@ -292,8 +310,9 @@ namespace Ship_Game
                 
                 {
                     float radius = Math.Min(0.09f, nodeRad);
-                    // draw a shade to dim the color. 
+                    // Empire-colored gradient halo (alpha 150).
                     batch.Draw(Node1, nodePos, ec, 0f, nodeOrigin, radius, SpriteEffects.None, 1f);
+                    // Black-tinted gradient overlay to dim the surroundings.
                     batch.Draw(Node1, nodePos, transparentBlack, 0f, nodeOrigin, nodeRad, SpriteEffects.None, 1f);
                 }
             }
@@ -321,8 +340,8 @@ namespace Ship_Game
         
         void DrawMinimapEmpireNodes(SpriteBatch batch, Empire e)
         {
+            DrawMinimapNodes(batch, e, e.SensorNodes, excludeProjectors: true);
             DrawMinimapNodes(batch, e, e.BorderNodes, excludeProjectors:false);
-            DrawMinimapNodes(batch, e, e.SensorNodes, excludeProjectors:true);
         }
 
         void ZoomToShip_OnClick(ToggleButton toggleButton)

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
@@ -954,10 +954,18 @@ namespace Ship_Game
             for (int i = bombs.Length - 1; i >= 0; --i)
             {
                 Bomb bomb = bombs[i];
-                if (bomb?.Model != null)
-                {
-                    Projectile.DrawMesh(this, bomb.Model, bomb.World, bomb.Texture.Texture, scale:25f);
-                }
+                // Skip Dead bombs — narrows the SimThread/main-thread race
+                // window between Bomb.Update setting Dead and the sim loop
+                // doing the actual BombList.RemoveAt.
+                if (bomb == null || bomb.Dead || bomb.Model == null)
+                    continue;
+                // Phase 3.5 dropped the *50 multiplier for projectile meshes
+                // (FBX corpus ships at native game-unit scale, not unit-scale
+                // like the old XNB). The bomb path kept its legacy scale:25f,
+                // which is what was rendering the bomb as a huge orange-yellow
+                // cloud. Switch to Weapon.Scale to match Projectile.cs:450
+                // (tune via Weapon xml's Scale).
+                Projectile.DrawMesh(this, bomb.Model, bomb.World, bomb.Texture.Texture, scale: bomb.Weapon.Scale);
             }
         }
         // FB - This cf needs refactor

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.UpdateGame.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.UpdateGame.cs
@@ -251,11 +251,21 @@ namespace Ship_Game
             {
                 ExplosionManager.Update(this, timeStep.FixedTime);
 
+                // Reverse iteration so RemoveAt(i) below doesn't disturb
+                // indices we haven't visited yet. Bomb.Update sets Dead=true
+                // on impact or miss; the actual list mutation happens here so
+                // it's confined to SimThread (DrawBombs reads BombList from
+                // the main thread without locking).
                 Span<Bomb> bombs = BombList.AsSpan();
                 for (int i = bombs.Length - 1; i >= 0; --i)
                 {
                     Bomb bomb = bombs[i];
-                    bomb?.Update(timeStep);
+                    if (bomb != null)
+                    {
+                        bomb.Update(timeStep);
+                        if (bomb.Dead)
+                            BombList.RemoveAt(i);
+                    }
                 }
 
                 Shields?.Update(timeStep);

--- a/StarDrive.csproj
+++ b/StarDrive.csproj
@@ -879,6 +879,7 @@
     <Compile Include="Ship_Game\PopupWindow.cs" />
     <Compile Include="Ship_Game\StoryAndEvents\EventPopup.cs" />
     <Compile Include="Ship_Game\GameScreens\MainMenu\MainMenuScreen.cs" />
+    <Compile Include="Ship_Game\GameScreens\MainMenu\SupportBlackbox.cs" />
     <Compile Include="Ship_Game\GameScreens\Universe\ShipListScreen.cs" />
     <Compile Include="Ship_Game\NodeState.cs" />
     <Compile Include="Ship_Game\StoryAndEvents\YouLoseScreen.cs" />

--- a/UnitTests/UI/AutoUpdateCheckerTests.cs
+++ b/UnitTests/UI/AutoUpdateCheckerTests.cs
@@ -147,5 +147,109 @@ namespace UnitTests.UI
             Assert.IsTrue(found);
             Assert.AreEqual(new Version(1, 60, 9), best);
         }
+
+        [TestMethod]
+        public void TrySelectMaxVersionRelease_StripsVPrefixOnModTags()
+        {
+            // Mod tag convention is v<major>.<minor>.NNNN. The `v` must be
+            // stripped before Version.TryParse or the tag is silently
+            // discarded and TrySelectMaxVersionRelease returns false.
+            string json = """
+            [
+                { "tag_name": "v1.60.0010", "prerelease": false },
+                { "tag_name": "v1.60.0014", "prerelease": false },
+                { "tag_name": "v1.60.0012", "prerelease": false }
+            ]
+            """;
+            using JsonDocument doc = JsonDocument.Parse(json);
+            bool found = AutoUpdateChecker.TrySelectMaxVersionRelease(
+                doc.RootElement, predicate: null,
+                out _, out Version best);
+            Assert.IsTrue(found, "v-prefixed mod tags must parse");
+            Assert.AreEqual(new Version(1, 60, 14), best);
+        }
+
+        [TestMethod]
+        public void TrySelectMaxVersionRelease_PredicateFiltersToVanillaLine()
+        {
+            // Mod releases page mixes a higher 1.61 release with the
+            // 1.60 line. With a Jupiter 1.60 install, the major.minor
+            // predicate must skip 1.61 and pick the highest 1.60.NNNN.
+            string json = """
+            [
+                { "tag_name": "v1.61.0001", "prerelease": false },
+                { "tag_name": "v1.60.0014", "prerelease": false },
+                { "tag_name": "v1.60.0009", "prerelease": false },
+                { "tag_name": "v1.51.0042", "prerelease": false }
+            ]
+            """;
+            using JsonDocument doc = JsonDocument.Parse(json);
+            bool ModLinePredicate(Version v) => v.Major == 1 && v.Minor == 60;
+            bool found = AutoUpdateChecker.TrySelectMaxVersionRelease(
+                doc.RootElement, ModLinePredicate,
+                out _, out Version best);
+            Assert.IsTrue(found, "Highest 1.60.NNNN must be picked when predicate filters out 1.61/1.51");
+            Assert.AreEqual(new Version(1, 60, 14), best);
+        }
+
+        [TestMethod]
+        public void IsModLatestNewer_SameLine_PicksByPatch()
+        {
+            // Both parse and share major.minor — direct numeric compare.
+            Assert.IsTrue(AutoUpdateChecker.IsModLatestNewer("v1.60.0014", "v1.60.0009"),
+                "Higher patch on same line should be newer");
+            Assert.IsFalse(AutoUpdateChecker.IsModLatestNewer("v1.60.0009", "v1.60.0009"),
+                "Equal versions should not trigger update");
+            Assert.IsFalse(AutoUpdateChecker.IsModLatestNewer("v1.60.0005", "v1.60.0009"),
+                "Older patch on same line should not be newer");
+        }
+
+        [TestMethod]
+        public void IsModLatestNewer_StripsVPrefixOnBothSides()
+        {
+            // The `v` prefix must be tolerated on either side independently —
+            // mod authors might tag with `v` and ship Version without it, or
+            // vice versa during the transition.
+            Assert.IsTrue(AutoUpdateChecker.IsModLatestNewer("v1.60.0014", "1.60.0009"));
+            Assert.IsTrue(AutoUpdateChecker.IsModLatestNewer("1.60.0014",  "v1.60.0009"));
+            Assert.IsFalse(AutoUpdateChecker.IsModLatestNewer("v1.60.0009", "1.60.0009"));
+        }
+
+        [TestMethod]
+        public void IsModLatestNewer_Fallback_LegacyUnparseableCurrent()
+        {
+            // Installed mod version is the legacy free-form string (e.g. "0.5b"
+            // or "2024-09-rev3") that won't parse to System.Version. The new
+            // aligned release should be promoted as an update so users on
+            // legacy mod versions get a one-click upgrade path.
+            Assert.IsTrue(AutoUpdateChecker.IsModLatestNewer("v1.60.0014", "0.5b"),
+                "Legacy unparseable current must fall back to promoting the candidate");
+            Assert.IsTrue(AutoUpdateChecker.IsModLatestNewer("v1.60.0014", "Combined Arms v3.2"),
+                "Free-form current must fall back to promoting the candidate");
+            Assert.IsTrue(AutoUpdateChecker.IsModLatestNewer("v1.60.0014", ""),
+                "Empty current must fall back to promoting the candidate");
+        }
+
+        [TestMethod]
+        public void IsModLatestNewer_Fallback_DifferentVanillaLine()
+        {
+            // Installed mod version parses cleanly but on a different
+            // major.minor (mod was tracking Mars 1.51, vanilla is now
+            // Jupiter 1.60). Treat the new aligned release as an update.
+            Assert.IsTrue(AutoUpdateChecker.IsModLatestNewer("v1.60.0001", "v1.51.42"),
+                "Mod on a different vanilla line must be promoted to the new aligned release");
+            Assert.IsTrue(AutoUpdateChecker.IsModLatestNewer("1.60.0001", "1.51.42"),
+                "Same case without v-prefix");
+        }
+
+        [TestMethod]
+        public void IsModLatestNewer_UnparseableCandidate_ReturnsFalse()
+        {
+            // Should not happen post-TrySelectMaxVersionRelease (which only
+            // emits parseable tags), but if a malformed candidate slips
+            // through we refuse rather than promoting blindly.
+            Assert.IsFalse(AutoUpdateChecker.IsModLatestNewer("garbage", "v1.60.0009"));
+            Assert.IsFalse(AutoUpdateChecker.IsModLatestNewer("", "v1.60.0009"));
+        }
     }
 }

--- a/game/Content/UI/MMenu.Jupiter.yaml
+++ b/game/Content/UI/MMenu.Jupiter.yaml
@@ -219,6 +219,12 @@ Elements:
           AbsSize: [200, 0] # aspect fill width
           ClickSfx: sd_ui_tactical_pause
       - Button:
+          Name: support
+          Title: "Support BlackBox"
+          AbsSize: [200, 0] # aspect fill width
+          ButtonStyle: Military
+          ClickSfx: sd_ui_tactical_pause
+      - Button:
           Name: exit
           Title: "{5}" # "Exit"
           AbsSize: [200, 0] # aspect fill width

--- a/game/Content/UI/MMenu.Mars.yaml
+++ b/game/Content/UI/MMenu.Mars.yaml
@@ -287,6 +287,12 @@ Elements:
           AbsSize: [200, 0] # aspect fill width
           ClickSfx: sd_ui_tactical_pause
       - Button:
+          Name: support
+          Title: "Support BlackBox"
+          AbsSize: [200, 0] # aspect fill width
+          ButtonStyle: Military
+          ClickSfx: sd_ui_tactical_pause
+      - Button:
           Name: exit
           Title: "{5}" # "Exit"
           AbsSize: [200, 0] # aspect fill width

--- a/game/Content/UI/MMenu.Venus.yaml
+++ b/game/Content/UI/MMenu.Venus.yaml
@@ -239,6 +239,12 @@ Elements:
           AbsSize: [200, 0] # aspect fill width
           ClickSfx: sd_ui_tactical_pause
       - Button:
+          Name: support
+          Title: "Support BlackBox"
+          AbsSize: [200, 0] # aspect fill width
+          ButtonStyle: Military
+          ClickSfx: sd_ui_tactical_pause
+      - Button:
           Name: exit
           Title: "{5}" # "Exit"
           AbsSize: [200, 0] # aspect fill width

--- a/game/Content/Weapons/Bombs/Death Spores.xml
+++ b/game/Content/Weapons/Bombs/Death Spores.xml
@@ -29,7 +29,7 @@
 
   <!-- Projectile Information -->
   <DamageAmount>0</DamageAmount>
-  <Scale>2</Scale>
+  <Scale>1</Scale>
   <MuzzleFlash>Yes</MuzzleFlash>
   <ProjectileSpeed>2000</ProjectileSpeed>
   <ExplosionRadius>75</ExplosionRadius> <!-- This Projectile Explodes -->

--- a/game/Content/Weapons/Bombs/Death Spores.xml
+++ b/game/Content/Weapons/Bombs/Death Spores.xml
@@ -29,7 +29,7 @@
 
   <!-- Projectile Information -->
   <DamageAmount>0</DamageAmount>
-  <Scale>1</Scale>
+  <Scale>0.25</Scale>
   <MuzzleFlash>Yes</MuzzleFlash>
   <ProjectileSpeed>2000</ProjectileSpeed>
   <ExplosionRadius>75</ExplosionRadius> <!-- This Projectile Explodes -->

--- a/game/Content/Weapons/Bombs/NuclearBomb.xml
+++ b/game/Content/Weapons/Bombs/NuclearBomb.xml
@@ -32,7 +32,7 @@
 
   <!-- Projectile Information -->
   <DamageAmount>0</DamageAmount>
-  <Scale>1</Scale>
+  <Scale>0.25</Scale>
   <MuzzleFlash>Yes</MuzzleFlash>
   <ProjectileSpeed>2000</ProjectileSpeed>
   <ExplosionRadius>75</ExplosionRadius> <!-- This Projectile Explodes -->

--- a/game/Content/Weapons/Bombs/NuclearBomb.xml
+++ b/game/Content/Weapons/Bombs/NuclearBomb.xml
@@ -32,7 +32,7 @@
 
   <!-- Projectile Information -->
   <DamageAmount>0</DamageAmount>
-  <Scale>2</Scale>
+  <Scale>1</Scale>
   <MuzzleFlash>Yes</MuzzleFlash>
   <ProjectileSpeed>2000</ProjectileSpeed>
   <ExplosionRadius>75</ExplosionRadius> <!-- This Projectile Explodes -->

--- a/game/Content/Weapons/Bombs/Owlwok Antidote.xml
+++ b/game/Content/Weapons/Bombs/Owlwok Antidote.xml
@@ -31,7 +31,7 @@
 
   <!-- Projectile Information -->
   <DamageAmount>0</DamageAmount>
-  <Scale>2</Scale>
+  <Scale>1</Scale>
   <MuzzleFlash>Yes</MuzzleFlash>
   <ProjectileSpeed>2700</ProjectileSpeed>
   <ExplosionRadius>75</ExplosionRadius> <!-- This Projectile Explodes -->

--- a/game/Content/Weapons/Bombs/Owlwok Antidote.xml
+++ b/game/Content/Weapons/Bombs/Owlwok Antidote.xml
@@ -31,7 +31,7 @@
 
   <!-- Projectile Information -->
   <DamageAmount>0</DamageAmount>
-  <Scale>1</Scale>
+  <Scale>0.25</Scale>
   <MuzzleFlash>Yes</MuzzleFlash>
   <ProjectileSpeed>2700</ProjectileSpeed>
   <ExplosionRadius>75</ExplosionRadius> <!-- This Projectile Explodes -->


### PR DESCRIPTION
## Summary

Second post-1.60 fix batch. Six independent fixes bundled because they
share the same release window:

- **Bomb effects:** oversized projectile mesh + bombs that flew forever
  on a miss + sim/draw race on `BombList`.
- **AutoUpdater (mod path):** discover mod releases that match the
  vanilla `major.minor` line, with a fallback for legacy free-form
  mod version strings (e.g. CA `v8.7i`).
- **Main menu:** new "Support BlackBox" button → Ko-fi popup.
- **FleetDesign sensor halo:** stopped flooding the whole screen green;
  size now reflects the ship's actual `SensorRange`, not the slider.
- **FleetDesign lighting:** post-migration `AssignLightRig` is a stub
  (SunBurn `.lightRig` content type was discontinued), so the screen
  was rendering under-lit. Installed a Key/Fill/Back + Ambient rig
  mirroring `ShipDesignScreen.SetupShipyardLighting`.
- **MiniMap nodes:** UI/node and UI/node1 are non-premul PNGs and
  leaked RGB under MonoGame's premul AlphaBlend; wrapped node passes
  in `NonPremultiplied` and trimmed alpha so overlapping nodes don't
  bloom.
