### PR TITLE
Jupiter 1.60/sentry fixes 03

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ game/SharpDX.XInput.dll
 # from Microsoft, not tracked in git). NSIS picks it up at build time.
 # See Deploy/prereq/README.md for fetch instructions.
 Deploy/prereq/*.exe
+TestResults/

--- a/Ship_Game/Audio/GameAudio.cs
+++ b/Ship_Game/Audio/GameAudio.cs
@@ -60,16 +60,15 @@ public static class GameAudio
         try
         {
             Destroy(); // just in case
+            AudioEngineGood = false; // reset; only flip true once Music/RacialMusic/AudioEngine are all set
 
             Devices = new();
-            AudioEngineGood = true;
 
             // try selecting an audio device if no argument given
             if (device == null && !Devices.PickAudioDevice(out device))
             {
                 Log.Warning("GameAudio is disabled since audio device selection failed.");
                 AudioDisabled = true;
-                AudioEngineGood = false;
                 return;
             }
 
@@ -86,10 +85,19 @@ public static class GameAudio
             AsyncSfxQueue = new(16);
             SfxThread = new(SfxEnqueueThread) { Name = "GameAudioSfx" };
             SfxThread.Start();
+
+            // Invariant for callers: AudioEngineGood == true implies Music, RacialMusic and
+            // AudioEngine are non-null. Worker threads (e.g. LoadGame.SetupUniverseScreen calling
+            // StopGenericMusic) may observe this flag concurrently with a re-init, so flipping
+            // it early — before fields are populated — caused NREs on Music.Stop.
+            AudioEngineGood = true;
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "AudioEngine init failed. Make sure that Speakers/Headphones are attached");
+            // Almost always user-environment: WASAPI AUDCLNT_E_UNSUPPORTED_FORMAT (0x88890008) from
+            // Bluetooth headsets in handsfree/mono, USB DACs with restricted format support, virtual
+            // audio devices, or a device-switch race. Game gracefully degrades to silent mode.
+            Log.Warning($"AudioEngine init failed (game will run without sound): {ex.Message}");
             Destroy();
             AudioEngineGood = false;
         }
@@ -154,7 +162,7 @@ public static class GameAudio
     public static void StopGenericMusic(bool fadeout)
     {
         if (AudioEngineGood)
-            Music.Stop(fadeout);
+            Music?.Stop(fadeout);
     }
 
     public static void PauseGenericMusic()  { if (!IsMusicDisabled) Music.Pause(); }

--- a/Ship_Game/Audio/GameAudio.cs
+++ b/Ship_Game/Audio/GameAudio.cs
@@ -17,7 +17,11 @@ public static class GameAudio
     static bool AudioDisabled;
     static bool EffectsDisabled;
     static bool MusicDisabled;
-    static bool AudioEngineGood;
+    // volatile: published by Initialize on the main thread after Music/RacialMusic/AudioEngine
+    // fields are assigned; read by worker threads (e.g. LoadGame.SetupUniverseScreen) that gate
+    // Music access on it. Without volatile the JIT/CPU could reorder so a reader sees the flag
+    // true while still seeing stale nulls in the dependent fields.
+    static volatile bool AudioEngineGood;
     
     static NAudioPlaybackEngine AudioEngine;
     static string ConfigFile;

--- a/Ship_Game/Combat.cs
+++ b/Ship_Game/Combat.cs
@@ -106,9 +106,23 @@ namespace Ship_Game
             }
         }
 
-        public bool Done => DefendingTroop?.Strength <= 0 || DefendingBuilding?.IsDestroyed == true 
-                                                          || AttackingBuilding?.IsDestroyed == true 
-                                                          || AttackingTroop?.Strength <= 0;
+        // External paths (volcano lava, ship crash, terraforming, bomb tile destroy, outcome events,
+        // UI scrap) can remove a building from BuildingList + tile while its Strength is still > 0.
+        // The Combat keeps a direct ref to the orphaned Building, ticks damage onto it, eventually
+        // drives Strength <= 0, then DestroyBuilding fails because it's already gone from the list.
+        // Detect the orphan state so ResolveTacticalCombats can sweep this Combat cleanly first.
+        bool DefendingBuildingOrphaned => DefendingBuilding != null
+                                       && DefenseTile != null
+                                       && DefenseTile.Building != DefendingBuilding;
+
+        bool AttackingBuildingOrphaned => AttackingBuilding != null
+                                       && !Planet.HasBuilding(b => b == AttackingBuilding);
+
+        public bool Done => DefendingTroop?.Strength <= 0 || DefendingBuilding?.IsDestroyed == true
+                                                          || AttackingBuilding?.IsDestroyed == true
+                                                          || AttackingTroop?.Strength <= 0
+                                                          || DefendingBuildingOrphaned
+                                                          || AttackingBuildingOrphaned;
 
         private struct AttackerStats
         {

--- a/Ship_Game/Combat.cs
+++ b/Ship_Game/Combat.cs
@@ -116,7 +116,7 @@ namespace Ship_Game
                                        && DefenseTile.Building != DefendingBuilding;
 
         bool AttackingBuildingOrphaned => AttackingBuilding != null
-                                       && !Planet.HasBuilding(b => b == AttackingBuilding);
+                                       && !Planet.ContainsBuilding(AttackingBuilding);
 
         public bool Done => DefendingTroop?.Strength <= 0 || DefendingBuilding?.IsDestroyed == true
                                                           || AttackingBuilding?.IsDestroyed == true

--- a/Ship_Game/GameScreens/MainMenu/AutoUpdateChecker.cs
+++ b/Ship_Game/GameScreens/MainMenu/AutoUpdateChecker.cs
@@ -743,13 +743,29 @@ public class AutoUpdateChecker : UIElementContainer
         var cts = new CancellationTokenSource(timeout);
         if (cancellableTask != null)
         {
-            Task.Run(async () =>
+            // Snapshot the token before the async hop. Caller wraps cts in `using`; once
+            // disposed, cts.Token getter throws ObjectDisposedException — and because this
+            // is fire-and-forget, the exception used to surface as UnobservedTaskException
+            // at finalization. The CancellationToken struct itself is safe post-Dispose.
+            // IsComplete in the loop guard ensures the task exits naturally after a
+            // successful download (Dispose alone doesn't set IsCancellationRequested).
+            CancellationToken token = cts.Token;
+            _ = Task.Run(async () =>
             {
-                while (!cts.IsCancellationRequested)
+                try
                 {
-                    if (cancellableTask.IsCancelRequested) { cts.Cancel(); return; }
-                    await Task.Delay(100, cts.Token).ContinueWith(_ => { });
+                    while (!token.IsCancellationRequested && !cancellableTask.IsComplete)
+                    {
+                        if (cancellableTask.IsCancelRequested)
+                        {
+                            try { cts.Cancel(); } catch (ObjectDisposedException) { }
+                            return;
+                        }
+                        await Task.Delay(100, token);
+                    }
                 }
+                catch (OperationCanceledException) { /* expected on timeout/cancel */ }
+                catch (ObjectDisposedException)    { /* expected if caller disposed cts */ }
             });
         }
         return cts;

--- a/Ship_Game/GameScreens/Program.cs
+++ b/Ship_Game/GameScreens/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.Xna.Framework;
 
@@ -10,6 +11,10 @@ internal static class Program
     public const int GAME_RUN_FAILURE = -1;
     public const int SCREEN_UPDATE_FAILURE = -2;
     public const int UNHANDLED_EXCEPTION = -3;
+    public const int NATIVE_DLL_LOAD_FAILURE = -4;
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, EntryPoint = "MessageBoxW")]
+    static extern int Win32MessageBox(IntPtr hWnd, string text, string caption, uint type);
 
     // Set by --apply-patch=<version> CLI arg. AutoPatcher's pre-elevation pass
     // (non-elevated download + unzip) writes a PendingPatch.json marker, then
@@ -199,6 +204,40 @@ internal static class Program
         return runGame;
     }
 
+    // Probe SDNative.dll explicitly so we can produce a clear, actionable error if the file
+    // is blocked by Windows security policy (Smart App Control, WDAC, AppLocker) or quarantined
+    // by AV. Without this probe the failure surfaces deep in startup as a TypeInitializationException
+    // for Ship_Game.Parallel (the first P/Invoke into SDNative.dll), which gives the user an opaque
+    // stack trace they can't act on. See Sentry HRESULT 0x800711C7 reports for context.
+    static void EnsureNativeDependenciesLoadable()
+    {
+        try
+        {
+            NativeLibrary.Load("SDNative.dll", typeof(Program).Assembly, null);
+        }
+        catch (Exception ex)
+        {
+            const uint MB_OK = 0x0;
+            const uint MB_ICONERROR = 0x10;
+            string message =
+                "StarDrive cannot start because the required native library 'SDNative.dll' could not be loaded.\n\n" +
+                "This is most often caused by Windows security policies blocking the file:\n" +
+                "  • Smart App Control (Windows 11)\n" +
+                "  • Windows Defender Application Control (WDAC) or AppLocker\n" +
+                "  • Antivirus quarantine\n\n" +
+                "How to fix:\n" +
+                "  1. Open Windows Security → App & browser control → Smart App Control settings.\n" +
+                "     Set it to 'Off' or 'Evaluation'.\n" +
+                "  2. Add an exception in your antivirus for the StarDrive install folder.\n" +
+                "  3. On a managed (work/school) machine, contact your IT administrator.\n\n" +
+                "Need help? Join our Discord server (link is on the game release page) and we'll help you sort it out.\n\n" +
+                "Technical details:\n" + ex.Message;
+
+            Win32MessageBox(IntPtr.Zero, message, "StarDrive — Native library blocked", MB_OK | MB_ICONERROR);
+            Environment.Exit(NATIVE_DLL_LOAD_FAILURE);
+        }
+    }
+
     [STAThread]
     static void Main(string[] args)
     {
@@ -208,6 +247,8 @@ internal static class Program
         Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
         CultureInfo.DefaultThreadCurrentCulture   = CultureInfo.InvariantCulture;
         CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+
+        EnsureNativeDependenciesLoadable();
 
         try
         {

--- a/Ship_Game/GameScreens/ScreenMediaPlayer.cs
+++ b/Ship_Game/GameScreens/ScreenMediaPlayer.cs
@@ -155,7 +155,7 @@ namespace Ship_Game.GameScreens
             }
             catch (Exception ex)
             {
-                Log.Error(ex, $"PlayVideo failed: 'Video/{videoPath}'");
+                Log.Warning($"PlayVideo failed: 'Video/{videoPath}' reason: {ex.Message}");
             }
         }
 
@@ -265,25 +265,37 @@ namespace Ship_Game.GameScreens
 
         public void Update(GameScreen screen)
         {
-            if (!PlaybackSuccess || IsDisposed)
+            if (!PlaybackSuccess || IsDisposed || PlaybackFailed)
                 return;
 
-            if (Video != null && Player.State != MediaState.Stopped)
+            try
             {
-                // pause video when game screen goes inactive
-                if (screen.IsActive && Player.State == MediaState.Paused)
-                    Player.Resume();
-                else if (!screen.IsActive && Player.State == MediaState.Playing)
-                    Player.Pause();
-            }
+                if (Video != null && Player.State != MediaState.Stopped)
+                {
+                    // pause video when game screen goes inactive
+                    if (screen.IsActive && Player.State == MediaState.Paused)
+                        Player.Resume();
+                    else if (!screen.IsActive && Player.State == MediaState.Playing)
+                        Player.Pause();
+                }
 
-            if (!ExtraMusic.IsStopped)
+                if (!ExtraMusic.IsStopped)
+                {
+                    // pause music if needed
+                    if (screen.IsActive && ExtraMusic.IsPaused)
+                        ExtraMusic.Resume();
+                    else if (!screen.IsActive && ExtraMusic.IsPlaying)
+                        ExtraMusic.Pause();
+                }
+            }
+            catch (Exception ex)
             {
-                // pause music if needed
-                if (screen.IsActive && ExtraMusic.IsPaused)
-                    ExtraMusic.Resume();
-                else if (!screen.IsActive && ExtraMusic.IsPlaying)
-                    ExtraMusic.Pause();
+                // Underlying MediaSession can transition to an invalid state (alt-tab, device loss,
+                // GPU reset, codec hiccup) and throw E_POINTER from Resume/Pause. Video is incidental;
+                // mark failed and bail so the game keeps running. DiplomacyScreen and other callers
+                // gate further PlayVideo calls on PlaybackFailed.
+                Log.Warning($"ScreenMediaPlayer.Update Pause/Resume failed for '{Name}': {ex.Message}");
+                PlaybackFailed = true;
             }
         }
 
@@ -299,9 +311,9 @@ namespace Ship_Game.GameScreens
 
         public void Draw(SpriteBatch batch, in Rectangle rect, Color color, float rotation, SpriteEffects effects)
         {
-            if (!PlaybackSuccess || Player.IsDisposed || !Active || IsDisposed)
+            if (!PlaybackSuccess || Player.IsDisposed || !Active || IsDisposed || PlaybackFailed)
                 return;
-            
+
             if (!Visible)
             {
                 if (IsPlaying)
@@ -314,7 +326,18 @@ namespace Ship_Game.GameScreens
                 // don't grab lo-fi default video thumbnail while video is looping around
                 if (CaptureThumbnail || Player.PlayPosition.TotalMilliseconds > 0)
                 {
-                    Frame = Player.GetTexture();
+                    try
+                    {
+                        Frame = Player.GetTexture();
+                    }
+                    catch (Exception ex)
+                    {
+                        // Same MediaSession failure mode as Update's Pause/Resume: platform layer can
+                        // return a null texture / throw when the underlying video session is invalid.
+                        Log.Warning($"ScreenMediaPlayer.Draw GetTexture failed for '{Name}': {ex.Message}");
+                        PlaybackFailed = true;
+                        return;
+                    }
                 }
             }
 

--- a/Ship_Game/GameScreens/ScreenMediaPlayer.cs
+++ b/Ship_Game/GameScreens/ScreenMediaPlayer.cs
@@ -155,6 +155,9 @@ namespace Ship_Game.GameScreens
             }
             catch (Exception ex)
             {
+                // Mark failed so callers (e.g. DiplomacyScreen.Update gates PlayVideoAndMusic on
+                // !PlaybackFailed) stop retrying every frame after a definitive load failure.
+                PlaybackFailed = true;
                 Log.Warning($"PlayVideo failed: 'Video/{videoPath}' reason: {ex.Message}");
             }
         }

--- a/Ship_Game/GameScreens/StarDriveGame.cs
+++ b/Ship_Game/GameScreens/StarDriveGame.cs
@@ -185,9 +185,23 @@ namespace Ship_Game
             if (IsDeviceGood)
             {
                 FrameTimeLogger.BeginDraw();
-                ScreenManager.ClearScreen(Color.Black);
-                ScreenManager.Draw();
-                base.Draw(gameTime);
+                try
+                {
+                    ScreenManager.ClearScreen(Color.Black);
+                    ScreenManager.Draw();
+                    base.Draw(gameTime);
+                }
+                finally
+                {
+                    // Defensive: several render-to-texture paths (Bloom, Distortion, ShadowMap,
+                    // FogMap ping-pong, DrawBorders RT, LightsTarget, MainTarget) bind a render
+                    // target without try/finally cleanup. If any of them throws or skips its
+                    // SetRenderTarget(null), MonoGame crashes Present with
+                    // "Cannot call Present when a render target is active." Restore the back
+                    // buffer unconditionally as a safety net. The underlying leak should still
+                    // be tracked and fixed; this just stops it from taking the game down.
+                    ScreenManager?.GraphicsDevice?.SetRenderTarget(null);
+                }
                 string topScreen = ScreenManager.NumScreens > 0
                     ? ScreenManager.Current?.GetType().Name ?? ""
                     : "";

--- a/Ship_Game/GameScreens/StarDriveGame.cs
+++ b/Ship_Game/GameScreens/StarDriveGame.cs
@@ -200,7 +200,11 @@ namespace Ship_Game
                     // "Cannot call Present when a render target is active." Restore the back
                     // buffer unconditionally as a safety net. The underlying leak should still
                     // be tracked and fixed; this just stops it from taking the game down.
-                    ScreenManager?.GraphicsDevice?.SetRenderTarget(null);
+                    // Inner try/catch: if the original draw threw because the device was lost or
+                    // disposed, this cleanup call can throw too — swallow it so we don't mask the
+                    // real exception bubbling out of the outer try.
+                    try { ScreenManager?.GraphicsDevice?.SetRenderTarget(null); }
+                    catch { /* device lost/disposed; let the original exception propagate */ }
                 }
                 string topScreen = ScreenManager.NumScreens > 0
                     ? ScreenManager.Current?.GetType().Name ?? ""

--- a/Ship_Game/Troops/Troop.cs
+++ b/Ship_Game/Troops/Troop.cs
@@ -442,7 +442,11 @@ namespace Ship_Game
         {
             if (!forceLaunch && !CanLaunch)
                 return null;
-            if (HostPlanet?.Troops.TryRemoveTroop(tile, this) != true)
+            // quiet: UniverseObjectManager.UpdateAllShips runs ship updates in parallel, so two
+            // ships' ProcessResupply → GetTroopShipForRebase calls can pick the same launchable
+            // troop from the same planet. The loser hits TryRemoveTroop after the winner already
+            // removed it — benign (caller gets null, retries next tick) but used to spam Sentry.
+            if (HostPlanet?.Troops.TryRemoveTroop(tile, this, quiet: true) != true)
                 return null;
 
             Ship troopShip = CreateShipForTroop(HostPlanet);

--- a/Ship_Game/Universe/SolarBodies/SolarSystemBody.cs
+++ b/Ship_Game/Universe/SolarBodies/SolarSystemBody.cs
@@ -692,6 +692,13 @@ namespace Ship_Game
             return BuildingList.Any(predicate);
         }
 
+        // Allocation-free reference-equality lookup; preferred over HasBuilding(b => b == target)
+        // for hot paths like Combat.Done where the predicate would close over `target` each call.
+        public bool ContainsBuilding(Building b)
+        {
+            return BuildingList.ContainsRef(b);
+        }
+
         public int CountBuildings(Predicate<Building> predicate)
         {
             return BuildingList.Count(predicate);

--- a/Ship_Game/Universe/SolarBodies/TroopManager.cs
+++ b/Ship_Game/Universe/SolarBodies/TroopManager.cs
@@ -75,7 +75,10 @@ namespace Ship_Game
             }
         }
 
-        public bool TryRemoveTroop(PlanetGridSquare tile, Troop troop)
+        // quiet: caller knows the troop may already be gone (concurrent removal race) and
+        // doesn't want this surfaced to Sentry. Used by Troop.LaunchToSpace where parallel
+        // ship updates can pick the same launchable troop.
+        public bool TryRemoveTroop(PlanetGridSquare tile, Troop troop, bool quiet = false)
         {
             lock (TroopsHere)
             {
@@ -89,7 +92,8 @@ namespace Ship_Game
                     return true;
                 }
 
-                Log.Error($"Could not remove troop {troop} on planet {Ground.Name}");
+                if (!quiet)
+                    Log.Error($"Could not remove troop {troop} on planet {Ground.Name}");
                 return false;
             }
         }


### PR DESCRIPTION
## Summary

Five Sentry-driven defensive fixes for Jupiter 1.60.

- **SDNative startup probe** — load `SDNative.dll` first; on failure show a Win32 dialog with Smart App Control / WDAC / AV remediation steps + Discord link, instead of an opaque `Parallel` cctor stack.
- **ScreenMediaPlayer** — demote noisy `PlayVideo` log; guard `Update` Pause/Resume and `Draw` GetTexture against MediaSession failures (E_POINTER on alt-tab / device loss / codec hiccup); set `PlaybackFailed` and bail.
- **GameAudio** — fix init race where worker threads (e.g. `LoadGame.SetupUniverseScreen`) saw `AudioEngineGood = true` before `Music`/`RacialMusic` were assigned and NRE'd in `StopGenericMusic`. Set the green-light flag at the END of `Initialize`. Also `?.` defense on `Music.Stop`. Demote AUDCLNT_E_UNSUPPORTED_FORMAT log.
- **StarDriveGame.Draw** — wrap `ScreenManager.Draw` + `base.Draw` in try/finally with `SetRenderTarget(null)` cleanup. Safety net for the multiple RT call sites (Bloom, Distortion, ShadowMap, FogMap, etc.) that don't clean up on throw and crash `Present` with "Cannot call Present when a render target is active."
- **TroopManager** — silence benign concurrent-launch race in `LaunchToSpace`. Two parallel `UpdateAllShips` threads can both pick the same launchable troop in `GetTroopShipForRebase`; loser was paging Sentry. Loud `Log.Error` kept on `DamageTroop`/`DoTroopTimers` paths as a canary.
- **Combat.Done** — end stale combats when the defending/attacking building was externally removed from BuildingList (volcano lava, ship crash, terraforming, bomb tile destroy, scrap, outcome events) while Strength was still > 0. Otherwise the orphan ref ticks damage until DestroyBuilding fails loudly.

## Test plan

- [ ] Smoke test: load a save, run a few sim ticks, no new Sentry errors
- [ ] Force a video load failure (e.g. rename `Loading 2.wmv`) — game continues without splash
- [ ] Long mid-game save with active ground combat + nearby volcano-prone planets — let it run, watch for `Combat`/`TroopManager` log spam
- [ ] Bluetooth audio device — game starts, audio gracefully disabled if format unsupported
