### PR TITLE
Jupiter 1.60/fixes 08

### DIFF
--- a/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
@@ -278,7 +278,7 @@ namespace Ship_Game.AI
             }
 
             ReverseThrustUntilStopped(timeStep);
-            Owner.Construction.AddConstructionEffects();
+            Owner.Construction.AddConstructionEffects(bg.TetherPlanet);
             if (!Owner.Construction.ConsturctionCompleted)
                 return;
 
@@ -354,7 +354,7 @@ namespace Ship_Game.AI
             }
 
             ReverseThrustUntilStopped(timeStep);
-            Owner.Construction.AddConstructionEffects();
+            Owner.Construction.AddConstructionEffects(bg.TetherPlanet);
             if (!Owner.Construction.ConsturctionCompleted)
                 return;
 

--- a/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
@@ -385,7 +385,10 @@ namespace Ship_Game.AI
             if (!orbital.IsResearchStation)
                 return;
 
-            Goal goal = Owner.Loyalty.AI.FindGoal(g => g.IsResearchStationGoal(target));
+            Goal goal = Owner.Loyalty.AI.FindGoal(g => g.IsResearchStationGoal(target)
+                                                   && g.StepName == "WaitForConstructor"
+                                                   && g.TargetShip == null
+                                                   && g.ToBuild?.Name == orbital.Name);
             if (goal != null)
             {
                 goal.TargetShip = orbital;
@@ -398,9 +401,12 @@ namespace Ship_Game.AI
             if (!orbital.IsMiningStation)
                 return;
 
-            Goal goal = Owner.Loyalty.AI.FindGoal(g => g.IsMiningOpsGoal(planet) 
-                                                  && (oldShipToRefit == null ? g.StepName == "WaitForConstructor"
-                                                                             : g.TargetShip == oldShipToRefit));
+            Goal goal = Owner.Loyalty.AI.FindGoal(g => g.IsMiningOpsGoal(planet)
+                                                  && (oldShipToRefit == null
+                                                      ? g.StepName == "WaitForConstructor" 
+                                                            && g.TargetShip == null 
+                                                            && g.ToBuild?.Name == orbital.Name
+                                                      : g.TargetShip == oldShipToRefit));
 
             if (goal != null)
                 goal.TargetShip = orbital;

--- a/Ship_Game/Building.cs
+++ b/Ship_Game/Building.cs
@@ -192,7 +192,7 @@ namespace Ship_Game
 
         public float ActualFireDelay(int planetLevel)
         {
-            if (TheWeapon == null || Strength == 0 || planetLevel == 1)
+            if (TheWeapon == null || Strength == 0 || planetLevel <= 1)
                 return 1;
 
             float fireDelay = (TheWeapon.FireDelay / planetLevel / CurrentStrPercentage).UpperBound(TheWeapon.FireDelay);

--- a/Ship_Game/Commands/Goals/MiningOps.cs
+++ b/Ship_Game/Commands/Goals/MiningOps.cs
@@ -19,6 +19,7 @@ namespace Ship_Game.Commands.Goals
         [StarData] int NumSupplyGoals = 1;
         [StarData] float SupplyDificit;
         Ship MiningStation => TargetShip;
+        public override IShipDesign ToBuild => StationToBuild;
         string ResourceCargoName => TargetPlanet.Mining.CargoId;
         float RemainingConsumables => Owner.NonCybernetic ? MiningStation.GetFood() : MiningStation.GetProduction();
         float ActualRefiningRatio => (TargetPlanet.Mining.RefiningRatio * Owner.data.RefiningRatioMultiplier).UpperBound(1);

--- a/Ship_Game/Commands/Goals/ProcessResearchStation.cs
+++ b/Ship_Game/Commands/Goals/ProcessResearchStation.cs
@@ -21,8 +21,9 @@ namespace Ship_Game.Commands.Goals
         [StarData] int NumSupplyGoals = 1;
         [StarData] float SupplyDificit;
         Ship ResearchStation => TargetShip;
+        public override IShipDesign ToBuild => StationToBuild;
 
-        public override bool IsResearchStationGoal(ExplorableGameObject body) 
+        public override bool IsResearchStationGoal(ExplorableGameObject body)
             => body != null && (TargetPlanet == body || TargetSystem == body);
 
         [StarDataConstructor]

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -2234,6 +2234,9 @@ namespace Ship_Game
                     troop.ChangeLoyalty(this);
             }
 
+            for (int i = 0; i < planets.Count; i++)
+                planets[i].LaunchNonOwnerTroops();
+
             target.ClearAllPlanets();
             var ships = target.OwnedShips;
             for (int i = ships.Count - 1; i >= 0; i--)

--- a/Ship_Game/Ships/ConstructionShip.cs
+++ b/Ship_Game/Ships/ConstructionShip.cs
@@ -100,7 +100,7 @@ namespace Ship_Game.Ships
                 Owner.Universe.Screen.ResetConstructionParts(Owner.Id);
         }
 
-        public void AddConstructionEffects()
+        public void AddConstructionEffects(Planet tetherPlanet)
         {
             if (Owner == null || !ConstructionStarted)
                 return;
@@ -137,7 +137,7 @@ namespace Ship_Game.Ships
                 if (percentCompleted > 5 && universe.Random.RollDice(percentCompleted*1.2f))
                 {
                     center = RandomPoint();
-                    SpaceJunk.ConstructionPart(universe, center.ToVec2(), Owner.Velocity, Owner, percentCompleted);
+                    SpaceJunk.ConstructionPart(universe, center.ToVec2(), Owner.Velocity, Owner, percentCompleted, tetherPlanet);
                 }
             }
 

--- a/Ship_Game/SpaceJunk.cs
+++ b/Ship_Game/SpaceJunk.cs
@@ -22,9 +22,12 @@ namespace Ship_Game
         ParticleEmitter FlameTrail;
         ParticleEmitter ProjTrail;
         int ConstructionPartId;
-        Planet TetherPlanet;       // anchors construction junk to a moving planet
-        Vector3 ConstructionOffset; // offset from TetherPlanet at spawn
+        Planet TetherPlanet;        // anchors construction junk to a moving planet
+        Vector2 TetherPointOffset;  // build point relative to planet center (stable)
+        Vector3 ConstructionOffset; // junk position relative to tether point (grows during fade)
+        bool IsFading;              // true once TryReset fires; render scale shrinks with remaining Duration
         const float ConstructionPartDuration = 10;
+        const float FadeOutwardRate = 0.2f; // ~e^(0.2*5) = 2.7x outward growth over the 5s fade
 
         public SpaceJunk()
         {
@@ -43,8 +46,12 @@ namespace Ship_Game
                 if (tetherPlanet != null)
                 {
                     TetherPlanet = tetherPlanet;
-                    ConstructionOffset = new Vector3(Position.X - tetherPlanet.Position.X,
-                                                     Position.Y - tetherPlanet.Position.Y,
+                    // Build point relative to planet center: stable, follows planet orbit
+                    TetherPointOffset = new Vector2(parentPos.X - tetherPlanet.Position.X,
+                                                    parentPos.Y - tetherPlanet.Position.Y);
+                    // Junk's spread around the build point: this is what grows during fade
+                    ConstructionOffset = new Vector3(Position.X - parentPos.X,
+                                                     Position.Y - parentPos.Y,
                                                      Position.Z);
                 }
                 CreateSceneObjectConstruction(parentPos, maxSize, constructorId);
@@ -142,7 +149,7 @@ namespace Ship_Game
 
             int junkIndex = Universe.Random.InRange(ResourceManager.NumJunkModels);
             var model = ResourceManager.GetJunkModel(junkIndex);
-            float meshDiameter = 3f * ResourceManager.GetJunkModelRadius(junkIndex);
+            float meshDiameter = 2f * ResourceManager.GetJunkModelRadius(junkIndex);
 
             // set lower bound to max size, otherwise we can't even see the junk
             float maxAllowedSize = maxSize.LowerBound(8f);
@@ -195,7 +202,8 @@ namespace Ship_Game
             {
                 lock (this)
                 {
-                    Duration -= ConstructionPartDuration - 5;
+                    Duration = MaxDuration = ConstructionPartDuration * 0.5f;
+                    IsFading = true;
                 }
             }
         }
@@ -215,8 +223,17 @@ namespace Ship_Game
 
             if (TetherPlanet != null)
             {
-                Position.X = TetherPlanet.Position.X + ConstructionOffset.X;
-                Position.Y = TetherPlanet.Position.Y + ConstructionOffset.Y;
+                if (IsFading)
+                {
+                    // Push outward from the tether point (build position), not planet center.
+                    // Exponential so rate scales with current distance and the cluster visibly
+                    // expands rather than rigidly translating.
+                    float growth = 1f + (FadeOutwardRate * timeStep.FixedTime);
+                    ConstructionOffset.X *= growth;
+                    ConstructionOffset.Y *= growth;
+                }
+                Position.X = TetherPlanet.Position.X + TetherPointOffset.X + ConstructionOffset.X;
+                Position.Y = TetherPlanet.Position.Y + TetherPointOffset.Y + ConstructionOffset.Y;
                 Position.Z = ConstructionOffset.Z;
             }
             else
@@ -224,7 +241,8 @@ namespace Ship_Game
                 Position += Velocity * timeStep.FixedTime;
             }
             RotationRadians += Spin * timeStep.FixedTime;
-            So.AffineTransform(Position, RotationRadians, Scale);
+            float renderScale = IsFading ? Scale * (Duration / MaxDuration) : Scale;
+            So.AffineTransform(Position, RotationRadians, renderScale);
 
             FlameTrail?.Update(timeStep.FixedTime, Position);
             ProjTrail?.Update(timeStep.FixedTime, Position);

--- a/Ship_Game/SpaceJunk.cs
+++ b/Ship_Game/SpaceJunk.cs
@@ -22,6 +22,8 @@ namespace Ship_Game
         ParticleEmitter FlameTrail;
         ParticleEmitter ProjTrail;
         int ConstructionPartId;
+        Planet TetherPlanet;       // anchors construction junk to a moving planet
+        Vector3 ConstructionOffset; // offset from TetherPlanet at spawn
         const float ConstructionPartDuration = 10;
 
         public SpaceJunk()
@@ -29,7 +31,7 @@ namespace Ship_Game
         }
 
         public SpaceJunk(UniverseState universe, Vector2 parentPos, Vector2 parentVel,
-                         float maxSize, bool ignite, int constructorId)
+                         float maxSize, bool ignite, int constructorId, Planet tetherPlanet)
         {
             Universe = universe;
             float spawnInRadius = maxSize + 25f;
@@ -37,9 +39,20 @@ namespace Ship_Game
             Position.Y = Universe.Random.Float(parentPos.Y - spawnInRadius, parentPos.Y + spawnInRadius);
             Position.Z = Universe.Random.Float(-spawnInRadius*0.5f, spawnInRadius*0.5f);
             if (constructorId > 0)
+            {
+                if (tetherPlanet != null)
+                {
+                    TetherPlanet = tetherPlanet;
+                    ConstructionOffset = new Vector3(Position.X - tetherPlanet.Position.X,
+                                                     Position.Y - tetherPlanet.Position.Y,
+                                                     Position.Z);
+                }
                 CreateSceneObjectConstruction(parentPos, maxSize, constructorId);
+            }
             else
+            {
                 CreateSceneObject(universe.Screen.Particles, parentPos, maxSize, ignite);
+            }
 
             // inherit extra velocity from parent
             Velocity.X += parentVel.X;
@@ -118,6 +131,7 @@ namespace Ship_Game
                 FlameTrail = particles.Flame.NewEmitter(flameParticles * Scale, Position, scale: Scale * 0.5f);
 
             So = model.CreateSceneObject();
+            So.Visibility = ObjectVisibility.Rendered;
             So.AffineTransform(Position, RotationRadians, Scale);
         }
 
@@ -128,27 +142,28 @@ namespace Ship_Game
 
             int junkIndex = Universe.Random.InRange(ResourceManager.NumJunkModels);
             var model = ResourceManager.GetJunkModel(junkIndex);
-            float meshDiameter = 2f * ResourceManager.GetJunkModelRadius(junkIndex);
+            float meshDiameter = 3f * ResourceManager.GetJunkModelRadius(junkIndex);
 
             // set lower bound to max size, otherwise we can't even see the junk
             float maxAllowedSize = maxSize.LowerBound(8f);
             float scale = (maxAllowedSize / meshDiameter);
             Scale = Universe.Random.Float(0.5f * scale, scale);
             So = model.CreateSceneObject();
+            So.Visibility = ObjectVisibility.Rendered;
             So.AffineTransform(Position, RotationRadians, Scale);
         }
 
 
         public static void ConstructionPart(UniverseState universe, Vector2 position, Vector2 velocity,
-            GameObject source, float maxSize) => SpawnJunk(universe, 1, position, velocity, source, maxSize, 
-                                                    ignite: false, constructorId: source.Id);
-        
+            GameObject source, float maxSize, Planet tetherPlanet) => SpawnJunk(universe, 1, position, velocity, source, maxSize,
+                                                    ignite: false, constructorId: source.Id, tetherPlanet: tetherPlanet);
+
         /**
          * @param spawnRadius Spawned junk is spread around the given radius
          * @param scaleMod Applies additional scale modifier on the spawned junk
          */
         public static void SpawnJunk(UniverseState universe, int howMuchJunk, Vector2 position, Vector2 velocity,
-                                     GameObject source, float maxSize, bool ignite, int constructorId = 0)
+                                     GameObject source, float maxSize, bool ignite, int constructorId = 0, Planet tetherPlanet = null)
         {
             if (universe == null)
             {
@@ -156,7 +171,7 @@ namespace Ship_Game
                 return; // we can't spawn junk while loading the game :'/
             }
 
-            if (universe.JunkList.Count > 800)
+            if (universe.JunkList.Count > 1000)
                 return; // don't allow too much junk
 
             if (!source.IsInFrustum(universe.Screen))
@@ -165,7 +180,7 @@ namespace Ship_Game
             var junk = new SpaceJunk[howMuchJunk];
             for (int i = 0; i < howMuchJunk; i++)
             {
-                junk[i] = new SpaceJunk(universe, position, velocity, maxSize, ignite, constructorId);
+                junk[i] = new SpaceJunk(universe, position, velocity, maxSize, ignite, constructorId, tetherPlanet);
             }
 
             // now add to scene
@@ -180,7 +195,7 @@ namespace Ship_Game
             {
                 lock (this)
                 {
-                    Duration -= ConstructionPartDuration - 1;
+                    Duration -= ConstructionPartDuration - 5;
                 }
             }
         }
@@ -198,7 +213,16 @@ namespace Ship_Game
                 !Universe.Screen.IsInFrustum(Position, 10f))
                 return;
 
-            Position += Velocity * timeStep.FixedTime;
+            if (TetherPlanet != null)
+            {
+                Position.X = TetherPlanet.Position.X + ConstructionOffset.X;
+                Position.Y = TetherPlanet.Position.Y + ConstructionOffset.Y;
+                Position.Z = ConstructionOffset.Z;
+            }
+            else
+            {
+                Position += Velocity * timeStep.FixedTime;
+            }
             RotationRadians += Spin * timeStep.FixedTime;
             So.AffineTransform(Position, RotationRadians, Scale);
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Serialization.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Serialization.cs
@@ -31,6 +31,7 @@ namespace Ship_Game
             UpdateMaxPopulation();
             UpdateIncomes();
             UpdatePlanetShields();
+            UpdateDevelopmentLevel();
         }
     }
 }


### PR DESCRIPTION
## Summary

Five fixes for post-Jupiter 1.60 issues.

### Permanent third-party invasions on AI surrender
`AbsorbEmpire` now launches non-owner troops from absorbed planets, so a third-party invasion that the merger isn't at war with no longer leaves planets stuck in `Invasion` state with idle attackers.
- `Ship_Game/Empire.cs`

### Planet defenses firing one shot after save/load
`Planet.Level` isn't `[StarData]`, so post-load it sits at 0 until the next empire turn. Combined with the Mars 1.51 `ActualFireDelay` formula (which only short-circuits at `planetLevel == 1`), the divide-by-zero clamped fire rate to the raw weapon delay — 3–5x slower than intended. Fixed by recomputing `Level` in `Planet.OnDeserialized` and widening the guard to `planetLevel <= 1`.
- `Ship_Game/Universe/SolarBodies/Planet/Planet_Serialization.cs`
- `Ship_Game/Building.cs`

### Mining/research stations missing their goal after multi-build
Queueing multiple mining/research stations on the same body deployed constructors in the same eval window; `FindGoal` returned the first `WaitForConstructor` goal repeatedly, so later orbitals overwrote `TargetShip` on the same goal and the earlier orbitals were orphaned (no `Mine()`/`Research()`, no supply chain). Predicate tightened to `TargetShip == null && ToBuild.Name == orbital.Name`; `StationToBuild` exposed via the standard `Goal.ToBuild` override on both goal types.
- `Ship_Game/AI/ShipAI/ShipAI.DoAction.cs`
- `Ship_Game/Commands/Goals/MiningOps.cs`
- `Ship_Game/Commands/Goals/ProcessResearchStation.cs`

### Invisible construction junk + drifting parts
Two bugs in one file:
1. `SceneObject.Visibility` was never set after `CreateSceneObject`, so `SunBurnStubs.RenderScene` skipped all junk meshes under the default `None`. Death-junk was masked by its particle trails; construction parts had no trails, so the bug was naked there.
2. Parts inherited the constructor's instantaneous velocity, but the constructor oscillates as it chases the moving build position — so some parts launched off on a chase-frame velocity while others stayed put. Now anchored to `TetherPlanet.Position + spawn-time offset` so they follow planet orbit smoothly; deep-space orbital builds with no planet fall back to velocity drift.

Also bumped `JunkList` cap 800 → 1000.
- `Ship_Game/SpaceJunk.cs`
- `Ship_Game/Ships/ConstructionShip.cs`

### Smooth fade-out on construction complete
Replaced the abrupt duration-cut at completion with a 5s shrink-and-spread fade: `TryReset` flags `IsFading` and resets duration; render scale lerps `Scale → 0` over the window while the spread offset (split from the stable tether-point offset so dispersal is anchored to the orbital, not planet center — matters for gas giants) grows exponentially at 0.2/s (~2.7× over the fade).
- `Ship_Game/SpaceJunk.cs`
