### PR TITLE
Jupiter 1.60/fixes 05

### DIFF
--- a/.github/workflows/patch-build.yml
+++ b/.github/workflows/patch-build.yml
@@ -187,12 +187,14 @@ jobs:
         run: |
           $codename = $env:CODENAME.ToLower()
           $prev = git tag --list "$codename-patch-*" --sort=-v:refname | Select-Object -First 1
+          # `--format='- %s'` drops the commit SHA and prefixes each subject with
+          # a hyphen, which GitHub renders as a markdown bullet in the release body.
           if ($prev) {
             Write-Host "Previous tag: $prev"
-            $log = git log "$prev..HEAD" --oneline --no-merges
+            $log = git log "$prev..HEAD" --format='- %s' --no-merges
           } else {
             Write-Host "No previous patch tag; falling back to last 20 commits"
-            $log = git log -20 --oneline --no-merges
+            $log = git log -20 --format='- %s' --no-merges
           }
           if (-not $log) { $log = "_(no new commits since previous patch)_" }
 

--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,4 @@ game/SharpDX.XInput.dll
 # See Deploy/prereq/README.md for fetch instructions.
 Deploy/prereq/*.exe
 TestResults/
+.claude/scheduled_tasks.lock

--- a/Ship_Game/AI/EmpireAI/EmpireAI.RunMilitaryPlanner.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.RunMilitaryPlanner.cs
@@ -296,7 +296,7 @@ namespace Ship_Game.AI
 
             public void PopulateRoleCountWithBuildableShips(Empire empire, Map<RoleCounts.CombatRole, RoleCounts> buildableShips)
             {
-                foreach (IShipDesign design in empire.ShipsWeCanBuild)
+                foreach (IShipDesign design in empire.ShipsWeCanBuildSnapshot)
                 {
                     var combatRole = RoleCounts.ShipRoleToCombatRole(design.Role);
                     if (buildableShips.TryGetValue(combatRole, out RoleCounts roleCounts))

--- a/Ship_Game/AI/EmpireAI/EmpireAI.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.cs
@@ -163,7 +163,7 @@ namespace Ship_Game.AI
                     int maxStrength   = 0;
                     int maxTechScore  = 0;
                     Log.Write($"------- ship list -----{OwnerEmpire.Universe?.StarDate} Ship list for {OwnerEmpire.Name}");
-                    foreach (IShipDesign design in OwnerEmpire.ShipsWeCanBuild)
+                    foreach (IShipDesign design in OwnerEmpire.ShipsWeCanBuildSnapshot)
                     {
                         Log.Write(ConsoleColor.Green ,$"{design.BaseHull.Role}, {design.Role}, '{design}'");
                         int strength   = (int)design.BaseStrength;

--- a/Ship_Game/AI/EmpireAI/ShipBuilder.cs
+++ b/Ship_Game/AI/EmpireAI/ShipBuilder.cs
@@ -48,7 +48,9 @@ namespace Ship_Game.AI
         static Array<IShipDesign> ShipsWeCanBuild(Empire empire, Predicate<IShipDesign> filter)
         {
             var ships = new Array<IShipDesign>();
-            foreach (IShipDesign design in empire.ShipsWeCanBuild)
+            // COW snapshot is lock-free in the common case and stable across iteration
+            // even if another thread mutates ShipsWeCanBuild.
+            foreach (IShipDesign design in empire.ShipsWeCanBuildSnapshot)
             {
                 if (filter(design))
                     ships.Add(design);
@@ -194,7 +196,7 @@ namespace Ship_Game.AI
 
             var potentialResearchStations = new Array<IShipDesign>();
             float maxResearchPerTurn = 0;
-            foreach (IShipDesign design in empire.ShipsWeCanBuild)
+            foreach (IShipDesign design in empire.ShipsWeCanBuildSnapshot)
             {
                 if (design.IsResearchStation)
                 {
@@ -233,7 +235,7 @@ namespace Ship_Game.AI
             var potentialMiningStations = new Array<IShipDesign>();
             float highestScore = 0;
             float minimumRefiningTurns = ShipResupply.NumTurnsForGoodRefiningSupply;
-            foreach (IShipDesign design in empire.ShipsWeCanBuild)
+            foreach (IShipDesign design in empire.ShipsWeCanBuildSnapshot)
             {
                 if (design.IsMiningStation)
                 {
@@ -297,7 +299,7 @@ namespace Ship_Game.AI
             }
 
             var freighters = new Array<IShipDesign>();
-            foreach (IShipDesign design in empire.ShipsWeCanBuild)
+            foreach (IShipDesign design in empire.ShipsWeCanBuildSnapshot)
             {
                 if (!design.IsCandidateForTradingBuild && design.Name != empire.data.DefaultMiningShip)
                     continue;
@@ -358,7 +360,7 @@ namespace Ship_Game.AI
             else
             {
                 var constructors = new Array<IShipDesign>();
-                foreach (IShipDesign design in empire.ShipsWeCanBuild)
+                foreach (IShipDesign design in empire.ShipsWeCanBuildSnapshot)
                     if (design.IsConstructor)
                         constructors.Add(design);
 

--- a/Ship_Game/AI/Research/ShipPicker.cs
+++ b/Ship_Game/AI/Research/ShipPicker.cs
@@ -42,7 +42,7 @@ namespace Ship_Game.AI.Research
         public IShipDesign FindCheapestShipInList(Empire empire, Array<IShipDesign> ships, HashSet<string> techs)
         {
             PopulateKnownTechs(empire);
-            var buildableShips = empire.ShipsWeCanBuild.ToArr();
+            var buildableShips = empire.ShipsWeCanBuildSnapshot;
             PopulateMostTechs(buildableShips, KnownTechs);
             PopulateMostTechs(ships, KnownTechs);
 

--- a/Ship_Game/Audio/GameAudio.cs
+++ b/Ship_Game/Audio/GameAudio.cs
@@ -136,6 +136,10 @@ public static class GameAudio
     // this is called from Game1.Update() every frame
     public static void Update()
     {
+        // Devices is null when Initialize() failed (AudioEngineGood=false) or after Destroy()/DisableAudio(true).
+        if (Devices == null)
+            return;
+
         Devices.HandleEvents();
 
         if (Devices.ShouldReloadAudioDevice)

--- a/Ship_Game/AutomationWindow.cs
+++ b/Ship_Game/AutomationWindow.cs
@@ -209,7 +209,7 @@ namespace Ship_Game
         {
             var sb = new StringBuilder("Player.ShipsWeCanBuild = {\n");
 
-            foreach (IShipDesign ship in Screen.Player.ShipsWeCanBuild)
+            foreach (IShipDesign ship in Screen.Player.ShipsWeCanBuildSnapshot)
                 sb.Append("  '").Append(ship.Name).Append("',\n");
             sb.Append("}");
 
@@ -223,7 +223,7 @@ namespace Ship_Game
             options.Clear();
 
 
-            foreach (IShipDesign ship in Screen.Player.ShipsWeCanBuild)
+            foreach (IShipDesign ship in Screen.Player.ShipsWeCanBuildSnapshot)
             {
                 if (predicate(ship))
                     options.AddOption(ship.Name, 0);

--- a/Ship_Game/Commands/Goals/MiningOps.cs
+++ b/Ship_Game/Commands/Goals/MiningOps.cs
@@ -225,9 +225,14 @@ namespace Ship_Game.Commands.Goals
             if (Owner.isPlayer && !Owner.AutoBuildMiningStations)
                 return false;
 
+            // BestMiningStationWeCanBuild is null until Empire.UpdateBestOrbitals has run, and
+            // can also stay null if the mod's data.MiningStation no longer resolves (Combined Arms
+            // renames designs). No candidate -> nothing to refit toward.
             string bestRefit = Owner.isPlayer && !Owner.AutoPickBestMiningStation
                 ? Owner.data.MiningStation
-                : Owner.BestMiningStationWeCanBuild.Name;
+                : Owner.BestMiningStationWeCanBuild?.Name;
+            if (bestRefit.IsEmpty())
+                return false;
 
             // Refit only one station of this resource type on this planet per refit
             if (MiningStation.Name != bestRefit

--- a/Ship_Game/Commands/Goals/MiningOps.cs
+++ b/Ship_Game/Commands/Goals/MiningOps.cs
@@ -235,7 +235,7 @@ namespace Ship_Game.Commands.Goals
                 return false;
 
             // Refit only one station of this resource type on this planet per refit
-            if (MiningStation.Name != bestRefit
+            if (MiningStation.Name != bestRefit 
                 && Owner.NeedMoreMiningOpsOfThis(ExoticBonusType)
                 && !Owner.AI.HasGoal(g => g is RefitOrbital && g.ToBuild.IsMiningStation && g.OldShip == MiningStation))
             {

--- a/Ship_Game/Debug/Page/PiratesDebug.cs
+++ b/Ship_Game/Debug/Page/PiratesDebug.cs
@@ -98,9 +98,9 @@ public class PiratesDebug : DebugPage
 
         Text.NewLine();
 
-        Text.String($"Fighter Designs We Can Launch ({e.Pirates.Owner.ShipsWeCanBuild.Count})");
+        Text.String($"Fighter Designs We Can Launch ({e.Pirates.Owner.ShipsWeCanBuildCount})");
         Text.String("---------------------------------------------");
-        foreach (IShipDesign s in e.Pirates.Owner.ShipsWeCanBuild)
+        foreach (IShipDesign s in e.Pirates.Owner.ShipsWeCanBuildSnapshot)
             Text.String(s.Name);
 
         Text.NewLine();

--- a/Ship_Game/DeepSpaceBuildingWindow.cs
+++ b/Ship_Game/DeepSpaceBuildingWindow.cs
@@ -43,7 +43,7 @@ namespace Ship_Game
             SL.EnableItemHighlight = true;
 
             //The Doctor: Ensure Projector is always the first entry on the DSBW list so that the player never has to scroll to find it.
-            foreach (IShipDesign s in Player.SpaceStationsWeCanBuild)
+            foreach (IShipDesign s in Player.SpaceStationsWeCanBuildSnapshot)
             {
                 if (s.IsSubspaceProjector)
                 {
@@ -51,7 +51,7 @@ namespace Ship_Game
                     break;
                 }
             }
-            foreach (IShipDesign s in Player.SpaceStationsWeCanBuild)
+            foreach (IShipDesign s in Player.SpaceStationsWeCanBuildSnapshot)
             {
                 if (!s.IsSubspaceProjector && !s.IsDysonSwarmController)
                     SL.AddItem(new(Screen, s));

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -871,7 +871,8 @@ namespace Ship_Game
         {
             foreach (Technology.LeadsToTech leadsToTech in tech.Tech.LeadsTo)
             {
-                TechEntry entry = GetTechEntry(leadsToTech.UID);
+                if (!TryGetTechEntry(leadsToTech.UID, out TechEntry entry))
+                    continue;
                 if (entry.shipDesignsCanuseThis || WeCanUseThisLater(entry))
                     return true;
             }

--- a/Ship_Game/Empire_ShipsWeCanBuild.cs
+++ b/Ship_Game/Empire_ShipsWeCanBuild.cs
@@ -29,7 +29,7 @@ public sealed partial class Empire
     volatile IShipDesign[] CachedSpaceStationsWeCanBuildSnapshot;
 
     // For TESTING
-    public string[] ShipsWeCanBuildIds => ShipsWeCanBuild.Select(s => s.Name);
+    public string[] ShipsWeCanBuildIds => ShipsWeCanBuildSnapshot.Select(s => s.Name);
 
     /// <summary>
     /// Stable snapshot of ShipsWeCanBuild for safe iteration. Lock-free in the
@@ -69,19 +69,24 @@ public sealed partial class Empire
     /// </summary>
     public bool CanBuildShip(string shipUID)
     {
-        if (ResourceManager.Ships.GetDesign(shipUID, out IShipDesign design))
+        if (!ResourceManager.Ships.GetDesign(shipUID, out IShipDesign design))
+            return false;
+        lock (ShipsWeCanBuildLock)
             return ShipsWeCanBuild.Contains(design);
-        return false;
     }
 
     public bool CanBuildShip(IShipDesign ship)
     {
-        return ship != null && ShipsWeCanBuild.Contains(ship);
+        if (ship == null) return false;
+        lock (ShipsWeCanBuildLock)
+            return ShipsWeCanBuild.Contains(ship);
     }
 
     public bool CanBuildStation(IShipDesign station)
     {
-        return station != null && SpaceStationsWeCanBuild.Contains(station);
+        if (station == null) return false;
+        lock (ShipsWeCanBuildLock)
+            return SpaceStationsWeCanBuild.Contains(station);
     }
 
     public bool AddBuildableShip(IShipDesign ship)
@@ -207,12 +212,18 @@ public sealed partial class Empire
 
     public void RemoveDuplicateShipDesigns()
     {
-        RemoveDuplicateShipDesigns(ShipsWeCanBuild);
-        RemoveDuplicateShipDesigns(SpaceStationsWeCanBuild);
+        lock (ShipsWeCanBuildLock)
+        {
+            if (RemoveDuplicateShipDesigns(ShipsWeCanBuild))
+                CachedShipsWeCanBuildSnapshot = null;
+            if (RemoveDuplicateShipDesigns(SpaceStationsWeCanBuild))
+                CachedSpaceStationsWeCanBuildSnapshot = null;
+        }
     }
 
-    void RemoveDuplicateShipDesigns(HashSet<IShipDesign> designs)
+    bool RemoveDuplicateShipDesigns(HashSet<IShipDesign> designs)
     {
+        bool anyRemoved = false;
         Map<string, IShipDesign> unique = new();
         foreach (IShipDesign design in designs.ToArr())
         {
@@ -240,7 +251,8 @@ public sealed partial class Empire
                                 $"Remove Cost={toRemove.BaseCost} Warp={toRemove.BaseWarpThrust} Str={toRemove.BaseStrength}.");
                 }
 
-                designs.Remove(toRemove);
+                if (designs.Remove(toRemove))
+                    anyRemoved = true;
                 unique[design.Name] = toKeep;
             }
             else
@@ -248,6 +260,7 @@ public sealed partial class Empire
                 unique.Add(design.Name, design);
             }
         }
+        return anyRemoved;
     }
 
     public bool WeCanShowThisWIP(IShipDesign shipData)

--- a/Ship_Game/Empire_ShipsWeCanBuild.cs
+++ b/Ship_Game/Empire_ShipsWeCanBuild.cs
@@ -8,12 +8,61 @@ namespace Ship_Game;
 
 public sealed partial class Empire
 {
-    [StarData] public HashSet<IShipDesign> ShipsWeCanBuild;
+    // Source of truth; private so all external access goes through the safe API
+    // (Snapshot/Count for reads, AddBuildableShip/RemoveBuildableShip/ClearShipsWeCanBuild
+    // for writes). Both HashSets are mutated under the same lock and share the cache
+    // invalidation flow.
+    [StarData] HashSet<IShipDesign> ShipsWeCanBuild;
     // shipyards, platforms, SSP-s
-    [StarData] public HashSet<IShipDesign> SpaceStationsWeCanBuild;
+    [StarData] HashSet<IShipDesign> SpaceStationsWeCanBuild;
+
+    // Copy-on-write cache for safe lock-free iteration. Sim-thread readers used
+    // to iterate the HashSets directly and could crash with `Collection was modified`
+    // when any other code path mutated them concurrently. Now readers call the
+    // *Snapshot properties which return these cached arrays; the cache is
+    // invalidated to null by every writer under ShipsWeCanBuildLock and lazily
+    // rebuilt on the next read. `volatile` is required because the reader's
+    // fast path is lock-free — without it the JIT could cache the field in a
+    // register and never observe the writer's invalidation.
+    readonly object ShipsWeCanBuildLock = new();
+    volatile IShipDesign[] CachedShipsWeCanBuildSnapshot;
+    volatile IShipDesign[] CachedSpaceStationsWeCanBuildSnapshot;
 
     // For TESTING
     public string[] ShipsWeCanBuildIds => ShipsWeCanBuild.Select(s => s.Name);
+
+    /// <summary>
+    /// Stable snapshot of ShipsWeCanBuild for safe iteration. Lock-free in the
+    /// common case (cache hit). Use this instead of iterating ShipsWeCanBuild
+    /// directly from any code path that might race with ship-design mutations.
+    /// </summary>
+    public IShipDesign[] ShipsWeCanBuildSnapshot
+    {
+        get
+        {
+            var snap = CachedShipsWeCanBuildSnapshot;
+            if (snap != null)
+                return snap;
+            lock (ShipsWeCanBuildLock)
+                return CachedShipsWeCanBuildSnapshot ??= ShipsWeCanBuild.ToArray();
+        }
+    }
+
+    /// <summary>Stable snapshot of SpaceStationsWeCanBuild. See ShipsWeCanBuildSnapshot.</summary>
+    public IShipDesign[] SpaceStationsWeCanBuildSnapshot
+    {
+        get
+        {
+            var snap = CachedSpaceStationsWeCanBuildSnapshot;
+            if (snap != null)
+                return snap;
+            lock (ShipsWeCanBuildLock)
+                return CachedSpaceStationsWeCanBuildSnapshot ??= SpaceStationsWeCanBuild.ToArray();
+        }
+    }
+
+    public int ShipsWeCanBuildCount         => ShipsWeCanBuildSnapshot.Length;
+    public int SpaceStationsWeCanBuildCount => SpaceStationsWeCanBuildSnapshot.Length;
 
     /// <summary>
     /// TRUE if this Empire can build this ship
@@ -37,23 +86,41 @@ public sealed partial class Empire
 
     public bool AddBuildableShip(IShipDesign ship)
     {
-        bool added = ShipsWeCanBuild.Add(ship);
-        if (added && ship.Role <= RoleName.station)
-            SpaceStationsWeCanBuild.Add(ship);
-        return added;
+        lock (ShipsWeCanBuildLock)
+        {
+            bool added = ShipsWeCanBuild.Add(ship);
+            if (added)
+            {
+                CachedShipsWeCanBuildSnapshot = null;
+                if (ship.Role <= RoleName.station && SpaceStationsWeCanBuild.Add(ship))
+                    CachedSpaceStationsWeCanBuildSnapshot = null;
+            }
+            return added;
+        }
     }
 
     public bool RemoveBuildableShip(IShipDesign ship)
     {
-        bool removed = ShipsWeCanBuild.Remove(ship);
-        SpaceStationsWeCanBuild.Remove(ship);
-        return removed;
+        lock (ShipsWeCanBuildLock)
+        {
+            bool removed = ShipsWeCanBuild.Remove(ship);
+            if (removed)
+                CachedShipsWeCanBuildSnapshot = null;
+            if (SpaceStationsWeCanBuild.Remove(ship))
+                CachedSpaceStationsWeCanBuildSnapshot = null;
+            return removed;
+        }
     }
 
     public void ClearShipsWeCanBuild()
     {
-        ShipsWeCanBuild.Clear();
-        SpaceStationsWeCanBuild.Clear();
+        lock (ShipsWeCanBuildLock)
+        {
+            ShipsWeCanBuild.Clear();
+            SpaceStationsWeCanBuild.Clear();
+            CachedShipsWeCanBuildSnapshot = null;
+            CachedSpaceStationsWeCanBuildSnapshot = null;
+        }
     }
 
     public void FactionShipsWeCanBuild()
@@ -85,14 +152,15 @@ public sealed partial class Empire
 
     public void RemoveInvalidShipDesigns()
     {
-        if (ShipsWeCanBuild.Any(sd => !sd.IsValidDesign))
+        IShipDesign[] snapshot = ShipsWeCanBuildSnapshot;
+        for (int i = 0; i < snapshot.Length; i++)
         {
-            foreach (IShipDesign sd in ShipsWeCanBuild.ToArr())
-                if (!sd.IsValidDesign)
-                {
-                    Log.Warning($"Removing invalid Buildable Ship: {sd.Name}");
-                    RemoveBuildableShip(sd);
-                }
+            IShipDesign sd = snapshot[i];
+            if (!sd.IsValidDesign)
+            {
+                Log.Warning($"Removing invalid Buildable Ship: {sd.Name}");
+                RemoveBuildableShip(sd);
+            }
         }
     }
 
@@ -291,7 +359,7 @@ public sealed partial class Empire
             return true;
 
         var scoutShipsWeCanBuild = new Array<IShipDesign>();
-        foreach (IShipDesign design in ShipsWeCanBuild)
+        foreach (IShipDesign design in ShipsWeCanBuildSnapshot)
             if (design.Role == RoleName.scout)
                 scoutShipsWeCanBuild.Add(design);
 

--- a/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Build.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Build.cs
@@ -124,7 +124,7 @@ namespace Ship_Game
             }
             else if (P.Owner != null)
             {
-                buildableShips = P.Owner.ShipsWeCanBuild
+                buildableShips = P.Owner.ShipsWeCanBuildSnapshot
                     .Filter(ship => (ship.IsBuildableByPlayer(Universe.Player) && Universe.Screen.Player.WeCanBuildThis(ship) || Universe.Debug)
                                     && !ship.IsResearchStation
                                     && !ship.IsMiningStation

--- a/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen.cs
+++ b/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen.cs
@@ -356,7 +356,7 @@ namespace Ship_Game
 
             if (SubShips.SelectedIndex == 0) // ShipsWeCanBuild
             {
-                IShipDesign[] designs = Player.ShipsWeCanBuild.Filter(CanShowDesign);
+                IShipDesign[] designs = Player.ShipsWeCanBuildSnapshot.Filter(CanShowDesign);
                 ShipSL.Reset();
                 InitShipSL(designs);
             }
@@ -382,7 +382,7 @@ namespace Ship_Game
             {
                 FleetDesignShipListItem header = new(this, role);
                 ShipSL.AddItem(header);
-                foreach (IShipDesign d in Player.ShipsWeCanBuild)
+                foreach (IShipDesign d in Player.ShipsWeCanBuildSnapshot)
                     if (IsCandidateShip(d) && d.GetRole() == header.HeaderText)
                         header.AddSubItem(new FleetDesignShipListItem(this, d));
             }

--- a/Ship_Game/GameScreens/MainMenu/AutoPatcher.cs
+++ b/Ship_Game/GameScreens/MainMenu/AutoPatcher.cs
@@ -573,6 +573,15 @@ internal class AutoPatcher : PopupWindow
             FileInfo[] filesToAdd = Dir.GetFiles(patchFilesFolder);
             var skipped = new Array<string>();
             int currentAction = 0;
+            int lockedFiles = 0;
+            // Per-file retry budget for stash-aside in MoveAndCreateDirs. Starts at 3 attempts
+            // (100/200/300 ms escalating waits) — handles isolated AV scans. After 5 files have
+            // exhausted retries we conclude the lock is systemic (AV scanning the whole patch
+            // dir, OneDrive batch-syncing, etc.) and drop to a single attempt so we don't burn
+            // minutes waiting on locks that won't clear this run. Skipped files survive in the
+            // staging cache and the user re-runs the patcher to pick them up next round.
+            int maxRetries = 3;
+            const int systemicLockThreshold = 5;
             foreach (FileInfo toAdd in filesToAdd)
             {
                 string srcFile = toAdd.FullName;
@@ -594,7 +603,24 @@ internal class AutoPatcher : PopupWindow
                 }
 
                 Log.Write($"CopyFile: {relPath}");
-                SafeCopy(srcFile, dstFile, relPath, tempDir);
+                try
+                {
+                    SafeCopy(srcFile, dstFile, relPath, tempDir, maxRetries);
+                }
+                catch (IOException e)
+                {
+                    // Dst file is locked (AV scan, OneDrive sync, game holding the texture, etc.).
+                    // SafeCopy already restored the previous dst on failure, so the install is
+                    // intact for this file. Skip rather than aborting — staging cache survives,
+                    // user can re-run the patcher to pick up whatever was locked this round.
+                    Log.Warning($"CopyFile skipped (destination locked — AV or in-use?): {relPath}: {e.Message}");
+                    skipped.Add(relPath);
+                    if (++lockedFiles == systemicLockThreshold && maxRetries > 1)
+                    {
+                        Log.Warning($"AutoPatcher: {systemicLockThreshold} locked files — dropping retries to 1 for remaining files");
+                        maxRetries = 1;
+                    }
+                }
                 ap.SetProgress(ProgressBarElement.GetPercent(++currentAction, filesToAdd.Length));
             }
 
@@ -657,14 +683,14 @@ internal class AutoPatcher : PopupWindow
     /// Move, which destroyed each source on success and left a half-gutted cache
     /// on any failure (no recovery without re-downloading).
     /// </summary>
-    static void SafeCopy(string srcFile, string dstFile, string relPath, string tempDir)
+    static void SafeCopy(string srcFile, string dstFile, string relPath, string tempDir, int maxRetries = 3)
     {
         string tmpFile = null;
         try
         {
             if (File.Exists(dstFile))
             {
-                tmpFile = MoveToTempPath(tempDir, relPath, dstFile);
+                tmpFile = MoveToTempPath(tempDir, relPath, dstFile, maxRetries);
             }
             CopyAndCreateDirs(srcFile, dstFile);
         }
@@ -726,7 +752,7 @@ internal class AutoPatcher : PopupWindow
     /// Moves `theFile` into `tempPath`, returning full path to the temp file,
     /// so that it can be restored if necessary
     /// </summary>
-    static string MoveToTempPath(string tempPath, string relPath, string theFile)
+    static string MoveToTempPath(string tempPath, string relPath, string theFile, int maxRetries = 3)
     {
         string tmpFile = Path.Combine(tempPath, relPath);
         if (File.Exists(tmpFile))
@@ -743,7 +769,7 @@ internal class AutoPatcher : PopupWindow
             }
         }
 
-        MoveAndCreateDirs(theFile, tmpFile);
+        MoveAndCreateDirs(theFile, tmpFile, maxRetries);
         return tmpFile;
     }
 
@@ -751,16 +777,30 @@ internal class AutoPatcher : PopupWindow
     // Move is genuinely the right primitive — intra-volume, atomic, leaves no copy.
     // For the src(staging-cache) → dst(install) transfer, use CopyAndCreateDirs so
     // a mid-apply failure doesn't destroy the staging cache.
-    static void MoveAndCreateDirs(string sourceFile, string destinationFile)
+    static void MoveAndCreateDirs(string sourceFile, string destinationFile, int maxAttempts = 3)
     {
-        try
+        Directory.CreateDirectory(Path.GetDirectoryName(destinationFile)!);
+
+        // Retry on transient sharing violations: AV/Defender often holds a handle on a
+        // freshly-touched file for ~100ms after scan start. Linear backoff (100/200/300 ms)
+        // covers the common single-file case. CopyNewFiles drops maxAttempts to 1 once it
+        // detects a systemic lock pattern (>5 files failed), to avoid burning minutes on a
+        // patch where AV is scanning the whole batch.
+        for (int attempt = 1; ; attempt++)
         {
-            Directory.CreateDirectory(Path.GetDirectoryName(destinationFile)!);
-            File.Move(sourceFile, destinationFile);
-        }
-        catch (Exception e)
-        {
-            throw new IOException($"Move failed: {sourceFile} --> {destinationFile}", e);
+            try
+            {
+                File.Move(sourceFile, destinationFile);
+                return;
+            }
+            catch (Exception e) when ((e is IOException || e is UnauthorizedAccessException) && attempt < maxAttempts)
+            {
+                Thread.Sleep(100 * attempt);
+            }
+            catch (Exception e)
+            {
+                throw new IOException($"Move failed: {sourceFile} --> {destinationFile}", e);
+            }
         }
     }
 

--- a/Ship_Game/GameScreens/MainMenu/AutoPatcher.cs
+++ b/Ship_Game/GameScreens/MainMenu/AutoPatcher.cs
@@ -613,7 +613,11 @@ internal class AutoPatcher : PopupWindow
                     // SafeCopy already restored the previous dst on failure, so the install is
                     // intact for this file. Skip rather than aborting — staging cache survives,
                     // user can re-run the patcher to pick up whatever was locked this round.
-                    Log.Warning($"CopyFile skipped (destination locked — AV or in-use?): {relPath}: {e.Message}");
+                    // SafeCopy wraps as `new IOException(relPath, e)`, so e.Message is just the
+                    // relPath we already log. Walk to the inner exception for the actual cause
+                    // (sharing violation, ACL denied, disk full, etc.).
+                    string cause = e.InnerException?.Message ?? e.Message;
+                    Log.Warning($"CopyFile skipped (destination locked — AV or in-use?): {relPath}: {cause}");
                     skipped.Add(relPath);
                     if (++lockedFiles == systemicLockThreshold && maxRetries > 1)
                     {

--- a/Ship_Game/GameScreens/ShipDesign/FighterScrollList.cs
+++ b/Ship_Game/GameScreens/ShipDesign/FighterScrollList.cs
@@ -35,7 +35,7 @@ namespace Ship_Game
             AddShip(ResourceManager.Ships.GetDesign(DynamicHangarOptions.DynamicLaunch.ToString()));
             AddShip(ResourceManager.Ships.GetDesign(DynamicHangarOptions.DynamicInterceptor.ToString()));
             AddShip(ResourceManager.Ships.GetDesign(DynamicHangarOptions.DynamicAntiShip.ToString()));
-            foreach (IShipDesign hangarShip in Screen.ParentUniverse.Player.ShipsWeCanBuild)
+            foreach (IShipDesign hangarShip in Screen.ParentUniverse.Player.ShipsWeCanBuildSnapshot)
             {
                 string role = hangarShip.HullRole.ToString();
                 if (!ActiveModule.PermittedHangarRoles.Contains(role))

--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignIssues.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignIssues.cs
@@ -61,7 +61,7 @@ namespace Ship_Game.GameScreens.ShipDesign
                 int totalWarpShipsCivilian   = 0;
                 int totalWarpShipsMilitary   = 0;
 
-                foreach (IShipDesign design in empire.ShipsWeCanBuild)
+                foreach (IShipDesign design in empire.ShipsWeCanBuildSnapshot)
                 {
                     float warpSpeed = ShipStats.GetFTLSpeed(design, empire);
                     if (warpSpeed < 2000 || Scout(design.Role))

--- a/Ship_Game/RefitToWindow.cs
+++ b/Ship_Game/RefitToWindow.cs
@@ -88,7 +88,7 @@ namespace Ship_Game
             RefitShipList.EnableItemHighlight = true;
             RefitShipList.OnClick = OnRefitShipItemClicked;
 
-            foreach (IShipDesign design in ShipToRefit.Loyalty.ShipsWeCanBuild)
+            foreach (IShipDesign design in ShipToRefit.Loyalty.ShipsWeCanBuildSnapshot)
             {
                 if ((design.Hull == ShipToRefit.ShipData.Hull || ShipToRefit.IsResearchStation || ShipToRefit.IsMiningStation) 
                     && design != ShipToRefit.ShipData 

--- a/Ship_Game/Spatial/NativeSpatial.cs
+++ b/Ship_Game/Spatial/NativeSpatial.cs
@@ -162,6 +162,19 @@ namespace Ship_Game.Spatial
                         var so = new NativeSpatialObject(go);
                         objectId = SpatialInsert(Spat, ref so);
                         go.SpatialIndex = objectId;
+
+                        // The native ObjectCollection::insert() returns `MaxObjects++`
+                        // when its FreeIds list is empty, so each insert past the
+                        // snapshot taken above grows MaxObjects on the native side.
+                        // The pre-sized `objects` array can therefore overflow when
+                        // many SpatialIndex==-1 objects appear in one UpdateAll
+                        // (Combined Arms mod with thousands of churning ships).
+                        // Geometric growth amortizes the resize cost across inserts.
+                        if (objectId >= objects.Length)
+                        {
+                            int newSize = Math.Max(objects.Length * 2, objectId + 1);
+                            Array.Resize(ref objects, newSize);
+                        }
                     }
                     else // update existing
                     {

--- a/Ship_Game/Troops/Troop.cs
+++ b/Ship_Game/Troops/Troop.cs
@@ -368,7 +368,11 @@ namespace Ship_Game
             Strength = (Strength - amount).Clamped(0, ActualStrengthMax);
             if (Strength < 1)
             {
-                planet.Troops.TryRemoveTroop(tile, this);
+                // quiet: another path (orbital bombing, allied troop sweep, prior combat in same
+                // tick) can pull this troop out of TroopsHere while Combat still holds a direct
+                // ref. The troop is genuinely dead — caller marks dead=true and the Combat cleans
+                // itself up — but TryRemoveTroop would otherwise spam Sentry on the second remove.
+                planet.Troops.TryRemoveTroop(tile, this, quiet: true);
                 dead = true;
             }
         }

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
@@ -91,18 +91,27 @@ namespace Ship_Game
 
                 var frustum = VisibleWorldRect;
 
+                // Sort by MilitaryScore (weaker first, stronger drawn on top). Skip the player
+                // inside the loop and render them last so the player's influence always sits over
+                // every AI — matches the minimap rule in DrawMinimapInfluenceNodes.
                 Empire[] empires = UState.Empires.Sorted(e => e.MilitaryScore);
                 foreach (Empire empire in empires)
                 {
-                    bool canShowBorders = Debug || empire == Player || Player.IsKnown(empire);
-                    if (!canShowBorders)
+                    if (empire == Player)
                         continue;
+                    if (!Debug && !Player.IsKnown(empire))
+                        continue;
+                    DrawEmpireInfluence(empire);
+                }
+                DrawEmpireInfluence(Player);
 
+                void DrawEmpireInfluence(Empire empire)
+                {
                     empire.BorderNodeCache.Update(empire);
 
                     Empire.InfluenceNode[] nodes = empire.BorderNodeCache.BorderNodes;
                     if (nodes.Length == 0)
-                        continue;
+                        return;
 
                     draw3d.Begin(ViewProjection);
 
@@ -114,7 +123,6 @@ namespace Ship_Game
                     // overlapping gradient edges into nice blobs
                     RenderStates.EnableSeparateAlphaBlend(graphics, BorderBlendSrc, BorderBlendDest);
                     RenderStates.EnableAlphaTest(graphics, CompareFunction.Greater);
-                    //RenderStates.DisableAlphaTest(graphics);
 
                     Color empireColor = empire.EmpireColor.Alpha(GlobalStats.InfluenceNodeAlpha);
                     for (int x = 0; x < nodes.Length; x++)

--- a/Ship_Game/Universe/UniverseState.cs
+++ b/Ship_Game/Universe/UniverseState.cs
@@ -201,10 +201,10 @@ namespace Ship_Game.Universe
                 }
                 foreach (Empire e in us.EmpireList)
                 {
-                    foreach (IShipDesign s in e.ShipsWeCanBuild)
+                    foreach (IShipDesign s in e.ShipsWeCanBuildSnapshot)
                         if (s.IsValidDesign)
                             designs.Add((ShipDesign)s);
-                    foreach (IShipDesign s in e.SpaceStationsWeCanBuild)
+                    foreach (IShipDesign s in e.SpaceStationsWeCanBuildSnapshot)
                         if (s.IsValidDesign)
                             designs.Add((ShipDesign)s);
                 }


### PR DESCRIPTION
**Sim-thread crashes**

- NativeSpatial.UpdateAll: pre-sized objects buffer overflowed when SpatialInsert grew MaxObjects past the snapshot (heavy ship churn drained FreeIds). Geometric Array.Resize after insert.
- Empire.ShipsWeCanBuild: Collection was modified during UpdateShipsWeCanBuild iteration. Privatized the HashSet behind a lock + COW snapshot caches (*Snapshot, *Count); 15 call sites migrated. volatile fields keep the lock-free fast path correct.
- MiningOps.NeedsRefit: NRE on Owner.BestMiningStationWeCanBuild.Name. Null-guard + early-return when no candidate (mod data can leave it null until UpdateBestOrbitals runs / if data.MiningStation no longer resolves).
- Empire.WeCanUseThisLater: GetTechEntry spammed Log.Error for dangling LeadsTo UIDs from mod data (e.g. legacy CA NemTech). Switched to TryGetTechEntry; Technology.ResolveLeadsToTechs already warns once at content load.
- Troop.DamageTroop: pass quiet:true to TryRemoveTroop for the benign concurrent-remove race (orbital bombing / allied sweep / prior combat tick can pull a troop from TroopsHere while Combat still holds the ref). Sister site at TroopManager.DoTroopTimers left noisy as a canary.
- GameAudio.Update: null-guard Devices so frames after Destroy() / failed Initialize() don't NRE.
UI
- UniverseScreen: extract DrawEmpireInfluence local, skip player in the sorted loop, draw player last — matches the minimap rule so the player's influence always sits on top regardless of MilitaryScore.

**AutoPatcher**
- Retry-with-backoff on locked destination stash (MoveAndCreateDirs); per-file IOException skip instead of failing the whole patch; systemic-lock threshold drops retries to 1 after 5 files exhaust attempts so a Defender/OneDrive batch scan can't blow the budget.
Tooling
- patch-build workflow: format release notes as - subject bullets (was emitting raw git log --oneline SHAs).
.gitignore housekeeping.