### PR TITLE
Jupiter 1.60/fixes 04

### DIFF
--- a/Ship_Game/AutomationWindow.cs
+++ b/Ship_Game/AutomationWindow.cs
@@ -152,15 +152,32 @@ namespace Ship_Game
             FreighterDropDown.Visible  = !Screen.Player.AutoPickBestFreighter;
             ColonyShipDropDown.Visible = !Screen.Player.AutoPickBestColonizer;
 
+            // Re-populate the Research/Mining dropdowns the first time CanBuild* flips to
+            // true. LoadContent only ran InitDropOptions once at window-open time, so if
+            // the player completes the gating tech while AutomationWindow is still open
+            // the dropdown becomes Visible (below) but stays empty — clicking it then
+            // crashed on Options[0] access via ActiveName. Lazy-init on demand here.
             if (ResearchStationsEnabled)
             {
-                ResearchStationDropDown.Visible = !Screen.Player.AutoPickBestResearchStation
-                                                   && Screen.Player.CanBuildResearchStations;
+                bool canBuild = Screen.Player.CanBuildResearchStations;
+                if (canBuild && ResearchStationDropDown.Count == 0)
+                {
+                    EmpireData pd = Screen.Player.data;
+                    InitDropOptions(ResearchStationDropDown, ref pd.CurrentResearchStation, pd.DefaultResearchStation,
+                        ship => ship.IsShipGoodToBuild(Screen.Player) && ship.IsResearchStation);
+                }
+                ResearchStationDropDown.Visible = !Screen.Player.AutoPickBestResearchStation && canBuild;
             }
             if (MiningOpsEnabled)
             {
-                MiningStationDropDown.Visible = !Screen.Player.AutoPickBestMiningStation
-                                                 && Screen.Player.CanBuildMiningStations;
+                bool canBuild = Screen.Player.CanBuildMiningStations;
+                if (canBuild && MiningStationDropDown.Count == 0)
+                {
+                    EmpireData pd = Screen.Player.data;
+                    InitDropOptions(MiningStationDropDown, ref pd.CurrentMiningStation, pd.DefaultMiningStation,
+                        ship => ship.IsShipGoodToBuild(Screen.Player) && ship.IsMiningStation);
+                }
+                MiningStationDropDown.Visible = !Screen.Player.AutoPickBestMiningStation && canBuild;
             }
             base.Draw(batch, elapsed);
         }

--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -4523,6 +4523,10 @@ namespace Ship_Game
         DesignIssueConstructorCostProblem = 4447,
         /// <summary>Add Storage or lower the amount</summary>
         DesignIssueConstructorCostRemidiation = 4448,
+        /// <summary>Spiral Galaxy</summary>
+        SpiralGalaxyGame = 4526,
+        /// <summary>Each empire starts at a random place along the arms of a Spiral Galaxy</summary>
+        SpiralGalaxyGameTip = 4527,
         /// <summary>Processing Per Trun</summary>
         RefinningPerTurnStat = 4449,
         /// <summary>Most Exotic resources are processed at</summary>

--- a/Ship_Game/DropOptions.cs
+++ b/Ship_Game/DropOptions.cs
@@ -242,6 +242,13 @@ namespace Ship_Game
 
         public override bool HandleInput(InputState input)
         {
+            // An empty dropdown is inert — don't capture input or toggle Open. Reading
+            // ActiveName / Active later would index Options[0] and throw IOOB. The
+            // existing Count==1 auto-close at the title-toggle below doesn't catch
+            // Count==0 because we never reach it.
+            if (Options.Count == 0)
+                return false;
+
             bool overTitle = HitTest(input.CursorPosition);
             bool overExpanded = Open && ClickAbleOpenRect.HitTest(input.CursorPosition);
 

--- a/Ship_Game/GameScreens/MainMenu/AutoPatcher.cs
+++ b/Ship_Game/GameScreens/MainMenu/AutoPatcher.cs
@@ -674,8 +674,15 @@ internal class AutoPatcher : PopupWindow
             {
                 // Restore best-effort: if even the restore fails we can't fix it,
                 // and chaining the original cause is more useful than a noisy throw
-                // from inside a catch.
-                try { File.Move(tmpFile, dstFile); } catch { }
+                // from inside a catch. Log the swallowed reason so an operator
+                // reading the patch log can correlate a missing file with the
+                // failed restore (otherwise the install just appears truncated).
+                try { File.Move(tmpFile, dstFile); }
+                catch (Exception restoreEx)
+                {
+                    Log.Warning(ConsoleColor.Red,
+                        $"AutoPatcher: failed to restore {relPath} from {tmpFile}: {restoreEx.Message}");
+                }
             }
 
             throw new IOException(relPath, e);

--- a/Ship_Game/GameScreens/MainMenu/AutoPatcher.cs
+++ b/Ship_Game/GameScreens/MainMenu/AutoPatcher.cs
@@ -569,18 +569,50 @@ internal class AutoPatcher : PopupWindow
         {
             string gameDir = GetGameDirectory();
             string tempDir = GetPatchTempFolder();
-            
+
             FileInfo[] filesToAdd = Dir.GetFiles(patchFilesFolder);
+            var skipped = new Array<string>();
             int currentAction = 0;
             foreach (FileInfo toAdd in filesToAdd)
             {
                 string srcFile = toAdd.FullName;
                 string relPath = srcFile.Replace(patchFilesFolder, "").TrimStart('\\', '/');
                 string dstFile = Path.Combine(gameDir, relPath);
-                
+
+                // Source can vanish between Dir.GetFiles enumeration and now — typically
+                // AV/Defender quarantining a freshly-extracted asset (esp. .png/.exe) or
+                // OneDrive/Dropbox re-syncing the AppData folder. Skip and continue rather
+                // than aborting the entire patch over one cosmetic icon. The user can
+                // re-run the patcher to retry; missing textures fall back to x_red so the
+                // game stays usable in the meantime.
+                if (!File.Exists(srcFile))
+                {
+                    Log.Warning($"CopyFile skipped (source missing — AV or sync interference?): {relPath}");
+                    skipped.Add(relPath);
+                    ap.SetProgress(ProgressBarElement.GetPercent(++currentAction, filesToAdd.Length));
+                    continue;
+                }
+
                 Log.Write($"CopyFile: {relPath}");
-                SafeMove(srcFile, dstFile, relPath, tempDir);
+                SafeCopy(srcFile, dstFile, relPath, tempDir);
                 ap.SetProgress(ProgressBarElement.GetPercent(++currentAction, filesToAdd.Length));
+            }
+
+            // Apply succeeded — now safe to drop the staging cache. Crucially this only
+            // runs on the SUCCESS path: if the loop above threw, the staging dir is
+            // preserved so the user can re-trigger the patch and we resume against an
+            // intact cached download. The old File.Move-based design destroyed sources
+            // as it went, leaving a half-gutted staging dir on any mid-apply failure.
+            TryDeleteFolder(GetPatchOutputFolder());
+
+            if (skipped.Count > 0)
+            {
+                RunOnNextFrame(() =>
+                {
+                    var label = ProgressSteps.AddLabel(
+                        $"Patch applied ({skipped.Count} file(s) skipped — see blackbox.log; usually antivirus interference)");
+                    label.Color = Color.Yellow;
+                });
             }
 
             RunOnNextFrame(() =>
@@ -615,11 +647,17 @@ internal class AutoPatcher : PopupWindow
     }
 
     /// <summary>
-    /// If the file is in use, it must be moved or renamed,
-    /// however, moving between different drives would cause the file to be copied,
-    /// so we always move it into game/PatchTemp folder
+    /// Copies a patch file from the staging cache (%APPDATA%\StarDrive\Patches\&lt;ver&gt;)
+    /// onto the install. If the destination exists, it is first moved aside into
+    /// game/PatchTemp so an in-use file (e.g. StarDrive.exe replacing itself) can
+    /// still be replaced — that move is intra-volume and atomic.
+    ///
+    /// The src→dst transfer is a Copy (not Move) so the staging cache survives a
+    /// mid-apply failure intact and the user can retry. Pre-Jupiter this was a
+    /// Move, which destroyed each source on success and left a half-gutted cache
+    /// on any failure (no recovery without re-downloading).
     /// </summary>
-    static void SafeMove(string srcFile, string dstFile, string relPath, string tempDir)
+    static void SafeCopy(string srcFile, string dstFile, string relPath, string tempDir)
     {
         string tmpFile = null;
         try
@@ -628,13 +666,16 @@ internal class AutoPatcher : PopupWindow
             {
                 tmpFile = MoveToTempPath(tempDir, relPath, dstFile);
             }
-            MoveAndCreateDirs(srcFile, dstFile);
+            CopyAndCreateDirs(srcFile, dstFile);
         }
         catch (Exception e)
         {
             if (tmpFile != null) // restore the file if needed
             {
-                File.Move(tmpFile, dstFile);
+                // Restore best-effort: if even the restore fails we can't fix it,
+                // and chaining the original cause is more useful than a noisy throw
+                // from inside a catch.
+                try { File.Move(tmpFile, dstFile); } catch { }
             }
 
             throw new IOException(relPath, e);
@@ -699,6 +740,10 @@ internal class AutoPatcher : PopupWindow
         return tmpFile;
     }
 
+    // Used only on the destination side (stashing in-use files into PatchTemp) where
+    // Move is genuinely the right primitive — intra-volume, atomic, leaves no copy.
+    // For the src(staging-cache) → dst(install) transfer, use CopyAndCreateDirs so
+    // a mid-apply failure doesn't destroy the staging cache.
     static void MoveAndCreateDirs(string sourceFile, string destinationFile)
     {
         try
@@ -709,6 +754,26 @@ internal class AutoPatcher : PopupWindow
         catch (Exception e)
         {
             throw new IOException($"Move failed: {sourceFile} --> {destinationFile}", e);
+        }
+    }
+
+    static void CopyAndCreateDirs(string sourceFile, string destinationFile)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationFile)!);
+            // overwrite:true — patches semantically OVERWRITE the install. SafeCopy
+            // also moves any existing dst aside into PatchTemp first, but treating
+            // overwrite as the contract (rather than relying on the prior move) is
+            // both clearer and safer: re-running the patcher against an already-
+            // partially-applied install just clobbers, instead of throwing because
+            // some files survived from the previous attempt. Especially relevant
+            // for mod patches where users often re-apply the same version.
+            File.Copy(sourceFile, destinationFile, overwrite: true);
+        }
+        catch (Exception e)
+        {
+            throw new IOException($"Copy failed: {sourceFile} --> {destinationFile}", e);
         }
     }
 

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
@@ -406,6 +406,7 @@ namespace Ship_Game
                 case GameMode.BigClusters:   return GameText.BigClustersGame;
                 case GameMode.SmallClusters: return GameText.SmallClustersGame;
                 case GameMode.Ring:          return GameText.RingGalaxyGame;
+                case GameMode.Spiral:        return GameText.SpiralGalaxyGame;
             }
         }
 
@@ -421,6 +422,7 @@ namespace Ship_Game
                 case GameMode.BigClusters:   return GameText.EachEmpireStartsInA;
                 case GameMode.SmallClusters: return GameText.TheGalaxyWillBeConsisted;
                 case GameMode.Ring:          return GameText.RingGalaxyGameTip;
+                case GameMode.Spiral:        return GameText.SpiralGalaxyGameTip;
             }
         }
 
@@ -696,7 +698,7 @@ namespace Ship_Game
         
         public enum GameMode
         {
-            Sandbox, Random, Ring, SmallClusters, BigClusters, Elimination, Corners
+            Sandbox, Spiral, Random, Ring, SmallClusters, BigClusters, Elimination, Corners
         }
 
         public enum StarsAbundance

--- a/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
+++ b/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
@@ -289,6 +289,7 @@ namespace Ship_Game.GameScreens.NewGame
                 case RaceDesignScreen.GameMode.BigClusters:   GenerateBigClusters(step);      break;
                 case RaceDesignScreen.GameMode.SmallClusters: GenerateSmallClusters(step);    break;
                 case RaceDesignScreen.GameMode.Ring:          GenerateRingMap(step);          break;
+                case RaceDesignScreen.GameMode.Spiral:        GenerateSpiralMap(step);        break;
                 case RaceDesignScreen.GameMode.Sandbox:       GenerateRandomMap(step, false); break;
                 default:                                      GenerateRandomMap(step, true);  break;
             }
@@ -491,6 +492,163 @@ namespace Ship_Game.GameScreens.NewGame
         void GenerateRingMap(ProgressCounter step)
         {
             SolarSystemSpacingRing(step);
+        }
+
+        // Three flavors of spiral galaxy. The variant is rolled per-game (using the
+        // seeded universe RNG) so the same seed reproduces the same galaxy.
+        enum SpiralVariant { TwoArm, FourArm, Barred }
+
+        void GenerateSpiralMap(ProgressCounter step)
+        {
+            // Logarithmic spiral: r(t) = armStartR * exp(pitch * t), theta = t + armOffset + phase.
+            // Stars are sampled by drawing a parameter t along the arm length, mapping to (r, theta),
+            // then adding a perpendicular jitter to give the arms visible thickness.
+            SpiralVariant variant = (SpiralVariant)Random.InRange(3);
+
+            int numArms;
+            float bulgeFraction;
+            float armThicknessFrac;
+            bool hasBar;
+            switch (variant)
+            {
+                case SpiralVariant.FourArm:
+                    numArms = 4; bulgeFraction = 0.15f; armThicknessFrac = 0.045f; hasBar = false; break;
+                case SpiralVariant.Barred:
+                    numArms = 2; bulgeFraction = 0.22f; armThicknessFrac = 0.06f;  hasBar = true;  break;
+                default: // TwoArm
+                    numArms = 2; bulgeFraction = 0.18f; armThicknessFrac = 0.06f;  hasBar = false; break;
+            }
+
+            const float armStartR    = 0.20f;  // arm origin radius (fraction of uSize)
+            const float armEndR      = 0.92f;  // arm end radius
+            const float pitch        = 0.45f;  // log-spiral pitch (radians per e-fold of r)
+            const float bulgeRadius  = 0.22f;  // bulge radial extent (fraction of uSize)
+            const float barHalfLen   = 0.30f;  // bar half-length along its long axis
+            const float barHalfWid   = 0.06f;  // bar half-width perpendicular
+
+            float uSize  = UState.Size;
+            float phase  = Random.Float(0f, RadMath.TwoPI); // randomize galactic orientation
+
+            Log.Info($"Spiral galaxy variant: {variant} (numArms={numArms}, bulge={bulgeFraction:P0})");
+
+            PlaceSpiralStartingSystems(numArms, phase, uSize, armStartR, armEndR, pitch, armThicknessFrac, step);
+            PlaceSpiralBackgroundSystems(numArms, phase, uSize, armStartR, armEndR, pitch,
+                                          armThicknessFrac, bulgeFraction, bulgeRadius,
+                                          hasBar, barHalfLen, barHalfWid, step);
+        }
+
+        void PlaceSpiralStartingSystems(int numArms, float phase, float uSize,
+                                         float armStartR, float armEndR, float pitch,
+                                         float armThicknessFrac, ProgressCounter step)
+        {
+            // Empires get random arm positions with a generous min-spacing so they don't
+            // start on top of each other. Spacing relaxes per retry (same pattern as
+            // GenerateSystemInCluster) so we always converge on tiny galaxies.
+            SystemPlaceHolder[] starting = Systems.Filter(s => s.IsStartingSystem);
+            float spacing = (uSize * 0.6f / starting.Length.LowerBound(2)).LowerBound(350000f);
+
+            foreach (SystemPlaceHolder sys in starting)
+            {
+                sys.Position = SampleArmPos(numArms, phase, uSize, armStartR, armEndR, pitch,
+                                             armThicknessFrac, spacing);
+                step.Advance();
+            }
+        }
+
+        void PlaceSpiralBackgroundSystems(int numArms, float phase, float uSize,
+                                           float armStartR, float armEndR, float pitch,
+                                           float armThicknessFrac, float bulgeFraction, float bulgeRadius,
+                                           bool hasBar, float barHalfLen, float barHalfWid,
+                                           ProgressCounter step)
+        {
+            // Shuffle so file-order doesn't determine arm position (same reasoning as
+            // GenerateClusterSystems: predefined systems should not always land in the
+            // same spot across unrelated seeds).
+            SystemPlaceHolder[] background = Systems.Filter(s => !s.IsStartingSystem);
+            Random.Shuffle(background);
+
+            foreach (SystemPlaceHolder sys in background)
+            {
+                bool inBulge = Random.Float() < bulgeFraction;
+                if (inBulge && hasBar)
+                    sys.Position = SampleBarPos(phase, uSize, barHalfLen, barHalfWid);
+                else if (inBulge)
+                    sys.Position = SampleBulgePos(uSize, bulgeRadius);
+                else
+                    sys.Position = SampleArmPos(numArms, phase, uSize, armStartR, armEndR, pitch,
+                                                 armThicknessFrac, 250000f);
+                step.Advance();
+            }
+        }
+
+        Vector2 SampleArmPos(int numArms, float phase, float uSize,
+                              float armStartR, float armEndR, float pitch,
+                              float armThicknessFrac, float spacing)
+        {
+            float maxT = (float)Math.Log(armEndR / armStartR) / pitch; // angular extent of one arm
+            float jitterScale = uSize * armThicknessFrac;
+            float armSep = RadMath.TwoPI / numArms;
+
+            Vector2 sysPos = default;
+            int attempts = 0;
+            do
+            {
+                int arm = Random.InRange(numArms);
+                float t = Random.Float() * maxT;
+                float r = armStartR * uSize * (float)Math.Exp(pitch * t);
+                float theta = t + arm * armSep + phase;
+
+                // Triangular distribution (sum of two uniforms) approximates a Gaussian
+                // cheaply — most stars near the arm centerline, few at the edges.
+                float jitterMag = (Random.Float(-1f, 1f) + Random.Float(-1f, 1f)) * 0.5f * jitterScale;
+                float perpAngle = theta + RadMath.HalfPI;
+                sysPos = new Vector2(r * RadMath.Cos(theta) + jitterMag * RadMath.Cos(perpAngle),
+                                     r * RadMath.Sin(theta) + jitterMag * RadMath.Sin(perpAngle));
+
+                spacing *= 0.97f;
+            } while (!SystemPosOK(sysPos, spacing) && ++attempts < 200);
+
+            ClaimedSpots.Add(sysPos);
+            return sysPos;
+        }
+
+        Vector2 SampleBulgePos(float uSize, float bulgeRadiusFrac)
+        {
+            float maxR = uSize * bulgeRadiusFrac;
+            float spacing = 200000f;
+            Vector2 sysPos = default;
+            int attempts = 0;
+            do
+            {
+                sysPos = Random.RandomPointInRing(0f, maxR);
+                spacing *= 0.95f;
+            } while (!SystemPosOK(sysPos, spacing) && ++attempts < 200);
+
+            ClaimedSpots.Add(sysPos);
+            return sysPos;
+        }
+
+        Vector2 SampleBarPos(float phase, float uSize, float halfLengthFrac, float halfWidthFrac)
+        {
+            // Sample uniformly in the bar's local frame (long axis = X), then rotate by phase
+            // so the bar inherits the same galactic orientation as the arms attached to it.
+            float halfLen = uSize * halfLengthFrac;
+            float halfWid = uSize * halfWidthFrac;
+            float c = RadMath.Cos(phase);
+            float s = RadMath.Sin(phase);
+            float spacing = 220000f;
+            Vector2 sysPos = default;
+            int attempts = 0;
+            do
+            {
+                float bx = Random.Float(-halfLen, halfLen);
+                float by = Random.Float(-halfWid, halfWid);
+                sysPos = new Vector2(bx * c - by * s, bx * s + by * c);
+                spacing *= 0.95f;
+            } while (!SystemPosOK(sysPos, spacing) && ++attempts < 200);
+
+            ClaimedSpots.Add(sysPos);
+            return sysPos;
         }
 
         void GenerateBigClusters(ProgressCounter step)

--- a/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
+++ b/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
@@ -653,9 +653,12 @@ namespace Ship_Game.GameScreens.NewGame
 
         void GenerateBigClusters(ProgressCounter step)
         {
-            // Divides the galaxy to several sectors and populates each sector with stars
+            // Divides the galaxy to several sectors and populates each sector with stars.
+            // 0.35 deviation lets each cluster center wander noticeably off its grid point
+            // so a 3x2 / 3x3 layout doesn't look mechanical. Sector ctor enforces a
+            // border pad so the wider deviation can't push systems against the universe rim.
             (int numHorizontalSectors, int numVerticalSectors) = GetNumSectors(NumOpponents + 1);
-            Array<Sector> sectors = GenerateSectors(numHorizontalSectors, numVerticalSectors, 0.25f);
+            Array<Sector> sectors = GenerateSectors(numHorizontalSectors, numVerticalSectors, 0.35f);
             GenerateClustersStartingSystems(step, sectors);
             GenerateClusterSystems(step, sectors);
         }
@@ -665,7 +668,7 @@ namespace Ship_Game.GameScreens.NewGame
             // Divides the galaxy to many sectors and populates each sector with stars
             int numSectorsPerAxis = GetNumSectorsPerAxis(NumSystems, NumOpponents + 1);
             float offsetMultiplier = 0.28f / numSectorsPerAxis.UpperBound(4);
-            float deviation = 0.05f * numSectorsPerAxis.UpperBound(4);
+            float deviation = 0.07f * numSectorsPerAxis.UpperBound(4);
             Array<Sector> sectors = GenerateSectors(numSectorsPerAxis, numSectorsPerAxis, deviation, offsetMultiplier);
             GenerateClustersStartingSystems(step, sectors, numSectorsPerAxis - 1);
             GenerateClusterSystems(step, sectors);
@@ -808,12 +811,12 @@ namespace Ship_Game.GameScreens.NewGame
 
         struct Sector
         {
-            private readonly float RightX;
+            private readonly float SampleRadius;
             private readonly Vector2 Center;
             public readonly int X;
             public readonly int Y;
 
-            public Sector(RandomBase random, float universeSize, 
+            public Sector(RandomBase random, float universeSize,
                           int horizontalSectors, int verticalSectors, int horizontalNum, int verticalNum,
                           float deviation, float offsetMultiplier) : this()
             {
@@ -823,6 +826,14 @@ namespace Ship_Game.GameScreens.NewGame
                 float ySection = universeSize / verticalSectors;
                 float offset = universeSize * offsetMultiplier;
 
+                // Border pad keeps cluster bounds (and therefore the systems sampled
+                // inside them) away from the universe rim, even when a wide deviation
+                // would otherwise push an edge sector hard against the wall.
+                float borderPad = universeSize * 0.08f;
+                float innerSize = universeSize - borderPad;
+                float minBound  = -innerSize;
+                float maxBound  = +innerSize;
+
                 // raw center is the center of the sector before generating offset (for gaps)
                 Vector2 rawCenter = new Vector2(-universeSize + xSection * (-1 + horizontalNum * 2),
                                              -universeSize + ySection * (-1 + verticalNum * 2));
@@ -830,17 +841,38 @@ namespace Ship_Game.GameScreens.NewGame
                 // Some deviation in the center of the cluster
                 rawCenter = rawCenter.GenerateRandomPointInsideCircle(universeSize * deviation, random);
 
-                float leftX = (rawCenter.X - xSection).LowerBound(-universeSize);
-                RightX = (rawCenter.X + xSection).UpperBound(universeSize);
-                float topY = (rawCenter.Y - ySection).LowerBound(-universeSize) + offset;
-                float botY = (rawCenter.Y + ySection).UpperBound(universeSize) - offset;
+                float leftX  = (rawCenter.X - xSection).LowerBound(minBound);
+                float rightX = (rawCenter.X + xSection).UpperBound(maxBound);
+                float topY   = (rawCenter.Y - ySection).LowerBound(minBound) + offset;
+                float botY   = (rawCenter.Y + ySection).UpperBound(maxBound) - offset;
 
-                // creating some gaps between clusters
-                GenerateOffset(universeSize, offset, ref leftX, ref RightX);
-                GenerateOffset(universeSize, offset, ref topY, ref botY);
+                // creating some gaps between clusters; pass innerSize so the edge-detection
+                // inside GenerateOffset still fires for sectors clamped to the padded bound.
+                GenerateOffset(innerSize, offset, ref leftX, ref rightX);
+                GenerateOffset(innerSize, offset, ref topY, ref botY);
 
-                // This is the true Center, after all offsets are applied with borders
-                Center = new Vector2((leftX + RightX) / 2, (topY + botY) / 2);
+                Center = new Vector2((leftX + rightX) * 0.5f, (topY + botY) * 0.5f);
+
+                // Sample radius derives from the GRID section size, not the post-offset
+                // bounds. Edge sectors get clamped + offset-shrunk by GenerateOffset above,
+                // which would give them a noticeably smaller radius than inner sectors and
+                // make their stars visibly crowded for the same star count. Anchoring the
+                // radius to the grid section size gives every cluster the same scale, so
+                // edge clusters look as airy as inner ones. Subtract `offset` to leave a
+                // small natural gap between neighbors. Captured BEFORE the post-creation
+                // Center jitter so cluster size stays stable as Center moves.
+                SampleRadius = Math.Min(xSection, ySection) - offset;
+
+                // Post-creation jitter: move Center in a random direction by a random
+                // magnitude to break the visible grid pattern. Magnitude varies per
+                // cluster so neighbors don't shift uniformly together. Clamped to a
+                // safe inner box so the cluster never wanders toward the rim.
+                float maxJitter = universeSize * 0.18f;
+                float safeInner = universeSize - SampleRadius - borderPad;
+                Vector2 jitter = random.Direction2D() * random.Float(0f, maxJitter);
+                Center = new Vector2(
+                    (Center.X + jitter.X).Clamped(-safeInner, safeInner),
+                    (Center.Y + jitter.Y).Clamped(-safeInner, safeInner));
             }
 
             // Offset from borders. Less offset if near one or 2 edges
@@ -863,7 +895,7 @@ namespace Ship_Game.GameScreens.NewGame
                 }
             }
 
-            public Vector2 GetRandomPosInSector(RandomBase random) => Center.GenerateRandomPointInsideCircle(RightX - Center.X, random);
+            public Vector2 GetRandomPosInSector(RandomBase random) => Center.GenerateRandomPointInsideCircle(SampleRadius, random);
         }
 
         Vector2 GenerateRandomCorners(int corner) //Added by Gretman for Corners Game type

--- a/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
+++ b/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
@@ -861,7 +861,13 @@ namespace Ship_Game.GameScreens.NewGame
                 // edge clusters look as airy as inner ones. Subtract `offset` to leave a
                 // small natural gap between neighbors. Captured BEFORE the post-creation
                 // Center jitter so cluster size stays stable as Center moves.
-                SampleRadius = Math.Min(xSection, ySection) - offset;
+                //
+                // LowerBound: on very dense grids (e.g. SmallClusters numSectorsPerAxis ~15,
+                // xSection ~0.067 universeSize) `min - offset` can drift negative because
+                // offsetMultiplier floors at 0.28/4 = 0.07. A negative radius silently
+                // inverts GenerateRandomPointInsideCircle and makes the safeInner clamp
+                // larger than universeSize. Pin to 5% of half-extent as a sane floor.
+                SampleRadius = (Math.Min(xSection, ySection) - offset).LowerBound(universeSize * 0.05f);
 
                 // Post-creation jitter: move Center in a random direction by a random
                 // magnitude to break the visible grid pattern. Magnitude varies per

--- a/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
+++ b/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
@@ -615,8 +615,16 @@ namespace Ship_Game.GameScreens.NewGame
 
         void GenerateClusterSystems(ProgressCounter step, Array<Sector> sectors)
         {
+            // Shuffle so the same alphabetically-first SolarSystems/Random/*.xml file
+            // doesn't always land in sectors[0] (h=1,v=1) every game. Without this,
+            // sector-to-system mapping is purely insertion-ordered and reproducible
+            // across unrelated seeds, which gave players a positional bias on the
+            // same corner sector.
+            SystemPlaceHolder[] nonStarting = Systems.Filter(s => !s.IsStartingSystem);
+            Random.Shuffle(nonStarting);
+
             int i = 0;
-            foreach (SystemPlaceHolder sys in Systems.Filter(s => !s.IsStartingSystem))
+            foreach (SystemPlaceHolder sys in nonStarting)
             {
                 Sector currentSector = sectors[i];
                 sys.Position = GenerateSystemInCluster(currentSector, 300000f);

--- a/Ship_Game/SpriteSystem/TextureBinding.cs
+++ b/Ship_Game/SpriteSystem/TextureBinding.cs
@@ -68,12 +68,28 @@ public class TextureBinding
     (Texture2D texture, SubTexture subTex) LoadTextureUnsafe()
     {
         var file = new FileInfo(UnpackedPath);
+        // Missing or unreadable texture files (AV quarantine, partial install, disk
+        // corruption, modder cleanup) used to surface as a fatal exception bubbling up
+        // through LayoutParser → LoadContent → UpdateGame. Degrade to the established
+        // x_red placeholder via DefaultTexture() so the game keeps running with a
+        // visible "missing texture" marker. Stays a Log.Warning, not Sentry — this is
+        // a user-environment issue we can't act on, and once survivable it would
+        // otherwise spam every frame the texture is referenced.
         if (!file.Exists)
         {
             Log.Warning(ConsoleColor.Red, $"NonPacked Texture does not exist: {UnpackedPath}");
+            return (null, ResourceManager.RootContent.DefaultTexture());
         }
-        var texture = ResourceManager.RootContent.LoadUncachedTexture(file, Atlas.Name);
-        SubTexture subTex = new(Name, texture, SourcePath);
-        return (texture, subTex);
+        try
+        {
+            var texture = ResourceManager.RootContent.LoadUncachedTexture(file, Atlas.Name);
+            SubTexture subTex = new(Name, texture, SourcePath);
+            return (texture, subTex);
+        }
+        catch (Exception e)
+        {
+            Log.Warning(ConsoleColor.Red, $"NonPacked Texture failed to load: {UnpackedPath} reason: {e.Message}");
+            return (null, ResourceManager.RootContent.DefaultTexture());
+        }
     }
 }

--- a/Ship_Game/Universe/MiniMap.cs
+++ b/Ship_Game/Universe/MiniMap.cs
@@ -255,7 +255,15 @@ namespace Ship_Game
                               Empire.InfluenceNode[] nodes, bool excludeProjectors)
         {
             Vector2 nodeOrigin = Node.CenterF;
-            var transparentBlack = new Color(Color.Black, 80);
+            // Halo alpha kept low (~30%) so overlapping nodes stay readable under
+            // NonPremultiplied blend — at higher alpha the territory layer would
+            // saturate the sensor halos underneath into a single uniform blob.
+            // The empire-color halo and black darkening overlay scale with the
+            // border-strength slider, but floored at 0.5 so the minimap never
+            // loses empire-territory readability even when the universe screen
+            // borders are dimmed all the way down.
+            byte haloAlpha = (byte)(80 * GlobalStats.InfluenceNodeAlpha.LowerBound(0.5f));
+            var transparentBlack = new Color(Color.Black, haloAlpha);
 
             for (int i = 0; i < nodes.Length; i++)
             {
@@ -265,11 +273,7 @@ namespace Ship_Game
 
                 bool combat = false;
                 float intensity = 0.005f;
-                // Halo alpha kept low (~30%) so overlapping nodes stay
-                // readable under NonPremultiplied blend — at higher alpha
-                // the territory layer would saturate the sensor halos
-                // underneath into a single uniform blob.
-                var ec = new Color(empire.EmpireColor, 80);
+                var ec = new Color(empire.EmpireColor, haloAlpha);
                 if (empire.isPlayer)
                 {
                     if (node.Source is Ship ship)
@@ -310,9 +314,9 @@ namespace Ship_Game
                 
                 {
                     float radius = Math.Min(0.09f, nodeRad);
-                    // Empire-colored gradient halo (alpha 80).
+                    // Empire-colored gradient halo + black darkening overlay; both
+                    // alphas scaled by the border-color-strength slider above.
                     batch.Draw(Node1, nodePos, ec, 0f, nodeOrigin, radius, SpriteEffects.None, 1f);
-                    // Black-tinted gradient overlay to dim the surroundings.
                     batch.Draw(Node1, nodePos, transparentBlack, 0f, nodeOrigin, nodeRad, SpriteEffects.None, 1f);
                 }
             }

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
@@ -77,7 +77,10 @@ namespace Ship_Game
             graphics.SetRenderTarget(BorderRT);
             graphics.Clear(Color.Transparent);
 
-            if (GlobalStats.InfluenceNodeAlpha > 0.1f)
+            // Skip the whole pass when the slider is effectively at zero. Threshold is
+            // small enough that any non-zero slider value still produces a render — the
+            // user-visible alpha scaling happens at composite time in DrawColoredBordersRT.
+            if (GlobalStats.InfluenceNodeAlpha > 0.01f)
             {
                 // the node texture has a smooth fade, so we need to scale it by a lot to match the actual SSP radius
                 float nodeScale = 1.8f;

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Render.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Render.cs
@@ -116,6 +116,12 @@ namespace Ship_Game
                 if (alpha > maxAlpha) alpha = maxAlpha;
                 else if (alpha < 10) alpha = 0;
 
+                // Apply the user's "border color strength" slider as the FINAL multiplier.
+                // Done after the < 10 cutoff so the camera-zoom fade kicks in at the same
+                // distance regardless of slider value — the slider only scales the result,
+                // it doesn't shift the cutoff zoom.
+                alpha = (int)(alpha * GlobalStats.InfluenceNodeAlpha);
+
                 // Phase 3.3 alpha fix: pre-multiply the tint so the (already-premul'd)
                 // BorderRT pixels get scaled by alpha at modulation time. Without
                 // pre-multiplication, MonoGame's premul AlphaBlend formula

--- a/Ship_Game/Utils/RandomBase.cs
+++ b/Ship_Game/Utils/RandomBase.cs
@@ -187,6 +187,20 @@ public abstract class RandomBase
     }
 
     /// <summary>
+    /// Fisher-Yates in-place shuffle using the seeded RNG.
+    /// Use this instead of ListExt.Shuffle when the caller already owns a RandomBase
+    /// (e.g. UniverseGenerator) so universe-seed reproducibility is preserved.
+    /// </summary>
+    public void Shuffle<T>(IList<T> list)
+    {
+        for (int n = list.Count - 1; n > 0; --n)
+        {
+            int k = Rand.Next(n + 1);
+            (list[k], list[n]) = (list[n], list[k]);
+        }
+    }
+
+    /// <summary>
     /// Performs a dice-roll, where chance must be between [0..100]
     /// @return TRUE if random chance passed
     /// @example if (RandomMath.RollDice(33)) {..} // 33% chance

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -12437,6 +12437,12 @@ RingGalaxyGame:
  Id: 4383
  ENG: "Ring Galaxy"
  UKR: "Кільцева галактика"
+SpiralGalaxyGame:
+ Id: 4526
+ ENG: "Spiral Galaxy"
+SpiralGalaxyGameTip:
+ Id: 4527
+ ENG: "Each empire starts at a random place along the arms of a Spiral Galaxy. The galaxy is shaped randomly per game as a 2-arm grand-design, a 4-arm tighter spiral, or a barred spiral, with a denser central bulge."
 FlatIncomePerTurn:
  Id: 4384
  ENG: "Flat Income Per Turn" 


### PR DESCRIPTION
**Summary**
New Spiral galaxy mode (Milky Way-style) with 3 randomized variants — 2-arm, 4-arm, and barred — using a logarithmic spiral with central bulge.
Cluster generation rework: broke the visible grid pattern in Big/Small clusters via wider deviation + post-creation Center jitter, and fixed crowded stars in edge clusters by anchoring SampleRadius to the grid section size.
Cluster system shuffle: removed the deterministic file-order → sector-order mapping where the alphabetically-first SolarSystems/Random/*.xml always landed in the same corner sector across unrelated seeds.
3 Sentry crash fixes carried over from triage: AutomationWindow empty-dropdown crash, AutoPatcher mid-apply data-loss risk, and missing-texture fatal exception.

Changes by commit

**Galaxy generation**

62f96445e — Cluster galaxies: per-cluster random-direction Center jitter (max 18% of half-extent), 0.08 border pad, deviation bumped to 0.35 (Big) / 0.07·n (Small), and SampleRadius decoupled from post-offset bounds so edge clusters match inner-cluster scale.

b7eaf71de — New GameMode.Spiral (cycles after Sandbox in the new-game UI). Variant rolled per-game from the seeded universe RNG. Empire placement is random along arms with min-spacing relaxed per retry. New GameText IDs 4526/4527 (ENG only). Reordered GameMode enum so Spiral lands after Sandbox and Corners stays last; Mode is never read after generation, so the integer shift on existing saves is cosmetic.

f56513de2 — GenerateClusterSystems shuffles the filtered non-starting list before sector assignment using the seeded RNG (added RandomBase.Shuffle<T> distinct from the existing unseeded ListExt.Shuffle). Same universe seed still produces the same galaxy.

**Sentry crashes**

bd6609d12 — AutomationWindow: lazy-init Research/Mining dropdowns in Draw() when CanBuildResearchStations/CanBuildMiningStations flips on mid-game; defense-in-depth Count == 0 guard in DropOptions.HandleInput so an empty dropdown can't crash on input.

678c0460b — AutoPatcher: refactor file apply from File.Move (destructive on source, no recovery on partial failure) to File.Copy + cleanup-on-success. Pre-checks source existence with skip-and-warn on missing files; surfaces a yellow non-fatal label when files were skipped; only deletes the patch staging dir if the whole apply succeeded.

54c029e1b — TextureBinding: missing or unreadable .dds/.png files (AV quarantine, partial install, OneDrive sync race) now degrade to DefaultTexture() (the established x_red placeholder) with a Log.Warning instead of a fatal exception bubbling up through LayoutParser → LoadContent → UpdateGame.