### PR TITLE
Jupiter 1.60/fixes 07

### DIFF
--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -4523,10 +4523,6 @@ namespace Ship_Game
         DesignIssueConstructorCostProblem = 4447,
         /// <summary>Add Storage or lower the amount</summary>
         DesignIssueConstructorCostRemidiation = 4448,
-        /// <summary>Spiral Galaxy</summary>
-        SpiralGalaxyGame = 4526,
-        /// <summary>Each empire starts at a random place along the arms of a Spiral Galaxy</summary>
-        SpiralGalaxyGameTip = 4527,
         /// <summary>Processing Per Trun</summary>
         RefinningPerTurnStat = 4449,
         /// <summary>Most Exotic resources are processed at</summary>
@@ -4681,9 +4677,18 @@ namespace Ship_Game
         DisableScreenPanningOption = 4524,
         /// <summary>Mouse pointer cannot be used for edge screen movement</summary>
         DisableScreenPanningOptionTip = 4525,
-
-
-
+        /// <summary>2-Arm Spiral Galaxy</summary>
+        SpiralTwoArmGalaxyGame = 4526,
+        /// <summary>Each empire starts at a random place along the arms of a classic 2-arm grand-design spiral galaxy</summary>
+        SpiralTwoArmGalaxyGameTip = 4527,
+        /// <summary>4-Arm Spiral Galaxy</summary>
+        SpiralFourArmGalaxyGame = 4528,
+        /// <summary>Each empire starts at a random place along the arms of a 4-arm spiral galaxy</summary>
+        SpiralFourArmGalaxyGameTip = 4529,
+        /// <summary>Barred Spiral Galaxy</summary>
+        SpiralBarredGalaxyGame = 4530,
+        /// <summary>Each empire starts at a random place along the arms of a barred spiral galaxy</summary>
+        SpiralBarredGalaxyGameTip = 4531,
 
 
 

--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -4691,7 +4691,7 @@ namespace Ship_Game
         SpiralBarredGalaxyGameTip = 4531,
         /// <summary>Magellanic Spiral Galaxy</summary>
         SpiralMagellanicGalaxyGame = 4532,
-        /// <summary>Each empire starts in a single fat asymmetric arm wrapped around an off-center bulge</summary>
+        /// <summary>Most empires start in the off-center bulge; the rest along the single asymmetric arm</summary>
         SpiralMagellanicGalaxyGameTip = 4533,
 
 

--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -4689,6 +4689,10 @@ namespace Ship_Game
         SpiralBarredGalaxyGame = 4530,
         /// <summary>Each empire starts at a random place along the arms of a barred spiral galaxy</summary>
         SpiralBarredGalaxyGameTip = 4531,
+        /// <summary>Magellanic Spiral Galaxy</summary>
+        SpiralMagellanicGalaxyGame = 4532,
+        /// <summary>Each empire starts in a single fat asymmetric arm wrapped around an off-center bulge</summary>
+        SpiralMagellanicGalaxyGameTip = 4533,
 
 
 

--- a/Ship_Game/GameScreens/NewGame/CreatingNewGameScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/CreatingNewGameScreen.cs
@@ -33,8 +33,7 @@ namespace Ship_Game
 
         public override void LoadContent()
         {
-            //Log.LogEventStats(Log.GameEvent.NewGame, P);
-
+            Log.LogEventStats(Log.GameEvent.NewGame, P);
             ScreenManager.ClearScene();
             LoadingScreenTexture = ResourceManager.LoadRandomLoadingScreen(Generator.Random, TransientContent);
             AdviceText = Fonts.Arial12Bold.ParseText(ResourceManager.LoadRandomAdvice(Generator.Random), 500f);

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
@@ -135,8 +135,14 @@ namespace Ship_Game
             TraitsList = Traits.List;
             TraitsList.EnableItemHighlight = true;
             TraitsList.OnClick = OnTraitsListItemClicked;
-            RectF traitsListBg = new(traitsList.X+60, traitsList.Y+90, traitsList.W, traitsList.H);
-            TraitsList.SetBackground(new Menu1(traitsListBg));
+            RectF traitsListBg = new(traitsList.X, traitsList.Y, traitsList.W, traitsList.H);
+            var traitsBg = new Menu1(traitsListBg);
+            TraitsList.SetBackground(traitsBg);
+            // Anchor at abs pos: SetBackground sets a wrong-sign LocalPos that
+            // would re-position the Menu1 on the next PerformLayout (triggered by
+            // SetItems when a trait tab is clicked). Pinning here makes
+            // UpdatePosAndSize no-op so the bg stays put.
+            traitsBg.SetAbsPos(traitsListBg.X, traitsListBg.Y);
 
             RectF chooseRace = new(5, (int)traitsList.Y, (int)traitsList.X - 10, (int)traitsList.H);
             ChooseRaceList = Add(new ScrollList<RaceArchetypeListItem>(chooseRace, 135));

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
@@ -234,12 +234,12 @@ namespace Ship_Game
                 .SetLocalPos(ChooseRaceList.Width / 2 - 10, ChooseRaceList.Height + containerMarginBottom);
 
             var pos = new Vector2(ScreenWidth / 2 - 84, traitsList.Y + traitsList.H + 10);
-            Traits.ButtonMedium(pos.X - 142, pos.Y, "Load Setup", OnLoadSetupClicked)
-                .SetLocalPos(Traits.Width / 2 + 98, Traits.Height + containerMarginBottom*3);
-            Traits.ButtonMedium(pos.X + 178, pos.Y, "Save Setup", OnSaveSetupClicked)
-                .SetLocalPos(Traits.Width / 2 - 200, Traits.Height + containerMarginBottom*3);
-            Traits.Button(ButtonStyle.MediumMenu, GameText.RuleOptions, click: OnRuleOptionsClicked)
-                .SetLocalPos(Traits.Width / 2 - 52, Traits.Height + containerMarginBottom*3);
+            Traits.ButtonBigDip(pos.X - 142, pos.Y, "Load Setup", OnLoadSetupClicked)
+                .SetLocalPos(Traits.Width / 2 + 94, Traits.Height + containerMarginBottom*3);
+            Traits.ButtonBigDip(pos.X + 178, pos.Y, "Save Setup", OnSaveSetupClicked)
+                .SetLocalPos(Traits.Width / 2 - 262, Traits.Height + containerMarginBottom*3);
+            Traits.Button(ButtonStyle.Default, GameText.RuleOptions, click: OnRuleOptionsClicked)
+                .SetLocalPos(Traits.Width / 2 - 84, Traits.Height + containerMarginBottom*3);
 
             ChooseRaceList.SlideInFromOffset(offset:new(-ChooseRaceList.Width, 0), TransitionOnTime);
             DescriptionTextList.SlideInFromOffset(offset:new(DescriptionTextList.Width, 0), TransitionOnTime);

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
@@ -411,8 +411,10 @@ namespace Ship_Game
                 case GameMode.Corners:       return GameText.Corners;
                 case GameMode.BigClusters:   return GameText.BigClustersGame;
                 case GameMode.SmallClusters: return GameText.SmallClustersGame;
-                case GameMode.Ring:          return GameText.RingGalaxyGame;
-                case GameMode.Spiral:        return GameText.SpiralGalaxyGame;
+                case GameMode.Ring:           return GameText.RingGalaxyGame;
+                case GameMode.SpiralTwoArm:   return GameText.SpiralTwoArmGalaxyGame;
+                case GameMode.SpiralFourArm:  return GameText.SpiralFourArmGalaxyGame;
+                case GameMode.SpiralBarred:   return GameText.SpiralBarredGalaxyGame;
             }
         }
 
@@ -421,14 +423,16 @@ namespace Ship_Game
             switch (P.Mode)
             {
                 default:
-                case GameMode.Random:        return GameText.InRandomGameMode;
-                case GameMode.Sandbox:       return GameText.InTheSandboxGameMode;
-                case GameMode.Elimination:   return GameText.InTheCapitalEliminationGame;
-                case GameMode.Corners:       return GameText.CornersIsARaceMatch;
-                case GameMode.BigClusters:   return GameText.EachEmpireStartsInA;
-                case GameMode.SmallClusters: return GameText.TheGalaxyWillBeConsisted;
-                case GameMode.Ring:          return GameText.RingGalaxyGameTip;
-                case GameMode.Spiral:        return GameText.SpiralGalaxyGameTip;
+                case GameMode.Random:         return GameText.InRandomGameMode;
+                case GameMode.Sandbox:        return GameText.InTheSandboxGameMode;
+                case GameMode.Elimination:    return GameText.InTheCapitalEliminationGame;
+                case GameMode.Corners:        return GameText.CornersIsARaceMatch;
+                case GameMode.BigClusters:    return GameText.EachEmpireStartsInA;
+                case GameMode.SmallClusters:  return GameText.TheGalaxyWillBeConsisted;
+                case GameMode.Ring:           return GameText.RingGalaxyGameTip;
+                case GameMode.SpiralTwoArm:   return GameText.SpiralTwoArmGalaxyGameTip;
+                case GameMode.SpiralFourArm:  return GameText.SpiralFourArmGalaxyGameTip;
+                case GameMode.SpiralBarred:   return GameText.SpiralBarredGalaxyGameTip;
             }
         }
 
@@ -704,7 +708,7 @@ namespace Ship_Game
         
         public enum GameMode
         {
-            Sandbox, Spiral, Random, Ring, SmallClusters, BigClusters, Elimination, Corners
+            Sandbox, SpiralTwoArm, SpiralFourArm, SpiralBarred, Random, Ring, SmallClusters, BigClusters, Elimination, Corners
         }
 
         public enum StarsAbundance

--- a/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
+++ b/Ship_Game/GameScreens/NewGame/RaceDesignScreen.cs
@@ -412,9 +412,10 @@ namespace Ship_Game
                 case GameMode.BigClusters:   return GameText.BigClustersGame;
                 case GameMode.SmallClusters: return GameText.SmallClustersGame;
                 case GameMode.Ring:           return GameText.RingGalaxyGame;
-                case GameMode.SpiralTwoArm:   return GameText.SpiralTwoArmGalaxyGame;
-                case GameMode.SpiralFourArm:  return GameText.SpiralFourArmGalaxyGame;
-                case GameMode.SpiralBarred:   return GameText.SpiralBarredGalaxyGame;
+                case GameMode.SpiralTwoArm:     return GameText.SpiralTwoArmGalaxyGame;
+                case GameMode.SpiralFourArm:    return GameText.SpiralFourArmGalaxyGame;
+                case GameMode.SpiralBarred:     return GameText.SpiralBarredGalaxyGame;
+                case GameMode.SpiralMagellanic: return GameText.SpiralMagellanicGalaxyGame;
             }
         }
 
@@ -430,9 +431,10 @@ namespace Ship_Game
                 case GameMode.BigClusters:    return GameText.EachEmpireStartsInA;
                 case GameMode.SmallClusters:  return GameText.TheGalaxyWillBeConsisted;
                 case GameMode.Ring:           return GameText.RingGalaxyGameTip;
-                case GameMode.SpiralTwoArm:   return GameText.SpiralTwoArmGalaxyGameTip;
-                case GameMode.SpiralFourArm:  return GameText.SpiralFourArmGalaxyGameTip;
-                case GameMode.SpiralBarred:   return GameText.SpiralBarredGalaxyGameTip;
+                case GameMode.SpiralTwoArm:     return GameText.SpiralTwoArmGalaxyGameTip;
+                case GameMode.SpiralFourArm:    return GameText.SpiralFourArmGalaxyGameTip;
+                case GameMode.SpiralBarred:     return GameText.SpiralBarredGalaxyGameTip;
+                case GameMode.SpiralMagellanic: return GameText.SpiralMagellanicGalaxyGameTip;
             }
         }
 
@@ -708,7 +710,7 @@ namespace Ship_Game
         
         public enum GameMode
         {
-            Sandbox, SpiralTwoArm, SpiralFourArm, SpiralBarred, Random, Ring, SmallClusters, BigClusters, Elimination, Corners
+            Sandbox, SpiralTwoArm, SpiralFourArm, SpiralBarred, SpiralMagellanic, Random, Ring, SmallClusters, BigClusters, Elimination, Corners
         }
 
         public enum StarsAbundance

--- a/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
+++ b/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
@@ -524,8 +524,9 @@ namespace Ship_Game.GameScreens.NewGame
                     // ~180 each around the bar tips. Arms attach at bar tip (armStartR ==
                     // barHalfLen) and span a wider radial band (0.72 -> 0.95) so they read
                     // as a fat band rather than a perfect arc; pitch tuned for ~180 sweep
-                    // (maxT = ln(0.95/0.72)/0.088 ~ 3.1 rad). Flare factor 1.2 still puffs
-                    // the bar-tip end further.
+                    // (maxT = ln(0.95/0.72)/0.088 ~ 3.1 rad). Flare factor 4.0 puffs the
+                    // bar-tip end (jitter is 5x at t=0 tapering to 1x at outer end) so the
+                    // arms read as a flared trumpet rather than uniform ribbons.
                     numArms = 2; bulgeFraction = 0.30f; bulgeRadius = 0.18f; armThicknessFrac = 0.06f;
                     armStartR = 0.72f; armEndR = 0.95f; pitch = 0.088f; armFlareFactor = 4.0f; hasBar = true;  break;
                 case SpiralVariant.Magellanic:

--- a/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
+++ b/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
@@ -289,7 +289,9 @@ namespace Ship_Game.GameScreens.NewGame
                 case RaceDesignScreen.GameMode.BigClusters:   GenerateBigClusters(step);      break;
                 case RaceDesignScreen.GameMode.SmallClusters: GenerateSmallClusters(step);    break;
                 case RaceDesignScreen.GameMode.Ring:          GenerateRingMap(step);          break;
-                case RaceDesignScreen.GameMode.Spiral:        GenerateSpiralMap(step);        break;
+                case RaceDesignScreen.GameMode.SpiralTwoArm:  GenerateSpiralMap(step, SpiralVariant.TwoArm);  break;
+                case RaceDesignScreen.GameMode.SpiralFourArm: GenerateSpiralMap(step, SpiralVariant.FourArm); break;
+                case RaceDesignScreen.GameMode.SpiralBarred:  GenerateSpiralMap(step, SpiralVariant.Barred);  break;
                 case RaceDesignScreen.GameMode.Sandbox:       GenerateRandomMap(step, false); break;
                 default:                                      GenerateRandomMap(step, true);  break;
             }
@@ -494,36 +496,43 @@ namespace Ship_Game.GameScreens.NewGame
             SolarSystemSpacingRing(step);
         }
 
-        // Three flavors of spiral galaxy. The variant is rolled per-game (using the
-        // seeded universe RNG) so the same seed reproduces the same galaxy.
+        // Three flavors of spiral galaxy, each picked explicitly via GameMode.
         enum SpiralVariant { TwoArm, FourArm, Barred }
 
-        void GenerateSpiralMap(ProgressCounter step)
+        void GenerateSpiralMap(ProgressCounter step, SpiralVariant variant)
         {
             // Logarithmic spiral: r(t) = armStartR * exp(pitch * t), theta = t + armOffset + phase.
             // Stars are sampled by drawing a parameter t along the arm length, mapping to (r, theta),
             // then adding a perpendicular jitter to give the arms visible thickness.
-            SpiralVariant variant = (SpiralVariant)Random.InRange(3);
-
             int numArms;
             float bulgeFraction;
+            float bulgeRadius;   // bulge radial extent (fraction of uSize)
             float armThicknessFrac;
+            float armStartR;  // arm origin radius (fraction of uSize)
+            float armEndR;    // arm end radius (fraction of uSize)
+            float pitch;      // log-spiral pitch (radians per e-fold of r) -- smaller = tighter winding = more curves
+            float armFlareFactor;  // 0 = uniform-thickness arms; >0 flares the bar-tip end and tapers toward armEndR
             bool hasBar;
             switch (variant)
             {
                 case SpiralVariant.FourArm:
-                    numArms = 4; bulgeFraction = 0.15f; armThicknessFrac = 0.045f; hasBar = false; break;
+                    numArms = 4; bulgeFraction = 0.15f; bulgeRadius = 0.22f; armThicknessFrac = 0.045f;
+                    armStartR = 0.20f; armEndR = 0.92f; pitch = 0.45f; armFlareFactor = 0f; hasBar = false; break;
                 case SpiralVariant.Barred:
-                    numArms = 2; bulgeFraction = 0.22f; armThicknessFrac = 0.06f;  hasBar = true;  break;
-                default: // TwoArm
-                    numArms = 2; bulgeFraction = 0.18f; armThicknessFrac = 0.06f;  hasBar = false; break;
+                    // Target look: long bar (~72% of uSize each side) with two arms wrapping
+                    // ~180 each around the bar tips. Arms attach at bar tip (armStartR ==
+                    // barHalfLen) and span a wider radial band (0.72 -> 0.95) so they read
+                    // as a fat band rather than a perfect arc; pitch tuned for ~180 sweep
+                    // (maxT = ln(0.95/0.72)/0.088 ~ 3.1 rad). Flare factor 1.2 still puffs
+                    // the bar-tip end further.
+                    numArms = 2; bulgeFraction = 0.30f; bulgeRadius = 0.18f; armThicknessFrac = 0.06f;
+                    armStartR = 0.72f; armEndR = 0.95f; pitch = 0.088f; armFlareFactor = 4.0f; hasBar = true;  break;
+                default: // TwoArm -- tighter winding (more curves) than the other variants
+                    numArms = 2; bulgeFraction = 0.18f; bulgeRadius = 0.22f; armThicknessFrac = 0.075f;
+                    armStartR = 0.20f; armEndR = 0.92f; pitch = 0.25f; armFlareFactor = 0f; hasBar = false; break;
             }
 
-            const float armStartR    = 0.20f;  // arm origin radius (fraction of uSize)
-            const float armEndR      = 0.92f;  // arm end radius
-            const float pitch        = 0.45f;  // log-spiral pitch (radians per e-fold of r)
-            const float bulgeRadius  = 0.22f;  // bulge radial extent (fraction of uSize)
-            const float barHalfLen   = 0.30f;  // bar half-length along its long axis
+            const float barHalfLen   = 0.72f;  // bar half-length along its long axis (~72% of uSize each side)
             const float barHalfWid   = 0.06f;  // bar half-width perpendicular
 
             float uSize  = UState.Size;
@@ -531,15 +540,15 @@ namespace Ship_Game.GameScreens.NewGame
 
             Log.Info($"Spiral galaxy variant: {variant} (numArms={numArms}, bulge={bulgeFraction:P0})");
 
-            PlaceSpiralStartingSystems(numArms, phase, uSize, armStartR, armEndR, pitch, armThicknessFrac, step);
+            PlaceSpiralStartingSystems(numArms, phase, uSize, armStartR, armEndR, pitch, armThicknessFrac, armFlareFactor, step);
             PlaceSpiralBackgroundSystems(numArms, phase, uSize, armStartR, armEndR, pitch,
-                                          armThicknessFrac, bulgeFraction, bulgeRadius,
+                                          armThicknessFrac, armFlareFactor, bulgeFraction, bulgeRadius,
                                           hasBar, barHalfLen, barHalfWid, step);
         }
 
         void PlaceSpiralStartingSystems(int numArms, float phase, float uSize,
                                          float armStartR, float armEndR, float pitch,
-                                         float armThicknessFrac, ProgressCounter step)
+                                         float armThicknessFrac, float armFlareFactor, ProgressCounter step)
         {
             // Empires get random arm positions with a generous min-spacing so they don't
             // start on top of each other. Spacing relaxes per retry (same pattern as
@@ -550,14 +559,15 @@ namespace Ship_Game.GameScreens.NewGame
             foreach (SystemPlaceHolder sys in starting)
             {
                 sys.Position = SampleArmPos(numArms, phase, uSize, armStartR, armEndR, pitch,
-                                             armThicknessFrac, spacing);
+                                             armThicknessFrac, armFlareFactor, spacing);
                 step.Advance();
             }
         }
 
         void PlaceSpiralBackgroundSystems(int numArms, float phase, float uSize,
                                            float armStartR, float armEndR, float pitch,
-                                           float armThicknessFrac, float bulgeFraction, float bulgeRadius,
+                                           float armThicknessFrac, float armFlareFactor,
+                                           float bulgeFraction, float bulgeRadius,
                                            bool hasBar, float barHalfLen, float barHalfWid,
                                            ProgressCounter step)
         {
@@ -576,14 +586,14 @@ namespace Ship_Game.GameScreens.NewGame
                     sys.Position = SampleBulgePos(uSize, bulgeRadius);
                 else
                     sys.Position = SampleArmPos(numArms, phase, uSize, armStartR, armEndR, pitch,
-                                                 armThicknessFrac, 250000f);
+                                                 armThicknessFrac, armFlareFactor, 250000f);
                 step.Advance();
             }
         }
 
         Vector2 SampleArmPos(int numArms, float phase, float uSize,
                               float armStartR, float armEndR, float pitch,
-                              float armThicknessFrac, float spacing)
+                              float armThicknessFrac, float armFlareFactor, float spacing)
         {
             float maxT = (float)Math.Log(armEndR / armStartR) / pitch; // angular extent of one arm
             float jitterScale = uSize * armThicknessFrac;
@@ -598,9 +608,24 @@ namespace Ship_Game.GameScreens.NewGame
                 float r = armStartR * uSize * (float)Math.Exp(pitch * t);
                 float theta = t + arm * armSep + phase;
 
+                // Optional taper: arms flare at the base (near armStartR) and taper toward
+                // the outer end. flareFactor=0 keeps uniform thickness; >0 multiplies jitter
+                // by (1 + flareFactor) at t=0 and 1.0x at t=maxT. Used for Barred so the
+                // arms don't read as a thin line where they leave the bar tips.
+                float taperMult = 1f + armFlareFactor * (1f - t / maxT);
+
+                // Radial scatter (Barred only -- gated on flare): pushes stars off the perfect
+                // log-spiral path so the arms read as a 2D band rather than a 1D curve. Without
+                // this, even with perpendicular jitter the arms' centerline is a clean arc.
+                if (armFlareFactor > 0f)
+                {
+                    float rJitter = (Random.Float(-1f, 1f) + Random.Float(-1f, 1f)) * 0.5f * jitterScale * 0.4f * taperMult;
+                    r += rJitter;
+                }
+
                 // Triangular distribution (sum of two uniforms) approximates a Gaussian
                 // cheaply — most stars near the arm centerline, few at the edges.
-                float jitterMag = (Random.Float(-1f, 1f) + Random.Float(-1f, 1f)) * 0.5f * jitterScale;
+                float jitterMag = (Random.Float(-1f, 1f) + Random.Float(-1f, 1f)) * 0.5f * jitterScale * taperMult;
                 float perpAngle = theta + RadMath.HalfPI;
                 sysPos = new Vector2(r * RadMath.Cos(theta) + jitterMag * RadMath.Cos(perpAngle),
                                      r * RadMath.Sin(theta) + jitterMag * RadMath.Sin(perpAngle));

--- a/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
+++ b/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
@@ -289,9 +289,10 @@ namespace Ship_Game.GameScreens.NewGame
                 case RaceDesignScreen.GameMode.BigClusters:   GenerateBigClusters(step);      break;
                 case RaceDesignScreen.GameMode.SmallClusters: GenerateSmallClusters(step);    break;
                 case RaceDesignScreen.GameMode.Ring:          GenerateRingMap(step);          break;
-                case RaceDesignScreen.GameMode.SpiralTwoArm:  GenerateSpiralMap(step, SpiralVariant.TwoArm);  break;
-                case RaceDesignScreen.GameMode.SpiralFourArm: GenerateSpiralMap(step, SpiralVariant.FourArm); break;
-                case RaceDesignScreen.GameMode.SpiralBarred:  GenerateSpiralMap(step, SpiralVariant.Barred);  break;
+                case RaceDesignScreen.GameMode.SpiralTwoArm:     GenerateSpiralMap(step, SpiralVariant.TwoArm);     break;
+                case RaceDesignScreen.GameMode.SpiralFourArm:    GenerateSpiralMap(step, SpiralVariant.FourArm);    break;
+                case RaceDesignScreen.GameMode.SpiralBarred:     GenerateSpiralMap(step, SpiralVariant.Barred);     break;
+                case RaceDesignScreen.GameMode.SpiralMagellanic: GenerateSpiralMap(step, SpiralVariant.Magellanic); break;
                 case RaceDesignScreen.GameMode.Sandbox:       GenerateRandomMap(step, false); break;
                 default:                                      GenerateRandomMap(step, true);  break;
             }
@@ -496,8 +497,8 @@ namespace Ship_Game.GameScreens.NewGame
             SolarSystemSpacingRing(step);
         }
 
-        // Three flavors of spiral galaxy, each picked explicitly via GameMode.
-        enum SpiralVariant { TwoArm, FourArm, Barred }
+        // Four flavors of spiral galaxy, each picked explicitly via GameMode.
+        enum SpiralVariant { TwoArm, FourArm, Barred, Magellanic }
 
         void GenerateSpiralMap(ProgressCounter step, SpiralVariant variant)
         {
@@ -527,6 +528,15 @@ namespace Ship_Game.GameScreens.NewGame
                     // the bar-tip end further.
                     numArms = 2; bulgeFraction = 0.30f; bulgeRadius = 0.18f; armThicknessFrac = 0.06f;
                     armStartR = 0.72f; armEndR = 0.95f; pitch = 0.088f; armFlareFactor = 4.0f; hasBar = true;  break;
+                case SpiralVariant.Magellanic:
+                    // Single fat arm wrapping ~250 around an off-center bulge. No bar.
+                    // originOffset (computed below) shifts the whole galaxy sideways so the
+                    // map looks lopsided -- the Magellanic Clouds signature. Sized to fill
+                    // the universe: bulge to 0.45 uSize, arm reaches to 0.95 uSize
+                    // (+0.10 offset = ~1.05 from world center on the offset axis; OOB
+                    // stars are rejected by SystemPosOK and respawned).
+                    numArms = 1; bulgeFraction = 0.30f; bulgeRadius = 0.55f; armThicknessFrac = 0.11f;
+                    armStartR = 0.50f; armEndR = 0.95f; pitch = 0.147f; armFlareFactor = 1.0f; hasBar = false; break;
                 default: // TwoArm -- tighter winding (more curves) than the other variants
                     numArms = 2; bulgeFraction = 0.18f; bulgeRadius = 0.22f; armThicknessFrac = 0.075f;
                     armStartR = 0.20f; armEndR = 0.92f; pitch = 0.25f; armFlareFactor = 0f; hasBar = false; break;
@@ -538,36 +548,80 @@ namespace Ship_Game.GameScreens.NewGame
             float uSize  = UState.Size;
             float phase  = Random.Float(0f, RadMath.TwoPI); // randomize galactic orientation
 
+            // Magellanic-only: shift the whole galaxy off-center perpendicular to the arm
+            // origin direction so the map looks visibly lopsided. Magnitude (0.10 * uSize)
+            // tuned so the bulk of the arm stays in-bounds even with armEndR=0.92;
+            // outliers are rejected by SystemPosOK and respawned.
+            Vector2 originOffset = Vector2.Zero;
+            if (variant == SpiralVariant.Magellanic)
+                originOffset = new Vector2(-RadMath.Sin(phase), RadMath.Cos(phase)) * (uSize * 0.10f);
+
             Log.Info($"Spiral galaxy variant: {variant} (numArms={numArms}, bulge={bulgeFraction:P0})");
 
-            PlaceSpiralStartingSystems(numArms, phase, uSize, armStartR, armEndR, pitch, armThicknessFrac, armFlareFactor, step);
+            // Magellanic puts most starting empires inside the bulge (it's huge and
+            // anchors the galaxy); the rest spread along the single arm. Other variants
+            // place all empires on arms via round-robin -- no bulge starts.
+            float bulgeStartFraction = variant == SpiralVariant.Magellanic ? 0.75f : 0f;
+
+            PlaceSpiralStartingSystems(numArms, phase, uSize, armStartR, armEndR, pitch, armThicknessFrac, armFlareFactor,
+                                        bulgeRadius, bulgeStartFraction, originOffset, step);
             PlaceSpiralBackgroundSystems(numArms, phase, uSize, armStartR, armEndR, pitch,
                                           armThicknessFrac, armFlareFactor, bulgeFraction, bulgeRadius,
-                                          hasBar, barHalfLen, barHalfWid, step);
+                                          hasBar, barHalfLen, barHalfWid, originOffset, step);
         }
 
         void PlaceSpiralStartingSystems(int numArms, float phase, float uSize,
                                          float armStartR, float armEndR, float pitch,
-                                         float armThicknessFrac, float armFlareFactor, ProgressCounter step)
+                                         float armThicknessFrac, float armFlareFactor,
+                                         float bulgeRadius, float bulgeStartFraction,
+                                         Vector2 originOffset, ProgressCounter step)
         {
-            // Deterministic round-robin slotting: assign each starting empire to an arm
-            // (i % numArms) and a position along that arm (i / numArms). Pure random
-            // placement into SampleArmPos relies on a min-spacing retry that decays
-            // 0.97x per attempt -- on the narrow spiral arm bands (especially Barred at
-            // armStartR=0.72) the constraint degrades into nothing and empires cluster.
-            // Round-robin guarantees angular + radial separation regardless of arm shape.
+            // Two-phase placement so that bulge-anchored variants (Magellanic) can put
+            // some empires in the central blob and the rest on arms.
+            //
+            // Phase 1: bulgeStartFraction of starts get sampled inside the bulge with
+            //          decaying min-spacing -- empires spread inside the central blob
+            //          but not too close to each other.
+            // Phase 2: remaining starts are slotted onto arms via deterministic
+            //          round-robin (arm = i % numArms, slot = i / numArms). Pure
+            //          random placement into SampleArmPos uses a min-spacing retry
+            //          that decays 0.97x per attempt -- on narrow arm bands the
+            //          constraint degrades into nothing and empires cluster. Slotting
+            //          guarantees angular + radial separation regardless of arm shape.
             SystemPlaceHolder[] starting = Systems.Filter(s => s.IsStartingSystem);
-            Random.Shuffle(starting); // randomize which empire gets which slot
+            Random.Shuffle(starting); // randomize which empire gets bulge vs arm
 
-            int slotsPerArm = (starting.Length + numArms - 1) / numArms; // ceiling division
+            int inBulgeCount = (int)Math.Round(starting.Length * bulgeStartFraction);
+            int onArmCount   = starting.Length - inBulgeCount;
+
+            // Phase 1: bulge placements
+            float bulgeMaxR    = uSize * bulgeRadius;
+            float bulgeSpacing = bulgeMaxR * 0.5f;
+            for (int i = 0; i < inBulgeCount; i++)
+            {
+                Vector2 sysPos = default;
+                int attempts = 0;
+                do
+                {
+                    sysPos = Random.RandomPointInRing(0f, bulgeMaxR) + originOffset;
+                    bulgeSpacing *= 0.97f;
+                } while (!SystemPosOK(sysPos, bulgeSpacing) && ++attempts < 200);
+
+                starting[i].Position = sysPos;
+                ClaimedSpots.Add(sysPos);
+                step.Advance();
+            }
+
+            // Phase 2: arm placements via round-robin slotting
+            int slotsPerArm   = onArmCount > 0 ? (onArmCount + numArms - 1) / numArms : 1;
             float maxT        = (float)Math.Log(armEndR / armStartR) / pitch;
             float jitterScale = uSize * armThicknessFrac;
             float armSep      = RadMath.TwoPI / numArms;
 
-            for (int i = 0; i < starting.Length; i++)
+            for (int armIndex = 0; armIndex < onArmCount; armIndex++)
             {
-                int arm  = i % numArms;
-                int slot = i / numArms;
+                int arm  = armIndex % numArms;
+                int slot = armIndex / numArms;
 
                 // Center the empire in its arm slot, then add a small wiggle so the
                 // same slot doesn't land at the exact same t across replays.
@@ -586,8 +640,9 @@ namespace Ship_Game.GameScreens.NewGame
 
                 Vector2 sysPos = new Vector2(r * RadMath.Cos(theta) + jitterMag * RadMath.Cos(perpAngle),
                                               r * RadMath.Sin(theta) + jitterMag * RadMath.Sin(perpAngle));
+                sysPos += originOffset;
 
-                starting[i].Position = sysPos;
+                starting[inBulgeCount + armIndex].Position = sysPos;
                 ClaimedSpots.Add(sysPos);
                 step.Advance();
             }
@@ -598,7 +653,7 @@ namespace Ship_Game.GameScreens.NewGame
                                            float armThicknessFrac, float armFlareFactor,
                                            float bulgeFraction, float bulgeRadius,
                                            bool hasBar, float barHalfLen, float barHalfWid,
-                                           ProgressCounter step)
+                                           Vector2 originOffset, ProgressCounter step)
         {
             // Shuffle so file-order doesn't determine arm position (same reasoning as
             // GenerateClusterSystems: predefined systems should not always land in the
@@ -612,17 +667,18 @@ namespace Ship_Game.GameScreens.NewGame
                 if (inBulge && hasBar)
                     sys.Position = SampleBarPos(phase, uSize, barHalfLen, barHalfWid);
                 else if (inBulge)
-                    sys.Position = SampleBulgePos(uSize, bulgeRadius);
+                    sys.Position = SampleBulgePos(uSize, bulgeRadius, originOffset);
                 else
                     sys.Position = SampleArmPos(numArms, phase, uSize, armStartR, armEndR, pitch,
-                                                 armThicknessFrac, armFlareFactor, 250000f);
+                                                 armThicknessFrac, armFlareFactor, originOffset, 250000f);
                 step.Advance();
             }
         }
 
         Vector2 SampleArmPos(int numArms, float phase, float uSize,
                               float armStartR, float armEndR, float pitch,
-                              float armThicknessFrac, float armFlareFactor, float spacing)
+                              float armThicknessFrac, float armFlareFactor,
+                              Vector2 originOffset, float spacing)
         {
             float maxT = (float)Math.Log(armEndR / armStartR) / pitch; // angular extent of one arm
             float jitterScale = uSize * armThicknessFrac;
@@ -658,6 +714,7 @@ namespace Ship_Game.GameScreens.NewGame
                 float perpAngle = theta + RadMath.HalfPI;
                 sysPos = new Vector2(r * RadMath.Cos(theta) + jitterMag * RadMath.Cos(perpAngle),
                                      r * RadMath.Sin(theta) + jitterMag * RadMath.Sin(perpAngle));
+                sysPos += originOffset;
 
                 spacing *= 0.97f;
             } while (!SystemPosOK(sysPos, spacing) && ++attempts < 200);
@@ -666,7 +723,7 @@ namespace Ship_Game.GameScreens.NewGame
             return sysPos;
         }
 
-        Vector2 SampleBulgePos(float uSize, float bulgeRadiusFrac)
+        Vector2 SampleBulgePos(float uSize, float bulgeRadiusFrac, Vector2 originOffset)
         {
             float maxR = uSize * bulgeRadiusFrac;
             float spacing = 200000f;
@@ -674,7 +731,7 @@ namespace Ship_Game.GameScreens.NewGame
             int attempts = 0;
             do
             {
-                sysPos = Random.RandomPointInRing(0f, maxR);
+                sysPos = Random.RandomPointInRing(0f, maxR) + originOffset;
                 spacing *= 0.95f;
             } while (!SystemPosOK(sysPos, spacing) && ++attempts < 200);
 

--- a/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
+++ b/Ship_Game/GameScreens/NewGame/UniverseGenerator.cs
@@ -550,16 +550,45 @@ namespace Ship_Game.GameScreens.NewGame
                                          float armStartR, float armEndR, float pitch,
                                          float armThicknessFrac, float armFlareFactor, ProgressCounter step)
         {
-            // Empires get random arm positions with a generous min-spacing so they don't
-            // start on top of each other. Spacing relaxes per retry (same pattern as
-            // GenerateSystemInCluster) so we always converge on tiny galaxies.
+            // Deterministic round-robin slotting: assign each starting empire to an arm
+            // (i % numArms) and a position along that arm (i / numArms). Pure random
+            // placement into SampleArmPos relies on a min-spacing retry that decays
+            // 0.97x per attempt -- on the narrow spiral arm bands (especially Barred at
+            // armStartR=0.72) the constraint degrades into nothing and empires cluster.
+            // Round-robin guarantees angular + radial separation regardless of arm shape.
             SystemPlaceHolder[] starting = Systems.Filter(s => s.IsStartingSystem);
-            float spacing = (uSize * 0.6f / starting.Length.LowerBound(2)).LowerBound(350000f);
+            Random.Shuffle(starting); // randomize which empire gets which slot
 
-            foreach (SystemPlaceHolder sys in starting)
+            int slotsPerArm = (starting.Length + numArms - 1) / numArms; // ceiling division
+            float maxT        = (float)Math.Log(armEndR / armStartR) / pitch;
+            float jitterScale = uSize * armThicknessFrac;
+            float armSep      = RadMath.TwoPI / numArms;
+
+            for (int i = 0; i < starting.Length; i++)
             {
-                sys.Position = SampleArmPos(numArms, phase, uSize, armStartR, armEndR, pitch,
-                                             armThicknessFrac, armFlareFactor, spacing);
+                int arm  = i % numArms;
+                int slot = i / numArms;
+
+                // Center the empire in its arm slot, then add a small wiggle so the
+                // same slot doesn't land at the exact same t across replays.
+                float tFrac = (slot + 0.5f) / slotsPerArm;
+                tFrac += Random.Float(-0.15f, 0.15f) / slotsPerArm;
+                float t = tFrac.Clamped(0.05f, 0.95f) * maxT;
+
+                float r     = armStartR * uSize * (float)Math.Exp(pitch * t);
+                float theta = t + arm * armSep + phase;
+
+                // Same flare-aware perpendicular jitter SampleArmPos uses, so starting
+                // systems visually blend with the background arm stars.
+                float taperMult = 1f + armFlareFactor * (1f - t / maxT);
+                float jitterMag = (Random.Float(-1f, 1f) + Random.Float(-1f, 1f)) * 0.5f * jitterScale * taperMult;
+                float perpAngle = theta + RadMath.HalfPI;
+
+                Vector2 sysPos = new Vector2(r * RadMath.Cos(theta) + jitterMag * RadMath.Cos(perpAngle),
+                                              r * RadMath.Sin(theta) + jitterMag * RadMath.Sin(perpAngle));
+
+                starting[i].Position = sysPos;
+                ClaimedSpots.Add(sysPos);
                 step.Advance();
             }
         }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
@@ -190,7 +190,7 @@ public partial class Planet
         bool TryGetQueueItemsFromRefitGoals(out Array<QueueItem> refitQueue)
         {
             refitQueue = new();
-            var refitGoals = Owner.AI.FindGoals(g => g.IsRefitGoalAtPlanet(this));
+            var refitGoals = Owner.AI.FindGoals(g => g?.IsRefitGoalAtPlanet(this) == true);
             if (refitGoals.Length == 0)
                 return false;
 

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -12437,12 +12437,24 @@ RingGalaxyGame:
  Id: 4383
  ENG: "Ring Galaxy"
  UKR: "Кільцева галактика"
-SpiralGalaxyGame:
+SpiralTwoArmGalaxyGame:
  Id: 4526
- ENG: "Spiral Galaxy"
-SpiralGalaxyGameTip:
+ ENG: "2-Arm Spiral Galaxy"
+SpiralTwoArmGalaxyGameTip:
  Id: 4527
- ENG: "Each empire starts at a random place along the arms of a Spiral Galaxy. The galaxy is shaped randomly per game as a 2-arm grand-design, a 4-arm tighter spiral, or a barred spiral, with a denser central bulge."
+ ENG: "Each empire starts at a random place along the arms of a classic 2-arm grand-design spiral galaxy with a dense central bulge."
+SpiralFourArmGalaxyGame:
+ Id: 4528
+ ENG: "4-Arm Spiral Galaxy"
+SpiralFourArmGalaxyGameTip:
+ Id: 4529
+ ENG: "Each empire starts at a random place along the arms of a 4-arm spiral galaxy: tighter winding, four distinct arms, thinner arm structure."
+SpiralBarredGalaxyGame:
+ Id: 4530
+ ENG: "Barred Spiral Galaxy"
+SpiralBarredGalaxyGameTip:
+ Id: 4531
+ ENG: "Each empire starts at a random place along the arms of a barred spiral galaxy, where a central elongated bar of stars feeds two trailing arms."
 FlatIncomePerTurn:
  Id: 4384
  ENG: "Flat Income Per Turn" 

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -12448,7 +12448,7 @@ SpiralFourArmGalaxyGame:
  ENG: "4-Arm Spiral Galaxy"
 SpiralFourArmGalaxyGameTip:
  Id: 4529
- ENG: "Each empire starts at a random place along the arms of a 4-arm spiral galaxy: tighter winding, four distinct arms, thinner arm structure."
+ ENG: "Each empire starts at a random place along the arms of a 4-arm spiral galaxy."
 SpiralBarredGalaxyGame:
  Id: 4530
  ENG: "Barred Spiral Galaxy"
@@ -12460,7 +12460,7 @@ SpiralMagellanicGalaxyGame:
  ENG: "Magellanic Spiral Galaxy"
 SpiralMagellanicGalaxyGameTip:
  Id: 4533
- ENG: "Each empire starts along a single fat asymmetric arm wrapping around an off-center bulge. The galaxy is visibly lopsided and one arm carries every starting system."
+ ENG: "A visibly lopsided galaxy with a single fat asymmetric arm wrapping around an off-center bulge. Most empires start inside the dense central bulge; the rest spread along the arm."
 FlatIncomePerTurn:
  Id: 4384
  ENG: "Flat Income Per Turn" 

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -12455,6 +12455,12 @@ SpiralBarredGalaxyGame:
 SpiralBarredGalaxyGameTip:
  Id: 4531
  ENG: "Each empire starts at a random place along the arms of a barred spiral galaxy, where a central elongated bar of stars feeds two trailing arms."
+SpiralMagellanicGalaxyGame:
+ Id: 4532
+ ENG: "Magellanic Spiral Galaxy"
+SpiralMagellanicGalaxyGameTip:
+ Id: 4533
+ ENG: "Each empire starts along a single fat asymmetric arm wrapping around an off-center bulge. The galaxy is visibly lopsided and one arm carries every starting system."
 FlatIncomePerTurn:
  Id: 4384
  ENG: "Flat Income Per Turn" 


### PR DESCRIPTION
## Summary

Post-Jupiter 1.60 patch batch covering: spiral galaxy rework, a Sentry crash fix, a UI drift fix, and a couple of small UI/telemetry polish items.

## Spiral galaxies

- **Split `GameMode.Spiral` into four dedicated modes**: `SpiralTwoArm`, `SpiralFourArm`, `SpiralBarred`, `SpiralMagellanic`. Variant is no longer randomized at gen time — players pick the layout they want. Each variant has its own `armStartR / armEndR / pitch / bulgeRadius / armThickness / armFlareFactor / hasBar`, lifted out of the file-level consts.
- **TwoArm**: pitch lowered to 0.25 — arms now sweep ~350° each (was ~194°).
- **Barred**: reworked to look like a real long-bar spiral instead of a loose open S.
  - `barHalfLen` 0.30 → 0.72 (bar dominates the galaxy width).
  - Arms attach at the bar tip (`armStartR == barHalfLen`) and wrap ~180° each.
  - `bulgeFraction` 0.22 → 0.30, `bulgeRadius` 0.22 → 0.18 (denser middle).
  - Per-variant `armFlareFactor`: arms flare wider at the bar attachment and taper toward the outer end (`taperMult = 1 + flare*(1 - t/maxT)`). Applied to both perpendicular jitter and a new radial scatter so the arms read as a 2D band, not a clean 1D curve. Gated on `flareFactor > 0` so TwoArm / FourArm stay clean log-spirals.
- **Magellanic (new)**: single fat arm wrapping ~250° around a large off-center bulge — the Magellanic Clouds signature.
  - `numArms = 1`, `bulgeRadius = 0.55`, `armStartR = 0.50`, `armEndR = 0.95`, `pitch = 0.147`.
  - New `originOffset` (Vector2, default `Vector2.Zero`) plumbed through `SampleArmPos`, `SampleBulgePos`, and both `PlaceSpiral*` helpers. Magellanic uses `0.10 × uSize` perpendicular to phase; other variants pass `Vector2.Zero` (no behavior change).
  - 75% of starting empires placed inside the bulge with decaying min-spacing, 25% on the arm. Other variants still place all empires on arms.

### Starting-position fix (all spirals)

`PlaceSpiralStartingSystems` used to call `SampleArmPos` with a min-spacing check, but spacing decays 0.97× per retry — on narrow arm bands (Barred is worst at `armStartR=0.72`) the constraint degrades to ~0.2% of original after 200 attempts and empires can spawn on top of each other. Replaced with deterministic round-robin slotting: empire `i` goes to arm `i % numArms`, slot `i / numArms`. Slot `t` is centered at `(slot + 0.5) / slotsPerArm` with ±15% slot-width wiggle so replays don't always land at identical `t`.

### GameText

`SpiralGalaxyGame[Tip]` replaced with `SpiralTwoArmGalaxyGame[Tip]`, `SpiralFourArmGalaxyGame[Tip]`, `SpiralBarredGalaxyGame[Tip]`, `SpiralMagellanicGalaxyGame[Tip]` at sequential IDs 4526–4533. **Old `GameMode.Spiral` saves won't deserialize** — intentional; the spiral option only just shipped in `b7eaf71de` so no shipping saves exist yet.

## Sentry crash fix

**`Planet.TurnsUntilQueueComplete` → `FindGoals` NRE** ([#13e2fbf77](../../commit/13e2fbf77)).
UI click on `DeepSpaceBuildingWindow` invokes `AddGoalAndEvaluate` on the main thread, which iterates `EmpireAI.GoalsList` via `FindGoals(predicate)`. Concurrent sim-thread `Array<T>.Remove` shifts items down and nulls the trailing slot — if the captured `Count` outruns the post-remove count, the lambda's `g.IsRefitGoalAtPlanet` NREs on null. Same defer-tolerant shape we use for other sim-thread collections. One-line null-guard:

```csharp
var refitGoals = Owner.AI.FindGoals(g => g?.IsRefitGoalAtPlanet(this) == true);
```

### UI fixes
- RaceDesignScreen traits-panel background drift ([#d4ef9544d](vscode-webview://0knd4tdve3lcmpqcdfq9ufb7kr37e7ilpdt396v7uqsmkpd951nl/commit/d4ef9544d)). ScrollListBase.SetBackground sets a wrong-sign LocalPos (Pos - bg.Pos instead of bg.Pos - Pos) which silently does nothing until something forces a relayout. Clicking a trait tab calls SetItems on the inner ScrollList → triggers PerformLayout → finally applies the bad LocalPos and shifts the Menu1 background up — and it never recovers. Anchored via SetAbsPos right after SetBackground so UpdatePosAndSize short-circuits. Shared SetBackground left alone to avoid blast-radius across the other 7 callers. Also dropped the +60 / +90 nudge that was compensating for the same drift on first render.
- RaceDesignScreen buttons ([#68aa4289c](vscode-webview://0knd4tdve3lcmpqcdfq9ufb7kr37e7ilpdt396v7uqsmkpd951nl/commit/68aa4289c)). Promoted Save / Load Setup to BigDip and Rule Options to Default (all three now 168px wide, re-centered side-by-side).