### PR TITLE
Jupiter 1.60/fixes 06

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Notice: We have StarDrive developer's [publicly and privately stated approval](h
 Do not use this for immoral or personal financial gain, donation requests are ok but can not be demanded or required.
 Do not attempt to circumvent game DRM. Be reasonably respectful of the dev and the original software and steam.
 
+# System Requirements
+
+* **OS**: Windows 10 version 1803 (April 2018 Update, build 17134) or later — including Windows 11. Older Windows 10 builds are missing per-thread DPI APIs that MonoGame 3.8 requires and the game will fail to start.
+* **Architecture**: 64-bit (x64)
+* **.NET runtime**: bundled with the installer (.NET 8)
+
 # Downloads
 
 The canonical distribution channel is **itch.io**:

--- a/Ship_Game/AI/EmpireAI/EmpireAI.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.cs
@@ -459,7 +459,7 @@ namespace Ship_Game.AI
 
         public bool AnyProjectorBridgeGoalTargetingSystem(SolarSystem system, Empire loyalty)
             => GoalsList.Any(g => g.Type == GoalType.ProjectorBridge
-               && g.BuildPosition.InRadius(system.Position, loyalty.AI.SpaceRoadsManager.ProgectorBridgeRadiusThreshold * 1.025f));
+               && g.BuildPosition.InRadius(system.Position, loyalty.AI.SpaceRoadsManager.ProjectorBridgeRadiusThreshold * 1.025f));
 
         public bool HasGoal(GoalType type)
         {

--- a/Ship_Game/AI/EmpireAI/SpaceRoadsManager.cs
+++ b/Ship_Game/AI/EmpireAI/SpaceRoadsManager.cs
@@ -25,7 +25,7 @@ namespace Ship_Game.AI
         [StarData] public readonly Array<SpaceRoad> SpaceRoads = new();
         [StarData] public readonly Empire Owner;
 
-        public float ProgectorBridgeRadiusThreshold => Owner.GetProjectorRadius() * 0.6f;
+        public float ProjectorBridgeRadiusThreshold => Owner.GetProjectorRadius() * 0.6f;
 
         bool ShouldManageRoads => Owner.CanBuildPlatforms
                                   && (!Owner.isPlayer || Owner.isPlayer && Owner.AutoBuildSpaceRoads);

--- a/Ship_Game/AI/EmpireAI/SpaceRoadsManager.cs
+++ b/Ship_Game/AI/EmpireAI/SpaceRoadsManager.cs
@@ -267,7 +267,8 @@ namespace Ship_Game.AI
                 {
                     // find where the ship was coming from and setup a projector bridge
                     Goal colonizationGoal = Owner.AI.FindGoal(g => g.FinishedShip == ship);
-                    if (colonizationGoal?.PlanetBuildingAt != null)
+                    if (colonizationGoal?.PlanetBuildingAt != null
+                        && !ProjectorAlreadyAtBridgeTarget(ship.System, colonizationGoal.PlanetBuildingAt.System.Position))
                     {
                         Owner.AI.AddGoal(new ProjectorBridge(ship.System,
                             colonizationGoal.PlanetBuildingAt.System.Position, Owner, endCondition));
@@ -281,7 +282,7 @@ namespace Ship_Game.AI
 
             void CheckBridgeNeededTradeOrConstruction()
             {
-                if ((ship.IsFreighter || ship.IsConstructor) 
+                if ((ship.IsFreighter || ship.IsConstructor)
                     && !Owner.AI.SpaceRoadsManager.InfluenceNodeExistsAt(ship.Position)
                     && !Owner.AI.AnyProjectorBridgeGoalTargetingSystem(ship.System, ship.Loyalty))
                 {
@@ -291,16 +292,31 @@ namespace Ship_Game.AI
                         ship.AI.OrderQueue.TryPeekFirst(out ShipGoal goal);
                         if (goal?.Trade != null)
                         {
-                            Owner.AI.AddGoalAndEvaluate(new ProjectorBridge(ship.System,
-                                goal.Trade.ExportFrom.System.Position, Owner, endCondition));
+                            if (!ProjectorAlreadyAtBridgeTarget(ship.System, goal.Trade.ExportFrom.System.Position))
+                            {
+                                Owner.AI.AddGoalAndEvaluate(new ProjectorBridge(ship.System,
+                                    goal.Trade.ExportFrom.System.Position, Owner, endCondition));
+                            }
 
                             return;
                         }
                     }
                     // fallback to ship position for bridge direction or if ship is a constructor
-                    Owner.AI.AddGoalAndEvaluate(new ProjectorBridge(ship.System, Owner.WeightedCenter, Owner, endCondition));
+                    if (!ProjectorAlreadyAtBridgeTarget(ship.System, Owner.WeightedCenter))
+                        Owner.AI.AddGoalAndEvaluate(new ProjectorBridge(ship.System, Owner.WeightedCenter, Owner, endCondition));
                 }
             }
+        }
+
+        // The outer InfluenceNodeExistsAt(ship.Position) guard checks where the ship *died*,
+        // but a ProjectorBridge actually builds at an offset from the system center — that
+        // offset can already be covered by an existing projector. Without this check, we
+        // schedule a redundant BuildConstructionShip and the constructor's "Build pos of
+        // projector is near ..." Log.Error fires.
+        bool ProjectorAlreadyAtBridgeTarget(SolarSystem targetSystem, Vector2 directionRefPos)
+        {
+            Vector2 plannedBuildPos = ProjectorBridge.GetBridgeBuildPosition(targetSystem, directionRefPos, Owner);
+            return Owner.FindProjectorAt(plannedBuildPos, 100, out _);
         }
     }
 }

--- a/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
@@ -144,6 +144,11 @@ namespace Ship_Game.AI
             ScannedFriendlies.Clear();
         }
 
+        // Per-scan cap on PotentialTargets — the AI's combat target list. Keeps
+        // SelectCombatTarget iteration bounded even when the wider visibility
+        // scan (MaxResults below) returns more.
+        const int MaxScannedTargets = 128;
+
         public void ScanForEnemies(Ship sensorShip, float sensorRadius)
         {
             if (sensorRadius <= 0f) // sensors can be disabled, we use radius 0 to signal this
@@ -156,9 +161,17 @@ namespace Ship_Game.AI
             BadGuysNear = false;
 
             Empire us = sensorShip.Loyalty;
+            // MaxResults raised from 64 to 512 so ScanForEnemies covers the full
+            // sensor radius in dense battles. Below 512, megabattles silently
+            // dropped far-but-in-radius enemies from the scan, missed their
+            // SetSeen calls, and their KnownContactTimer (1.0s) expired —
+            // players saw distant enemy ships flicker in and out as adjacent
+            // scan ticks returned slightly different subsets. PotentialTargets
+            // is still capped via MaxScannedTargets below so the AI's combat
+            // target list stays bounded.
             var findEnemies = new SearchOptions(sensorShip.Position, sensorRadius, GameObjectType.Ship)
             {
-                MaxResults = 64,
+                MaxResults = 512,
                 Exclude = sensorShip,
                 ExcludeLoyalty = us,
             };
@@ -187,7 +200,8 @@ namespace Ship_Game.AI
                 if (us.IsEmpireAttackable(other, enemy, scanOnly:true))
                 {
                     BadGuysNear = true;
-                    ScannedTargets.Add(enemy);
+                    if (ScannedTargets.Count < MaxScannedTargets)
+                        ScannedTargets.Add(enemy);
                 }
             }
 

--- a/Ship_Game/Audio/GameAudio.cs
+++ b/Ship_Game/Audio/GameAudio.cs
@@ -177,6 +177,26 @@ public static class GameAudio
     public static void ResumeGenericMusic() { if (!IsMusicDisabled) Music.Resume(); }
     public static void MuteGenericMusic()   { if (!IsMusicDisabled) Music.Volume = 0f; }
     public static void UnMuteGenericMusic() { if (!IsMusicDisabled) Music.Volume = GlobalStats.MusicVolume; }
+
+    /// <summary>
+    /// Silences all NAudio mixer output (music + SFX) at the mixer level, before it reaches
+    /// the WasapiOut device. Per-instance and per-category volumes are untouched, so the
+    /// per-sample auto-Stop (which would cause ScreenManager.StartMusic to detect
+    /// Music.IsStopped and re-call ConfigureAudioSettings, undoing our mute) does NOT fire.
+    /// MonoGame VideoPlayer audio (MediaFoundation, not routed through this mixer) is
+    /// unaffected. Pair with RestoreMixerOutput().
+    /// </summary>
+    public static void MuteMixerOutput()
+    {
+        if (AudioEngineGood)
+            AudioEngine.MixerMasterVolume = 0f;
+    }
+
+    public static void RestoreMixerOutput()
+    {
+        if (AudioEngineGood)
+            AudioEngine.MixerMasterVolume = 1f;
+    }
     public static void MuteRacialMusic()    { if(!IsMusicDisabled) RacialMusic.Volume = 0f;}
     public static void UnMuteRacialMusic()  { if (!IsMusicDisabled) RacialMusic.Volume = GlobalStats.MusicVolume; }
 

--- a/Ship_Game/Audio/GameAudio.cs
+++ b/Ship_Game/Audio/GameAudio.cs
@@ -185,6 +185,13 @@ public static class GameAudio
     /// Music.IsStopped and re-call ConfigureAudioSettings, undoing our mute) does NOT fire.
     /// MonoGame VideoPlayer audio (MediaFoundation, not routed through this mixer) is
     /// unaffected. Pair with RestoreMixerOutput().
+    /// <para>
+    /// NOTE: Mute is not reference counted — overlapping callers (e.g. two ScreenMediaPlayer
+    /// instances opting into MuteGameAudioWhilePlaying at once) are NOT supported. The first
+    /// one to stop will RestoreMixerOutput() and the second caller will hear game audio
+    /// despite still expecting silence. If a future feature needs concurrent mute requests,
+    /// add a counter here or store/restore per-caller volume.
+    /// </para>
     /// </summary>
     public static void MuteMixerOutput()
     {

--- a/Ship_Game/Audio/NAudio/NAudioPlaybackEngine.cs
+++ b/Ship_Game/Audio/NAudio/NAudioPlaybackEngine.cs
@@ -40,12 +40,25 @@ internal class NAudioPlaybackEngine : IDisposable
     }
 
     /// <summary>
-    /// Global volume of the mixer
+    /// Global volume of the OutputDevice. WARNING: WasapiOut shares the per-process Windows
+    /// audio session, so setting this also affects MediaFoundation (XNA VideoPlayer) audio.
+    /// For NAudio-only mute that leaves video audio audible, use <see cref="MixerMasterVolume"/>.
     /// </summary>
     public float Volume
     {
         get => OutputDevice.Volume;
         set => OutputDevice.Volume = value;
+    }
+
+    /// <summary>
+    /// Master volume applied to the NAudio mixer's output before it reaches the WasapiOut
+    /// device. Use this to silence in-game music/SFX without affecting MediaFoundation video.
+    /// Clamped to [0, 1] so a caller mistake can't polarity-invert or NaN-poison the buffer.
+    /// </summary>
+    public float MixerMasterVolume
+    {
+        get => Mixer.MasterVolume;
+        set => Mixer.MasterVolume = float.IsNaN(value) ? 1f : Math.Clamp(value, 0f, 1f);
     }
 
     /// <summary>

--- a/Ship_Game/Audio/NAudio/NAudioSampleMixer.cs
+++ b/Ship_Game/Audio/NAudio/NAudioSampleMixer.cs
@@ -41,6 +41,15 @@ internal class NAudioSampleMixer : ISampleProvider, IDisposable
     /// </summary>
     public bool ReadFully { get; set; }
 
+    /// <summary>
+    /// Master volume multiplier applied to the mixed output. 1.0 = pass-through, 0.0 = silent.
+    /// Used to mute NAudio output without affecting per-instance volumes or stopping samples
+    /// (which would trigger MainMenu music restart loops). Process-wide audio sessions
+    /// (MediaFoundation video, etc.) are unaffected since they don't go through this mixer.
+    /// `volatile` so the WASAPI render thread sees writes from the main thread promptly.
+    /// </summary>
+    public volatile float MasterVolume = 1.0f;
+
     public void Dispose()
     {
         lock (Sources)
@@ -123,6 +132,17 @@ internal class NAudioSampleMixer : ISampleProvider, IDisposable
                 buffer[outputIndex++] = 0;
             outputSamples = count;
         }
+
+        // apply master volume to the mixed output (used for video-playback NAudio mute).
+        // Snapshot once — main thread may flip MasterVolume between the gate and the loop.
+        float vol = MasterVolume;
+        if (vol != 1.0f)
+        {
+            int end = offset + outputSamples;
+            for (int i = offset; i < end; i++)
+                buffer[i] *= vol;
+        }
+
         return outputSamples;
     }
 }

--- a/Ship_Game/Commands/Goals/FleetRequisition.cs
+++ b/Ship_Game/Commands/Goals/FleetRequisition.cs
@@ -50,10 +50,7 @@ namespace Ship_Game.Commands.Goals
         GoalStep AddShipToFleetAndMoveToPosition()
         {
             if (Fleet == null)
-            {
-                Log.Error($"FleetRequisition {Build.Template.Name} complete but Fleet is null!");
                 return GoalStep.GoalComplete;
-            }
             if (FinishedShip == null)
             {
                 Log.Error($"FleetRequisition {Build.Template.Name} failed: BuiltShip is null!");

--- a/Ship_Game/Commands/Goals/ProjectorBridge.cs
+++ b/Ship_Game/Commands/Goals/ProjectorBridge.cs
@@ -39,11 +39,18 @@ namespace Ship_Game.Commands.Goals
             ProjectorBridgeEndCondition endCondition) : this(e)
         {
             TargetSystem = targetSystem;
-            float distanceToDeploy = Owner.AI.SpaceRoadsManager.ProgectorBridgeRadiusThreshold;
-            Vector2 dir = targetSystem.Position.DirectionToTarget(originPos);
-            StaticBuildPosition = TargetSystem.Position + dir * distanceToDeploy;
+            StaticBuildPosition = GetBridgeBuildPosition(targetSystem, originPos, Owner);
             BuildGoal = new BuildConstructionShip(StaticBuildPosition, "Subspace Projector", Owner, rush: true);
             EndCondition = endCondition;
+        }
+
+        // directionRefPos is only used to pick which side of the target system the bridge
+        // projector lands on; the build position itself is always offset from the system center.
+        public static Vector2 GetBridgeBuildPosition(SolarSystem targetSystem, Vector2 directionRefPos, Empire owner)
+        {
+            float distanceToDeploy = owner.AI.SpaceRoadsManager.ProgectorBridgeRadiusThreshold;
+            Vector2 dir = targetSystem.Position.DirectionToTarget(directionRefPos);
+            return targetSystem.Position + dir * distanceToDeploy;
         }
 
         GoalStep BuildProjector()

--- a/Ship_Game/Commands/Goals/ProjectorBridge.cs
+++ b/Ship_Game/Commands/Goals/ProjectorBridge.cs
@@ -48,7 +48,7 @@ namespace Ship_Game.Commands.Goals
         // projector lands on; the build position itself is always offset from the system center.
         public static Vector2 GetBridgeBuildPosition(SolarSystem targetSystem, Vector2 directionRefPos, Empire owner)
         {
-            float distanceToDeploy = owner.AI.SpaceRoadsManager.ProgectorBridgeRadiusThreshold;
+            float distanceToDeploy = owner.AI.SpaceRoadsManager.ProjectorBridgeRadiusThreshold;
             Vector2 dir = targetSystem.Position.DirectionToTarget(directionRefPos);
             return targetSystem.Position + dir * distanceToDeploy;
         }

--- a/Ship_Game/Empire_Relationship.cs
+++ b/Ship_Game/Empire_Relationship.cs
@@ -521,9 +521,9 @@ namespace Ship_Game
                     switch (Personality)
                     {
                         case PersonalityType.Pacifist   when usToPlayer.StolenSystems.Count >= 4:
-                        case PersonalityType.Cunning:   usToPlayer.PrepareForWar(WarType.DefensiveWar, player);   break;
+                        case PersonalityType.Cunning:   usToPlayer.PrepareForWar(WarType.DefensiveWar, this);   break;
                         case PersonalityType.Aggressive:
-                        case PersonalityType.Ruthless:  usToPlayer.PrepareForWar(WarType.ImperialistWar, player); break;
+                        case PersonalityType.Ruthless:  usToPlayer.PrepareForWar(WarType.ImperialistWar, this); break;
                         case PersonalityType.Xenophobic:
                         case PersonalityType.Honorable: player.AddToDiplomacyContactView(this, "DECLAREWAR");     break;
                         case PersonalityType.Pacifist:  BreakAllTreatiesWith(player);                             break;

--- a/Ship_Game/GameScreens/Program.cs
+++ b/Ship_Game/GameScreens/Program.cs
@@ -12,6 +12,7 @@ internal static class Program
     public const int SCREEN_UPDATE_FAILURE = -2;
     public const int UNHANDLED_EXCEPTION = -3;
     public const int NATIVE_DLL_LOAD_FAILURE = -4;
+    public const int WIN_VERSION_TOO_OLD = -5;
 
     [DllImport("user32.dll", CharSet = CharSet.Unicode, EntryPoint = "MessageBoxW")]
     static extern int Win32MessageBox(IntPtr hWnd, string text, string caption, uint type);
@@ -273,9 +274,46 @@ internal static class Program
             Log.Write("The game exited normally.");
             RunCleanupAndExit(0);
         }
+        catch (EntryPointNotFoundException ex) when (IsMissingDpiApi(ex))
+        {
+            HandleUnsupportedWindowsVersion(ex);
+        }
         catch (Exception ex)
         {
             Log.ErrorDialog(ex, "Game.Run() failed", GAME_RUN_FAILURE);
         }
+    }
+
+    // MonoGame 3.8 P/Invokes GetThreadDpiHostingBehavior unconditionally; the API
+    // was added in Windows 10 1803 (build 17134). Players on older builds crash
+    // inside WinFormsGameForm..ctor with EntryPointNotFoundException naming the
+    // missing entry point and USER32.dll.
+    static bool IsMissingDpiApi(EntryPointNotFoundException ex)
+    {
+        return ex.Message.Contains("GetThreadDpi", StringComparison.OrdinalIgnoreCase)
+            || ex.Message.Contains("USER32", StringComparison.OrdinalIgnoreCase);
+    }
+
+    static void HandleUnsupportedWindowsVersion(EntryPointNotFoundException ex)
+    {
+        const uint MB_OK = 0x0;
+        const uint MB_ICONERROR = 0x10;
+        string message =
+            "StarDrive cannot start because your version of Windows is missing APIs the\n" +
+            "MonoGame 3.8 renderer requires.\n\n" +
+            "Minimum supported Windows version:\n" +
+            "  • Windows 10 version 1803 (April 2018 Update, build 17134) or later\n" +
+            "  • Windows 11 (any build)\n\n" +
+            "How to fix:\n" +
+            "  1. Open Settings -> Windows Update and install all available updates.\n" +
+            "  2. Restart and try launching the game again.\n\n" +
+            "Need help? Join our Discord (link is on the game release page).\n\n" +
+            "Technical details:\n" + ex.Message;
+
+        // Log once so we keep visibility on how many players this affects;
+        // Log.Error has built-in rate limiting so repeat crashes won't flood Sentry.
+        Log.Error($"Unsupported Windows version: {ex.Message}");
+        Win32MessageBox(IntPtr.Zero, message, "StarDrive — Windows version too old", MB_OK | MB_ICONERROR);
+        Environment.Exit(WIN_VERSION_TOO_OLD);
     }
 }

--- a/Ship_Game/GameScreens/Program.cs
+++ b/Ship_Game/GameScreens/Program.cs
@@ -290,8 +290,11 @@ internal static class Program
     // missing entry point and USER32.dll.
     static bool IsMissingDpiApi(EntryPointNotFoundException ex)
     {
+        // AND-match: require both the DPI entry-point name AND the USER32 module
+        // so a future MonoGame upgrade missing some unrelated USER32 helper
+        // doesn't get misclassified as "Windows version too old".
         return ex.Message.Contains("GetThreadDpi", StringComparison.OrdinalIgnoreCase)
-            || ex.Message.Contains("USER32", StringComparison.OrdinalIgnoreCase);
+            && ex.Message.Contains("USER32", StringComparison.OrdinalIgnoreCase);
     }
 
     static void HandleUnsupportedWindowsVersion(EntryPointNotFoundException ex)

--- a/Ship_Game/GameScreens/ScreenMediaPlayer.cs
+++ b/Ship_Game/GameScreens/ScreenMediaPlayer.cs
@@ -339,6 +339,14 @@ namespace Ship_Game.GameScreens
                     // pause video when game screen goes inactive
                     if (screen.IsActive && currentState == MediaState.Paused)
                     {
+                        // Player.Resume() here is MonoGame's VideoPlayer.Resume, NOT our
+                        // public Resume() wrapper's Stop+Play workaround. This is intentional:
+                        // the wedge that the wrapper guards against was a startup-only race
+                        // in BeginPlayTask that left MediaSession in a bad state before any
+                        // normal transitions. The pause/resume cycle from a screen-deactivate
+                        // hits MediaSession in a stable Paused state and Resume works as
+                        // designed, with the bonus of resuming from the paused position
+                        // rather than restarting from t=0.
                         Player.Resume();
                         MuteGameAudioIfRequested();
                     }

--- a/Ship_Game/GameScreens/ScreenMediaPlayer.cs
+++ b/Ship_Game/GameScreens/ScreenMediaPlayer.cs
@@ -43,6 +43,17 @@ namespace Ship_Game.GameScreens
         // If TRUE, the video will always capture low-res video thumbnail
         public bool CaptureThumbnail;
 
+        // If TRUE, NAudio mixer output (music + sound effects) is muted while the video is
+        // actively playing and restored on any pause/stop/dispose/screen-deactivate transition.
+        // Opt-in so callers like DiplomacyScreen (which want their own racial music) are unaffected.
+        public bool MuteGameAudioWhilePlaying;
+        bool GameAudioMuted;
+
+        // Last Player.State observed by Update — needed to detect the Playing→Stopped
+        // transition (natural end-of-stream) without false-firing during the transient
+        // Stopped state right after our Resume()'s Stop+Play sequence.
+        MediaState LastSeenPlayerState = MediaState.Stopped;
+
         // Video play status changed
         public Action OnPlayStatusChange;
 
@@ -74,6 +85,27 @@ namespace Ship_Game.GameScreens
 
         ~ScreenMediaPlayer() { Dispose(false); }
 
+        void MuteGameAudioIfRequested()
+        {
+            if (MuteGameAudioWhilePlaying && !GameAudioMuted)
+            {
+                // Mixer-level mute: silences NAudio output before it reaches the WasapiOut
+                // device, so MediaFoundation video audio (which shares the per-process Windows
+                // audio session but bypasses this mixer) stays audible.
+                GameAudio.MuteMixerOutput();
+                GameAudioMuted = true;
+            }
+        }
+
+        void RestoreGameAudioIfMuted()
+        {
+            if (GameAudioMuted)
+            {
+                GameAudio.RestoreMixerOutput();
+                GameAudioMuted = false;
+            }
+        }
+
         void Dispose(bool disposing)
         {
             IsDisposed = true;
@@ -81,6 +113,7 @@ namespace Ship_Game.GameScreens
             Visible = false;
             OnPlayStatusChange = null;
             Frame = null;
+            RestoreGameAudioIfMuted();
 
             if (ExtraMusic is { IsPlaying: true })
             {
@@ -117,6 +150,11 @@ namespace Ship_Game.GameScreens
             if (IsPlaying || IsDisposed)
                 return; // video has already started
 
+            // Belt-and-suspenders: if a prior call left audio muted (e.g., caller is
+            // re-using this instance and the previous restore path never fired), clear it
+            // now so a new call with MuteGameAudioWhilePlaying=false can't leak the mute.
+            RestoreGameAudioIfMuted();
+
             try
             {
                 Video = ResourceManager.LoadVideo(Content, videoPath);
@@ -138,6 +176,11 @@ namespace Ship_Game.GameScreens
                         {
                             CaptureThumbnail = true;
                             Player.Pause();
+                        }
+                        else
+                        {
+                            // active playback begins immediately when not started paused
+                            MuteGameAudioIfRequested();
                         }
                         PlaybackSuccess = true;
                         OnPlayStatusChange?.Invoke();
@@ -187,6 +230,7 @@ namespace Ship_Game.GameScreens
                 return;
 
             Frame = null;
+            RestoreGameAudioIfMuted();
 
             if (!IsStopped)
             {
@@ -206,12 +250,27 @@ namespace Ship_Game.GameScreens
             if (IsDisposed)
                 return;
 
-            if (IsPaused)
+            // Stop+Play bypasses MediaSession.Resume E_POINTER after startPaused init
+            // (MonoGame 3.8.1.303). Restarts the video from t=0.
+            // Gate on "not currently playing" rather than IsPaused — the Play→Pause race
+            // on the BeginPlayTask worker can leave Player.State as Stopped, not Paused.
+            if (Video != null && Player.State != MediaState.Playing)
             {
-                Player.Resume();
-                OnPlayStatusChange?.Invoke();
+                try
+                {
+                    Player.Stop();
+                    Player.Play(Video);
+                    MuteGameAudioIfRequested();
+                    OnPlayStatusChange?.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning($"ScreenMediaPlayer.Resume Stop+Play failed for '{Name}': {ex.Message}");
+                    PlaybackFailed = true;
+                    RestoreGameAudioIfMuted();
+                }
             }
-            
+
             if (ExtraMusic.IsPaused)
             {
                 ExtraMusic.Resume();
@@ -227,9 +286,10 @@ namespace Ship_Game.GameScreens
             if (IsPlaying)
             {
                 Player.Pause();
+                RestoreGameAudioIfMuted();
                 OnPlayStatusChange?.Invoke();
             }
-            
+
             if (ExtraMusic.IsPlaying)
             {
                 ExtraMusic.Pause();
@@ -271,15 +331,33 @@ namespace Ship_Game.GameScreens
             if (!PlaybackSuccess || IsDisposed || PlaybackFailed)
                 return;
 
+            MediaState currentState = Player.State;
             try
             {
-                if (Video != null && Player.State != MediaState.Stopped)
+                if (Video != null && currentState != MediaState.Stopped)
                 {
                     // pause video when game screen goes inactive
-                    if (screen.IsActive && Player.State == MediaState.Paused)
+                    if (screen.IsActive && currentState == MediaState.Paused)
+                    {
                         Player.Resume();
-                    else if (!screen.IsActive && Player.State == MediaState.Playing)
+                        MuteGameAudioIfRequested();
+                    }
+                    else if (!screen.IsActive && currentState == MediaState.Playing)
+                    {
                         Player.Pause();
+                        RestoreGameAudioIfMuted();
+                    }
+                }
+                else if (Video != null
+                         && LastSeenPlayerState == MediaState.Playing
+                         && currentState == MediaState.Stopped)
+                {
+                    // Playing→Stopped transition = natural end of stream. Reached only when a
+                    // MuteGameAudioWhilePlaying caller also drives Update() (InGameWiki today
+                    // does not — left in place for future opt-in callers like DiplomacyScreen).
+                    // LastSeenPlayerState gate avoids false-firing during the transient Stopped
+                    // state right after Resume()'s Stop+Play sequence.
+                    RestoreGameAudioIfMuted();
                 }
 
                 if (!ExtraMusic.IsStopped)
@@ -299,6 +377,13 @@ namespace Ship_Game.GameScreens
                 // gate further PlayVideo calls on PlaybackFailed.
                 Log.Warning($"ScreenMediaPlayer.Update Pause/Resume failed for '{Name}': {ex.Message}");
                 PlaybackFailed = true;
+                RestoreGameAudioIfMuted();
+            }
+            finally
+            {
+                // Always advance — otherwise a thrown catch leaves LastSeenPlayerState stale
+                // and the next frame may misclassify the Playing→Stopped transition.
+                LastSeenPlayerState = currentState;
             }
         }
 

--- a/Ship_Game/Pirates.cs
+++ b/Ship_Game/Pirates.cs
@@ -914,7 +914,7 @@ namespace Ship_Game
             if (currentAssaultGoals >= maxAssaultGoals || victim.data.TaxRate > 0.8f) 
                 return;
 
-            if (FoundClosestKnownPirateBase(victim, out Ship pirateBase) || Random.RollDice(PirateBaseDetectionChance))
+            if (FoundClosestKnownUntargetedPirateBase(victim, out Ship pirateBase) || Random.RollDice(PirateBaseDetectionChance))
             {
                 Goal goal = new AssaultPirateBase(victim, Owner, pirateBase);
                 victim.AI.AddGoal(goal);
@@ -936,17 +936,28 @@ namespace Ship_Game
                 Owner.Universe.Notifications.AddDestroyedPirateBase(killedShip, reward);
         }
 
-        bool FoundClosestKnownPirateBase(Empire victim, out Ship pirateBase)
+        bool FoundClosestKnownUntargetedPirateBase(Empire victim, out Ship pirateBase)
         {
             pirateBase = null;
-            if (GetBases(out Array<Ship> bases))
+            if (!GetBases(out Array<Ship> bases))
+                return false;
+
+            var potentialClusters = victim.AI.ThreatMatrix.GetPirateBases(Owner);
+            if (potentialClusters.Length == 0)
+                return false;
+
+            Vector2 center = victim.WeightedCenter;
+            var sortedClusters = potentialClusters.Sorted(c => c.Position.SqDist(center));
+            foreach (var cluster in sortedClusters)
             {
-                var potentialClusters = victim.AI.ThreatMatrix.GetPirateBases(Owner);
-                if (potentialClusters.Length > 0)
+                for (int i = 0; i < cluster.Ships.Length; i++)
                 {
-                    var closestCluster = potentialClusters.FindMin(c => c.Position.SqDist(victim.WeightedCenter));
-                    pirateBase = closestCluster.Ships.Find(s => bases.Any(b => b == s));
-                    return pirateBase != null;
+                    Ship ship = cluster.Ships[i];
+                    if (bases.Any(b => b == ship) && !victim.AI.HasAssaultPirateBaseTask(ship, out _))
+                    {
+                        pirateBase = ship;
+                        return true;
+                    }
                 }
             }
 

--- a/Ship_Game/StoryAndEvents/InGameWiki.cs
+++ b/Ship_Game/StoryAndEvents/InGameWiki.cs
@@ -68,6 +68,7 @@ namespace Ship_Game
             Player = new(ContentManager)
             {
                 EnableInteraction = true,
+                MuteGameAudioWhilePlaying = true,
                 OnPlayStatusChange = OnPlayerStatusChanged
             };
 

--- a/Ship_Game/Threading/Parallel.cs
+++ b/Ship_Game/Threading/Parallel.cs
@@ -40,7 +40,15 @@ namespace Ship_Game
         {
             Error = e;
             IsComplete = true;
-            Finished.Set();
+            try
+            {
+                Finished.Set();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Race with Dispose(): a polling caller already observed IsComplete
+                // and disposed us before we got here. Signaling is moot.
+            }
         }
 
         // Wait until task has finished
@@ -101,7 +109,15 @@ namespace Ship_Game
             Error = e;
             Result = value != null ? (T)value : default;
             IsComplete = true;
-            Finished.Set();
+            try
+            {
+                Finished.Set();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Race with Dispose(): a polling caller already observed IsComplete
+                // and disposed us before we got here. Signaling is moot.
+            }
         }
 
         // Wait until task has finished

--- a/Ship_Game/Universe/SolarBodies/SolarsystemOverlay.cs
+++ b/Ship_Game/Universe/SolarBodies/SolarsystemOverlay.cs
@@ -39,7 +39,7 @@ namespace Ship_Game
             if (BackdropTex != null && !BackdropTex.IsDisposed)
                 return BackdropTex;
             const int Size = 128;
-            var pixels = new Microsoft.Xna.Framework.Color[Size * Size];
+            var pixels = new Color[Size * Size];
             float center = (Size - 1) * 0.5f;
             float radius = Size * 0.5f;
             for (int y = 0; y < Size; y++)
@@ -50,7 +50,7 @@ namespace Ship_Game
                     float d = (float)Math.Sqrt(dx * dx + dy * dy);
                     float a = Math.Clamp(radius - d, 0f, 1f); // 1px AA edge
                     byte b = (byte)(a * 255f);
-                    pixels[y * Size + x] = new Microsoft.Xna.Framework.Color(b, b, b, b);
+                    pixels[y * Size + x] = new Color(b, b, b, b);
                 }
             }
             var tex = new Texture2D(device, Size, Size);
@@ -84,10 +84,13 @@ namespace Ship_Game
             double pRadius = insetRadialSS.Distance(pPos).LowerBound(5);
 
             // Backdrop: dim background star systems so they don't visually
-            // compete with the orbital overlay. Sized to the outermost orbit
-            // (40 + 40*i) plus a small pad for planet icons.
+            // compete with the orbital overlay. Sized to cover the bracket
+            // (pRadius) plus the outermost orbit ring (40 + 40*i) plus a small
+            // icon pad, whichever is larger. Falls back to bracket-only for
+            // unexplored systems where planet count is unknown.
             int planetCount = Sys.IsExploredBy(player) ? Sys.PlanetList.Count : 0;
-            float backdropRadius = 40f + 40f * planetCount + 20f;
+            float orbitRadius = 40f + 40f * planetCount + 20f;
+            float backdropRadius = Math.Max(orbitRadius, (float)pRadius + 12f);
             float fadeIn = Math.Clamp(SelectionTimer / 0.4f, 0f, 1f);
             byte backdropAlpha = (byte)(200f * fadeIn);
             if (backdropAlpha > 0)

--- a/Ship_Game/Universe/SolarBodies/SolarsystemOverlay.cs
+++ b/Ship_Game/Universe/SolarBodies/SolarsystemOverlay.cs
@@ -29,6 +29,36 @@ namespace Ship_Game
 
         Planet CurrentlyHoveredPlanet;
 
+        static Texture2D BackdropTex;
+
+        // Procedural anti-aliased filled-circle alpha texture, cached once.
+        // Drawn black-tinted under the orbital diagram so background star
+        // systems don't bleed through the overlay.
+        static Texture2D GetBackdropTexture(GraphicsDevice device)
+        {
+            if (BackdropTex != null && !BackdropTex.IsDisposed)
+                return BackdropTex;
+            const int Size = 128;
+            var pixels = new Microsoft.Xna.Framework.Color[Size * Size];
+            float center = (Size - 1) * 0.5f;
+            float radius = Size * 0.5f;
+            for (int y = 0; y < Size; y++)
+            {
+                for (int x = 0; x < Size; x++)
+                {
+                    float dx = x - center, dy = y - center;
+                    float d = (float)Math.Sqrt(dx * dx + dy * dy);
+                    float a = Math.Clamp(radius - d, 0f, 1f); // 1px AA edge
+                    byte b = (byte)(a * 255f);
+                    pixels[y * Size + x] = new Microsoft.Xna.Framework.Color(b, b, b, b);
+                }
+            }
+            var tex = new Texture2D(device, Size, Size);
+            tex.SetData(pixels);
+            BackdropTex = tex;
+            return tex;
+        }
+
         public SolarsystemOverlay(Rectangle r, ScreenManager sm, UniverseScreen universe)
         {
             Universe = universe;
@@ -52,6 +82,22 @@ namespace Ship_Game
             Vector2 radialPos = new(Sys.Position.X + 4500f, Sys.Position.Y);
             Vector2d insetRadialSS = Universe.ProjectToScreenPosition(radialPos.ToVec3());
             double pRadius = insetRadialSS.Distance(pPos).LowerBound(5);
+
+            // Backdrop: dim background star systems so they don't visually
+            // compete with the orbital overlay. Sized to the outermost orbit
+            // (40 + 40*i) plus a small pad for planet icons.
+            int planetCount = Sys.IsExploredBy(player) ? Sys.PlanetList.Count : 0;
+            float backdropRadius = 40f + 40f * planetCount + 20f;
+            float fadeIn = Math.Clamp(SelectionTimer / 0.4f, 0f, 1f);
+            byte backdropAlpha = (byte)(200f * fadeIn);
+            if (backdropAlpha > 0)
+            {
+                var backdrop = GetBackdropTexture(batch.GraphicsDevice);
+                var backdropRect = new RectF(
+                    (float)pPos.X - backdropRadius, (float)pPos.Y - backdropRadius,
+                    backdropRadius * 2f, backdropRadius * 2f);
+                batch.Draw(backdrop, backdropRect, new Color((byte)0, (byte)0, (byte)0, backdropAlpha));
+            }
 
             batch.BracketRectangle(pPos, pRadius, Color.White);
 

--- a/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
+++ b/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
@@ -275,7 +275,11 @@ namespace Ship_Game.Universe
                 return;
 
             Vector2 corrected = HelperFunctions.GetCorrectedMovePosWithAudio(fleet.Ships, enemyShips, movePosition);
-            fleet.MoveTo(corrected, facingDir, GetMoveOrderType());
+            // ForceReassembly so AssembleFleet rotates every ship's FleetOffset to the
+            // new facingDir even for ships already moving; without it, AssembleFleet
+            // only touches AwaitingOrders ships and the fleet keeps its old formation
+            // orientation after a right-drag rotate.
+            fleet.MoveTo(corrected, facingDir, GetMoveOrderType() | AI.MoveOrder.ForceReassembly);
         }
 
         void ResetShipsTargetAndPriorityOrders(Ship ship)

--- a/Ship_Game/Universe/UniverseScreen/UniverseObjectManager.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseObjectManager.cs
@@ -519,25 +519,24 @@ namespace Ship_Game
             Projectile[] projs = Empty<Projectile>.Array;
             Beam[] beams = Empty<Beam>.Array;
 
-            // No cap on visibility queries: the spatial system used to return at most
-            // 1024 ships / 2048 projs / 2048 beams per visible-rect query, which was
-            // fine for old battle sizes but Combined Arms megabattles routinely
-            // exceed 1024 ships in frame. Capped queries drop the far ones, flag
-            // them InFrustum=false even when they're geometrically on screen, and
-            // their SOs flip to Visibility.None — players see ships intermittently
-            // disappear while their projectiles keep firing. 32768 here just
-            // means "return whatever's actually in the rect"; the qtree walk cost
-            // is bounded by rect size, not by this number.
+            // Visible-rect query caps raised from 1024 ships / 2048 projs / 2048
+            // beams to 8192 each. The old caps were fine for vanilla battles but
+            // megabattles (Combined Arms) routinely exceed 1024 ships in frame —
+            // capped queries dropped the far ones, flagged them InFrustum=false
+            // even when geometrically on screen, and their SOs flipped to
+            // Visibility.None. Players saw ships intermittently disappear while
+            // their projectiles kept firing. 8192 covers any realistic battle;
+            // the qtree walk cost is bounded by rect size, not by this number.
             if (UState.IsPlanetViewOrCloser)
             {
-                projs = Spatial.FindNearby(GameObjectType.Proj, visibleWorld, 32768)
+                projs = Spatial.FindNearby(GameObjectType.Proj, visibleWorld, 8192)
                                .FastCast<SpatialObjectBase, Projectile>();
 
-                beams = Spatial.FindNearby(GameObjectType.Beam, visibleWorld, 32768)
+                beams = Spatial.FindNearby(GameObjectType.Beam, visibleWorld, 8192)
                                .FastCast<SpatialObjectBase, Beam>();
             }
 
-            Ship[] ships = Spatial.FindNearby(GameObjectType.Ship, visibleWorld, 32768)
+            Ship[] ships = Spatial.FindNearby(GameObjectType.Ship, visibleWorld, 8192)
                                   .FastCast<SpatialObjectBase, Ship>();
 
             // Reset frustum value for ship visible in previous frame

--- a/Ship_Game/Universe/UniverseScreen/UniverseObjectManager.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseObjectManager.cs
@@ -519,16 +519,25 @@ namespace Ship_Game
             Projectile[] projs = Empty<Projectile>.Array;
             Beam[] beams = Empty<Beam>.Array;
 
+            // No cap on visibility queries: the spatial system used to return at most
+            // 1024 ships / 2048 projs / 2048 beams per visible-rect query, which was
+            // fine for old battle sizes but Combined Arms megabattles routinely
+            // exceed 1024 ships in frame. Capped queries drop the far ones, flag
+            // them InFrustum=false even when they're geometrically on screen, and
+            // their SOs flip to Visibility.None — players see ships intermittently
+            // disappear while their projectiles keep firing. 32768 here just
+            // means "return whatever's actually in the rect"; the qtree walk cost
+            // is bounded by rect size, not by this number.
             if (UState.IsPlanetViewOrCloser)
             {
-                projs = Spatial.FindNearby(GameObjectType.Proj, visibleWorld, 2048)
+                projs = Spatial.FindNearby(GameObjectType.Proj, visibleWorld, 32768)
                                .FastCast<SpatialObjectBase, Projectile>();
 
-                beams = Spatial.FindNearby(GameObjectType.Beam, visibleWorld, 2048)
+                beams = Spatial.FindNearby(GameObjectType.Beam, visibleWorld, 32768)
                                .FastCast<SpatialObjectBase, Beam>();
             }
 
-            Ship[] ships = Spatial.FindNearby(GameObjectType.Ship, visibleWorld, 1024)
+            Ship[] ships = Spatial.FindNearby(GameObjectType.Ship, visibleWorld, 32768)
                                   .FastCast<SpatialObjectBase, Ship>();
 
             // Reset frustum value for ship visible in previous frame

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.HandleInput.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.HandleInput.cs
@@ -520,42 +520,36 @@ namespace Ship_Game
             // The old spatial-search approach built the world click rect by unprojecting the
             // cursor pixel ± a screen-pixel radius. On epic maps Unproject diverges from Project
             // by ~17 pixels / ~500 world units (float matrix invert amplifies error after
-            // perspective division), so the rect is offset from the ship's actual position and
-            // the spatial search returns 0 even when the cursor is visually on the icon.
+            // perspective division), so the rect was offset from the ship's actual position and
+            // the spatial search returned 0 even when the cursor was visually on the icon.
             // We instead project each candidate ship forward to screen and compare in pixel
-            // space — Project alone is fine, only the invert step loses precision. Cheap
-            // world-distance prefilter keeps 5000-ship epic maps well under a millisecond.
+            // space — Project alone is fine, only the invert step loses precision.
             //
             // Per-ship click radius: take whichever is larger — the ship's actual on-screen
             // radius (close zoom: many pixels) or the icon-mode floor (far zoom: ~12 px).
             // Without this the click box is fixed at 12 px and you can only select close-up
             // ships by clicking near their geometric center.
+            //
+            // No prefilter: iterating 5000 ships with a Vector2 distance check is sub-
+            // millisecond and avoids the same Unproject-precision trap on cursor→world.
+            // Also no InFrustum gate: a Project per candidate already validates on-screen
+            // position, and InFrustum can be momentarily stale in the camera-move window
+            // before UpdateVisibleObjects re-runs.
             float iconHalfPx = (16f + GlobalStats.IconSize) * 0.5f;
             const float MarginPx = 4f;
             float iconClickRadiusPx = iconHalfPx + MarginPx;
 
             Vector2 cursor = input.CursorPosition;
-            Vector2 cursorWorld = UnprojectToWorldPosition(cursor);
-            // Loose world-radius prefilter. At close zoom UnprojectToWorldSize(iconClick*4)
-            // is small but the largest ship's world radius dwarfs it — pad by a safe upper
-            // bound so we don't filter out a capital ship the cursor is on top of. Not a
-            // true cap; a future modded 5000-radius ship would silently lose clicks at
-            // extreme zoom — increase or derive from UState if that happens.
-            const float PrefilterPadWorldRadius = 4_000f;
-            float prefilterWorldRadius = UnprojectToWorldSize(iconClickRadiusPx * 4f)
-                                       + PrefilterPadWorldRadius;
-            float prefilterWorldRadiusSq = prefilterWorldRadius * prefilterWorldRadius;
-
             Ship best = null;
             float bestDistPx = float.MaxValue;
 
-            foreach (Ship ship in UState.Ships)
+            Ship[] ships = UState.Ships;
+            for (int i = 0; i < ships.Length; i++)
             {
-                if (!ship.Active || !ship.InFrustum || !ship.InPlayerSensorRange)
+                Ship ship = ships[i];
+                if (!ship.Active || !ship.InPlayerSensorRange)
                     continue;
                 if (ship.IsSubspaceProjector && CamPos.Z > 1_200_000.0)
-                    continue;
-                if (ship.Position.SqDist(cursorWorld) > prefilterWorldRadiusSq)
                     continue;
 
                 ProjectToScreenCoords(ship.Position, ship.Radius,

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.HandleInput.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.HandleInput.cs
@@ -516,23 +516,59 @@ namespace Ship_Game
 
         Ship FindClickedShip(InputState input)
         {
-            const float ClickRadius = 5f;
-            AABoundingBox2D clickRect = UnprojectToWorldRect(new(input.CursorPosition, ClickRadius));
-            SearchOptions opt = new(clickRect, GameObjectType.Ship)
+            // Workaround for #254 (Matrix.Invert precision loss at CamPos.Z in the millions).
+            // The old spatial-search approach built the world click rect by unprojecting the
+            // cursor pixel ± a screen-pixel radius. On epic maps Unproject diverges from Project
+            // by ~17 pixels / ~500 world units (float matrix invert amplifies error after
+            // perspective division), so the rect is offset from the ship's actual position and
+            // the spatial search returns 0 even when the cursor is visually on the icon.
+            // We instead project each candidate ship forward to screen and compare in pixel
+            // space — Project alone is fine, only the invert step loses precision. Cheap
+            // world-distance prefilter keeps 5000-ship epic maps well under a millisecond.
+            float iconHalfPx = (16f + GlobalStats.IconSize) * 0.5f;
+            const float MarginPx = 4f;
+            float clickRadiusPx = iconHalfPx + MarginPx;
+
+            Vector2 cursor = input.CursorPosition;
+            Vector2 cursorWorld = UnprojectToWorldPosition(cursor);
+            // Generous world-radius prefilter: 4x the screen click radius unprojected. Loose
+            // enough to absorb perspective skew at screen edges, tight enough to drop the
+            // overwhelming majority of off-screen ships before we project anything.
+            float prefilterWorldRadius = UnprojectToWorldSize(clickRadiusPx * 4f);
+            float prefilterWorldRadiusSq = prefilterWorldRadius * prefilterWorldRadius;
+
+            Ship best = null;
+            float bestDistPx = clickRadiusPx;
+
+            foreach (Ship ship in UState.Ships)
             {
-                MaxResults = 32,
-                SortByDistance = true, // only care about closest results
-                FilterFunction = CanClickOnShip
-            };
-            return UState.Spatial.FindNearby(ref opt).FirstOrDefault() as Ship;
+                if (!ship.Active || !ship.InFrustum || !ship.InPlayerSensorRange)
+                    continue;
+                if (ship.IsSubspaceProjector && CamPos.Z > 1_200_000.0)
+                    continue;
+                if (ship.Position.SqDist(cursorWorld) > prefilterWorldRadiusSq)
+                    continue;
+
+                Vector2 shipScreen = ProjectToScreenPosition(ship.Position).ToVec2f();
+                float distPx = cursor.Distance(shipScreen);
+                if (distPx <= bestDistPx)
+                {
+                    best = ship;
+                    bestDistPx = distPx;
+                }
+            }
+            return best;
         }
 
         Planet FindPlanetUnderCursor()
         {
-            // because the visible size of the planet icon changes depending on the zoom level
-            // simply figure out a pixel based search radius
-            float searchRadius = UnprojectToWorldSize(sizeOnScreen: 16) - 500;
-            searchRadius = searchRadius.LowerBound(100);
+            // Mitigates #254 on the planet click path: a wider screen-pixel radius gives more
+            // forgiveness against the same Unproject precision drift that affected ships.
+            // Was: UnprojectToWorldSize(16) - 500, which subtracted a magic number that did
+            // nothing useful at large world coords (where the value is huge) and over-trimmed
+            // at small ones (forcing the LowerBound floor). Removed the subtraction and
+            // widened the source pixel size for click forgiveness on large maps.
+            float searchRadius = UnprojectToWorldSize(sizeOnScreen: 24).LowerBound(100);
 
             Vector3d worldPos = UnprojectToWorldPosition3D(Input.CursorPosition, ZPlane: 2500);
             Planet p = UState.FindPlanetAt(worldPos.ToVec2f(), searchRadius: searchRadius);
@@ -547,8 +583,17 @@ namespace Ship_Game
             float maxZ = 2_500_000f;
             float relZ = MathExt.LerpInverse((float)CamPos.Z, minZ, maxZ).Clamped(0, 1);
 
-            // and then convert the relative Z to a solar hit radius
+            // convert the relative Z to a solar hit radius
             float hitRadius = 5_000f.LerpTo(50_000f, relZ);
+
+            // Mitigates #254 on the sun click path. Large maps allow MaxCamHeight up to
+            // CAM_MAX (15M), well past maxZ. Without continued scaling the sun icon visually
+            // grows but the hit radius stops at 50_000, so clicks on the icon's edge miss.
+            // Scale linearly with CamPos.Z above maxZ to keep the hit zone in step with the
+            // icon size and absorb the Unproject precision drift at extreme zoom.
+            if (CamPos.Z > maxZ)
+                hitRadius *= (float)(CamPos.Z / maxZ);
+
             return UState.FindSolarSystemAt(CursorWorldPosition2D, hitRadius: hitRadius);
         }
 

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.HandleInput.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.HandleInput.cs
@@ -525,20 +525,29 @@ namespace Ship_Game
             // We instead project each candidate ship forward to screen and compare in pixel
             // space — Project alone is fine, only the invert step loses precision. Cheap
             // world-distance prefilter keeps 5000-ship epic maps well under a millisecond.
+            //
+            // Per-ship click radius: take whichever is larger — the ship's actual on-screen
+            // radius (close zoom: many pixels) or the icon-mode floor (far zoom: ~12 px).
+            // Without this the click box is fixed at 12 px and you can only select close-up
+            // ships by clicking near their geometric center.
             float iconHalfPx = (16f + GlobalStats.IconSize) * 0.5f;
             const float MarginPx = 4f;
-            float clickRadiusPx = iconHalfPx + MarginPx;
+            float iconClickRadiusPx = iconHalfPx + MarginPx;
 
             Vector2 cursor = input.CursorPosition;
             Vector2 cursorWorld = UnprojectToWorldPosition(cursor);
-            // Generous world-radius prefilter: 4x the screen click radius unprojected. Loose
-            // enough to absorb perspective skew at screen edges, tight enough to drop the
-            // overwhelming majority of off-screen ships before we project anything.
-            float prefilterWorldRadius = UnprojectToWorldSize(clickRadiusPx * 4f);
+            // Loose world-radius prefilter. At close zoom UnprojectToWorldSize(iconClick*4)
+            // is small but the largest ship's world radius dwarfs it — pad by a safe upper
+            // bound so we don't filter out a capital ship the cursor is on top of. Not a
+            // true cap; a future modded 5000-radius ship would silently lose clicks at
+            // extreme zoom — increase or derive from UState if that happens.
+            const float PrefilterPadWorldRadius = 4_000f;
+            float prefilterWorldRadius = UnprojectToWorldSize(iconClickRadiusPx * 4f)
+                                       + PrefilterPadWorldRadius;
             float prefilterWorldRadiusSq = prefilterWorldRadius * prefilterWorldRadius;
 
             Ship best = null;
-            float bestDistPx = clickRadiusPx;
+            float bestDistPx = float.MaxValue;
 
             foreach (Ship ship in UState.Ships)
             {
@@ -549,9 +558,11 @@ namespace Ship_Game
                 if (ship.Position.SqDist(cursorWorld) > prefilterWorldRadiusSq)
                     continue;
 
-                Vector2 shipScreen = ProjectToScreenPosition(ship.Position).ToVec2f();
-                float distPx = cursor.Distance(shipScreen);
-                if (distPx <= bestDistPx)
+                ProjectToScreenCoords(ship.Position, ship.Radius,
+                                      out Vector2d shipScreen, out double shipScreenRadius);
+                float threshold = Math.Max(iconClickRadiusPx, (float)shipScreenRadius + MarginPx);
+                float distPx = cursor.Distance(shipScreen.ToVec2f());
+                if (distPx <= threshold && distPx < bestDistPx)
                 {
                     best = ship;
                     bestDistPx = distPx;


### PR DESCRIPTION
## Summary

13 Jupiter 1.60 follow-up fixes spanning rendering, AI behavior, crash hardening, and Sentry noise reduction. No save-format changes; safe to backport.

## Rendering & UI

- **Ship visibility flicker in megabattles** (#issue-if-any) — In ~200+ ship battles, enemy ships intermittently disappeared while their projectiles kept firing. Two stacked spatial caps were dropping ships from the visibility sets:
  - `UniverseObjectManager.UpdateVisibleObjects` capped the visible-rect query at 1024 ships → ships past the cap got `InFrustum=false` despite being on screen → SceneObject flipped to `Visibility.None`. Raised to **8192**.
  - `ShipAI.Combat.ScanForEnemies` capped at 64 → enemies past the cap missed their `SetSeen` call, `KnownContactTimer` (1.0s) expired → `InPlayerSensorRange=false`. Raised to **512**, with new `MaxScannedTargets=128` bound on `PotentialTargets` so AI combat target lists stay tractable.
- **`SolarsystemOverlay` backdrop disc** — The galaxy-view system overlay drew orbital rings and planet icons directly on the starfield; background systems bled through and competed visually. Added a procedural anti-aliased black circle (alpha ~0.78) drawn behind the diagram, fading in over the existing 0.4s selection animation.
- **`FindClickedShip` precision on epic maps** — Workaround for #254 (`Matrix.Invert(ViewProjection)` loses ~17px of precision at `CamPos.Z` in the millions). `FindClickedShip` now iterates `UState.Ships` with a screen-space `ProjectToScreenCoords` per candidate instead of trusting `UnprojectToWorldPosition` on the cursor. Sub-millisecond at 5000 ships.
- **`FindClickedShip` per-ship click threshold** — Follow-up so close-zoom clicks don't require pinpoint-center accuracy on large ships. Threshold is `max(iconClickRadiusPx, ProjectToScreenCoords(ship.Radius) + margin)`.

## Game logic

- **Fleet right-drag rotation regression** — Player right-drag rotation showed the preview but ships kept their old formation orientation. `MoveFleetToLocation` now passes `MoveOrder.ForceReassembly` so `AssembleFleet` rotates every ship's `FleetOffset`, not just ships in `AwaitingOrders`. Ad-hoc multi-ship groups already did this; fleets were the regression introduced in Mars 1.51.
- **Pirate AI assault diversification** — `Pirates.ExecuteVictimRetaliation` kept re-targeting the same closest pirate base every tick (creating duplicate `MilitaryTask`s that `HasAssaultPirateBaseTask` then cleaned up with a warning). Renamed and rewrote `FoundClosestKnownUntargetedPirateBase` to walk clusters closest-to-farthest, skipping bases that already have an assault task. AI now spreads `maxAssaultGoals` across distinct bases.

## Crash hardening & Sentry noise

- **MonoGame 3.8 DPI crash on old Windows** — Players on Windows 10 < build 17134 (April 2018 Update) crashed inside `WinFormsGameForm..ctor` with an opaque `EntryPointNotFoundException` for `GetThreadDpiHostingBehavior` in `USER32.dll`. Catch the specific exception in `Program.Main` and show a friendly MessageBox naming the minimum supported Windows version. Also documented the OS requirement in `README.md` under a new System Requirements section.
- **`TaskResult.SetResult` Dispose race** — `GameLoadingScreen` polls `LoadResult.WaitNoThrow(1)` per frame, observes `IsComplete`, and disposes the result. The worker thread is still finishing `SetResult` and calls `Finished.Set()` on a now-disposed `SafeWaitHandle` → `ObjectDisposedException`. Caught in both `TaskResult` and `TaskResult<T>` since the caller has already moved on; signaling is moot.
- **Tutorial-video `MediaSession` E_POINTER** — `Player.Resume()` after worker-thread state churn wedged `MediaSession`. Replaced with `Stop()+Play(Video)` (restarts from t=0) and loosened the gating to `Player.State != Playing`. Also added music+SFX mute around wiki video playback (`GameAudio.MuteMixerOutput`) so video audio isn't lost in the mix.
- **`FleetRequisition` Sentry noise** — `Log.Error` when fleet was disbanded mid-build was logging a normal lifecycle event to Sentry (the goal was already returning `GoalComplete` gracefully). Demoted to silent.
- **`SpaceRoadsManager` projector bridge** — Outer `InfluenceNodeExistsAt(ship.Position)` guard didn't match the actual offset-from-system-center bridge build position. Added `ProjectorAlreadyAtBridgeTarget` helper that checks `Owner.FindProjectorAt(plannedBuildPos, 100)` against the real `ProjectorBridge.GetBridgeBuildPosition`.
- **`RespondPlayerStoleColony` self-war** — Switch arms passed `player` instead of `this` to `PrepareForWar`, triggering "Called prepare for war vs. ourselves". One-character fix in `Empire_Relationship.cs`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
