### PR TITLE
Jupiter 1.60 fixes: VFX placement, crash diagnostics, sim cleanups

### DIFF
--- a/Ship_Game/Commands/Goals/ProcessResearchStation.cs
+++ b/Ship_Game/Commands/Goals/ProcessResearchStation.cs
@@ -253,7 +253,10 @@ namespace Ship_Game.Commands.Goals
 
             string bestRefit = Owner.isPlayer && !Owner.AutoPickBestResearchStation
                 ? Owner.data.CurrentResearchStation
-                : Owner.BestResearchStationWeCanBuild.Name;
+                : Owner.BestResearchStationWeCanBuild?.Name;
+
+            if (bestRefit == null)
+                return false;
 
             if (ResearchStation.Name != bestRefit && !Owner.AI.HasGoal(g => g is RefitOrbital && g.OldShip == ResearchStation))
                 betterStation = ResourceManager.Ships.GetDesign(bestRefit);

--- a/Ship_Game/Data/GameContentManager.cs
+++ b/Ship_Game/Data/GameContentManager.cs
@@ -750,7 +750,7 @@ namespace Ship_Game.Data
             return shader;
         }
 
-        public StaticMesh LoadStaticMesh(string meshName, bool animated = false)
+        public StaticMesh LoadStaticMesh(string meshName, bool animated = false, bool extractVertexPositions = false)
         {
             AssetName asset = new(meshName);
             if (TryGetAsset(asset.RelPathWithExt, out StaticMesh mesh))
@@ -783,7 +783,7 @@ namespace Ship_Game.Data
 
             if (RawContentLoader.IsSupportedMesh(loadPath))
             {
-                mesh = RawContent.LoadStaticMesh(loadPath);
+                mesh = RawContent.LoadStaticMesh(loadPath, extractVertexPositions);
             }
             else
             {

--- a/Ship_Game/Data/Mesh/MeshImporter.cs
+++ b/Ship_Game/Data/Mesh/MeshImporter.cs
@@ -24,7 +24,7 @@ namespace Ship_Game.Data.Mesh
         {
         }
 
-        public unsafe StaticMesh ImportStaticMesh(string meshPath, string meshName)
+        public unsafe StaticMesh ImportStaticMesh(string meshPath, string meshName, bool extractVertexPositions = false)
         {
             SdMesh* mesh = null;
             try
@@ -41,7 +41,7 @@ namespace Ship_Game.Data.Mesh
 
                 Log.Info(ConsoleColor.Green,
                     $"StaticMesh {mesh->Name.AsString} | faces:{mesh->NumFaces} | groups:{mesh->NumGroups}");
-                StaticMesh sm = LoadMeshGroups(mesh, meshName);
+                StaticMesh sm = LoadMeshGroups(mesh, meshName, extractVertexPositions);
                 LoadSkinnedAndAnimData(mesh, sm);
                 return sm;
             }
@@ -66,7 +66,7 @@ namespace Ship_Game.Data.Mesh
             return null;
         }
 
-        unsafe StaticMesh LoadMeshGroups(SdMesh* mesh, string modelName)
+        unsafe StaticMesh LoadMeshGroups(SdMesh* mesh, string modelName, bool extractVertexPositions)
         {
             // Phase 3.10.B.6: detect skinning at the mesh level so every group's
             // material effect lands as SkinnedLightingEffect (skin VS) rather
@@ -76,7 +76,7 @@ namespace Ship_Game.Data.Mesh
             Map<long, LightingEffect> materials = GetMaterials(mesh, modelName, isSkinned);
 
             var rawMeshes = new Array<MeshData>();
-            var positions = new Array<Vector3>();
+            var positions = extractVertexPositions ? new Array<Vector3>() : null;
             XnaBoundingBox bounds = default;
 
             for (int i = 0; i < mesh->NumGroups; ++i)
@@ -105,7 +105,8 @@ namespace Ship_Game.Data.Mesh
                     MeshToObject = g->Transform,
                 });
 
-                ExtractObjectSpacePositions(data, g->Transform, positions);
+                if (positions != null)
+                    ExtractObjectSpacePositions(data, g->Transform, positions);
 
                 var bb = XnaBoundingBox.CreateFromSphere(g->Bounds);
                 if (g->Transform != Matrix.Identity)
@@ -119,7 +120,7 @@ namespace Ship_Game.Data.Mesh
             return new StaticMesh(mesh->Name.AsString, bounds)
             {
                 RawMeshes = rawMeshes,
-                VertexPositions = positions.ToArray(),
+                VertexPositions = positions?.ToArray(),
             };
         }
 

--- a/Ship_Game/Data/Mesh/MeshImporter.cs
+++ b/Ship_Game/Data/Mesh/MeshImporter.cs
@@ -76,6 +76,7 @@ namespace Ship_Game.Data.Mesh
             Map<long, LightingEffect> materials = GetMaterials(mesh, modelName, isSkinned);
 
             var rawMeshes = new Array<MeshData>();
+            var positions = new Array<Vector3>();
             XnaBoundingBox bounds = default;
 
             for (int i = 0; i < mesh->NumGroups; ++i)
@@ -104,6 +105,8 @@ namespace Ship_Game.Data.Mesh
                     MeshToObject = g->Transform,
                 });
 
+                ExtractObjectSpacePositions(data, g->Transform, positions);
+
                 var bb = XnaBoundingBox.CreateFromSphere(g->Bounds);
                 if (g->Transform != Matrix.Identity)
                 {
@@ -115,8 +118,39 @@ namespace Ship_Game.Data.Mesh
 
             return new StaticMesh(mesh->Name.AsString, bounds)
             {
-                RawMeshes = rawMeshes
+                RawMeshes = rawMeshes,
+                VertexPositions = positions.ToArray(),
             };
+        }
+
+        // Same MeshToObject transform the renderer applies to vertices, so
+        // collected positions live in the same space as SceneObject bounds.
+        static unsafe void ExtractObjectSpacePositions(SdVertexData data, in Matrix transform, Array<Vector3> dst)
+        {
+            int posOffset = -1;
+            byte posFormat = 0;
+            for (int i = 0; i < data.LayoutCount; ++i)
+            {
+                if (data.Layout[i].NativeUsage == 0) // SDElementUsage::Position
+                {
+                    posOffset = data.Layout[i].Offset;
+                    posFormat = data.Layout[i].NativeFormat;
+                    break;
+                }
+            }
+            if (posOffset < 0 || (posFormat != 2 && posFormat != 3)) // Vector3 / Vector4
+                return;
+
+            bool identity = transform == Matrix.Identity;
+            byte* basePtr = data.VertexData + posOffset;
+            int stride = data.VertexStride;
+            for (int i = 0; i < data.VertexCount; ++i)
+            {
+                var pos = *(Vector3*)(basePtr + i * stride);
+                if (!identity)
+                    pos = Vector3.Transform(pos, transform);
+                dst.Add(pos);
+            }
         }
 
         // Phase 3.10.B.3: pulls SkinnedBones + AnimationClips out of the loaded

--- a/Ship_Game/Data/Mesh/StaticMesh.cs
+++ b/Ship_Game/Data/Mesh/StaticMesh.cs
@@ -74,12 +74,12 @@ public sealed class StaticMesh : IDisposable
     /// Loads a cached StaticMesh from GameContentManager.
     /// </summary>
     /// <returns>`null` on failure, otherwise a valid StaticMesh</returns>
-    public static StaticMesh LoadMesh(GameContentManager content, string modelName, bool animated = false)
+    public static StaticMesh LoadMesh(GameContentManager content, string modelName, bool animated = false, bool extractVertexPositions = false)
     {
         try
         {
             var c = content ?? ResourceManager.RootContent;
-            return c.LoadStaticMesh(modelName, animated);
+            return c.LoadStaticMesh(modelName, animated, extractVertexPositions);
         }
         catch (Exception e)
         {

--- a/Ship_Game/Data/Mesh/StaticMesh.cs
+++ b/Ship_Game/Data/Mesh/StaticMesh.cs
@@ -35,6 +35,10 @@ public sealed class StaticMesh : IDisposable
     public AnimationClipData[] AnimationClips;
     public bool IsSkinned => SkinnedBones != null && SkinnedBones.Length > 0;
 
+    // Object-space, concatenated across groups; consumed by ShipHull
+    // to build a per-module surface-Z map for damage-VFX placement.
+    public XnaVector3[] VertexPositions;
+
     public StaticMesh(string name, in BoundingBox bounds)
     {
         Name = name;

--- a/Ship_Game/Data/RawContentLoader.cs
+++ b/Ship_Game/Data/RawContentLoader.cs
@@ -120,10 +120,10 @@ namespace Ship_Game.Data
 
         ///////////////////////////////////////////////////
 
-        public StaticMesh LoadStaticMesh(string meshName)
+        public StaticMesh LoadStaticMesh(string meshName, bool extractVertexPositions = false)
         {
             string meshPath = GetContentPath(meshName);
-            return MeshImport.ImportStaticMesh(meshPath, meshName);
+            return MeshImport.ImportStaticMesh(meshPath, meshName, extractVertexPositions);
         }
 
         public Model LoadModel(string meshName)

--- a/Ship_Game/Data/Texture/TextureImporter.cs
+++ b/Ship_Game/Data/Texture/TextureImporter.cs
@@ -60,10 +60,20 @@ namespace Ship_Game.Data.Texture
         Texture2D ImageUtilsPNG_XnaDDS(string fullPath)
         {
             if (fullPath.EndsWith(".png", StringComparison.OrdinalIgnoreCase))
-                return ImageUtils.LoadPng(Device, fullPath);
+            {
+                // ParticleEffect.fx uses straight-alpha blend per system (Particles.yaml);
+                // premul-at-load would square the alpha at composite and crush tinted RGB.
+                bool premultiply = !IsParticleTexturePath(fullPath);
+                return ImageUtils.LoadPng(Device, fullPath, premultiplyAlpha: premultiply);
+            }
             if (fullPath.EndsWith(".dds", StringComparison.OrdinalIgnoreCase))
                 return ImageUtils.LoadDds(Device, fullPath);
             return LoadXna(fullPath);
+        }
+
+        static bool IsParticleTexturePath(string fullPath)
+        {
+            return fullPath.IndexOf("3DParticles", StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         // Converts a AlphaOnly byte[] into a 1:1 aspect ratio RGBA texture

--- a/Ship_Game/GameScreens/ScreenManager.cs
+++ b/Ship_Game/GameScreens/ScreenManager.cs
@@ -101,7 +101,59 @@ namespace Ship_Game
 
         void GraphicsDevice_DeviceLost(object sender, EventArgs e)
         {
-            Log.Write(ConsoleColor.Green, "GraphicsDevice Lost");
+            string reason = TryGetDeviceRemovedReason(GraphicsDevice);
+            Log.Write(ConsoleColor.Green, reason != null
+                ? $"GraphicsDevice Lost [DeviceRemovedReason: {reason}]"
+                : "GraphicsDevice Lost");
+        }
+
+        // DXGI device-removed diagnostic. Reflectively pulls the MonoGame WindowsDX
+        // backend's internal SharpDX D3D11 device and queries DeviceRemovedReason,
+        // which is the call MS explicitly directs us to in the
+        // "GPU device instance has been suspended" message. Returns null if any
+        // step fails so callers can fall back to the original message.
+        static string TryGetDeviceRemovedReason(GraphicsDevice gd)
+        {
+            try
+            {
+                var fld = typeof(GraphicsDevice).GetField("_d3dDevice",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+                object d3dDevice = fld?.GetValue(gd);
+                if (d3dDevice == null) return null;
+                object result = d3dDevice.GetType().GetProperty("DeviceRemovedReason")?.GetValue(d3dDevice);
+                if (result == null) return null;
+                object codeObj = result.GetType().GetProperty("Code")?.GetValue(result);
+                if (codeObj is not int code) return result.ToString();
+                return $"{DecodeDxgiHResult(code)} (0x{code:X8})";
+            }
+            catch (Exception ex)
+            {
+                return $"(query failed: {ex.GetType().Name})";
+            }
+        }
+
+        static string DecodeDxgiHResult(int hr) => (uint)hr switch
+        {
+            0x00000000 => "S_OK",
+            0x887A0001 => "DXGI_ERROR_INVALID_CALL",
+            0x887A0002 => "DXGI_ERROR_NOT_FOUND",
+            0x887A0005 => "DXGI_ERROR_DEVICE_REMOVED",
+            0x887A0006 => "DXGI_ERROR_DEVICE_HUNG",
+            0x887A0007 => "DXGI_ERROR_DEVICE_RESET",
+            0x887A000A => "DXGI_ERROR_WAS_STILL_DRAWING",
+            0x887A0020 => "DXGI_ERROR_DRIVER_INTERNAL_ERROR",
+            0x887A0026 => "DXGI_ERROR_ACCESS_LOST",
+            0x887A0027 => "DXGI_ERROR_ACCESS_DENIED",
+            0x80070057 => "E_INVALIDARG",
+            0x8007000E => "E_OUTOFMEMORY",
+            _ => "UNKNOWN_HRESULT"
+        };
+
+        static bool IsDxgiDeviceRemovedHResult(int hr)
+        {
+            uint u = (uint)hr;
+            return u == 0x887A0005 || u == 0x887A0006 || u == 0x887A0007
+                || u == 0x887A0020 || u == 0x887A0026 || u == 0x887A0027;
         }
 
         void GraphicsDevice_Disposing(object sender, EventArgs e)
@@ -401,10 +453,13 @@ namespace Ship_Game
                     }
                     catch (Exception e)
                     {
-                        Log.Error(e, $"Draw Screen failed: {screen.GetType().GetTypeName()}");
+                        string extra = IsDxgiDeviceRemovedHResult(e.HResult)
+                            ? $" [DeviceRemovedReason: {TryGetDeviceRemovedReason(GraphicsDevice) ?? "(unavailable)"}]"
+                            : "";
+                        Log.Error(e, $"Draw Screen failed: {screen.GetType().GetTypeName()}{extra}");
                         if (!batch.SafeEnd())
                         {
-                            Log.Error("Draw Screen fatal error: batch end failed"); 
+                            Log.Error("Draw Screen fatal error: batch end failed");
                             screen.Dispose();
                             GameScreens.Remove(screen);
                         }

--- a/Ship_Game/GameScreens/StarDriveGame.cs
+++ b/Ship_Game/GameScreens/StarDriveGame.cs
@@ -198,13 +198,12 @@ namespace Ship_Game
                     // target without try/finally cleanup. If any of them throws or skips its
                     // SetRenderTarget(null), MonoGame crashes Present with
                     // "Cannot call Present when a render target is active." Restore the back
-                    // buffer unconditionally as a safety net. The underlying leak should still
-                    // be tracked and fixed; this just stops it from taking the game down.
-                    // Inner try/catch: if the original draw threw because the device was lost or
-                    // disposed, this cleanup call can throw too — swallow it so we don't mask the
-                    // real exception bubbling out of the outer try.
-                    try { ScreenManager?.GraphicsDevice?.SetRenderTarget(null); }
-                    catch { /* device lost/disposed; let the original exception propagate */ }
+                    // buffer unconditionally as a safety net. Use Game.GraphicsDevice (live),
+                    // not ScreenManager's cached field which can be a disposed device after
+                    // reset. Catch swallows cleanup throws so the original exception (if any)
+                    // propagates instead of being masked.
+                    try { GraphicsDevice?.SetRenderTarget(null); }
+                    catch { }
                 }
                 string topScreen = ScreenManager.NumScreens > 0
                     ? ScreenManager.Current?.GetType().Name ?? ""

--- a/Ship_Game/Graphics/Particles/ParticleEmitter.cs
+++ b/Ship_Game/Graphics/Particles/ParticleEmitter.cs
@@ -43,9 +43,10 @@ namespace Ship_Game
         {
             if (elapsedTime > 0f)
             {
-                Vector3 velocity = newPosition - PreviousPosition;
+                // zVelocity is in units/sec — assign AFTER the divide so it isn't
+                // scaled by 1/dt (was a framerate-dependent ~60x speed-up at 60fps).
+                Vector3 velocity = (newPosition - PreviousPosition) / elapsedTime;
                 velocity.Z = zVelocity;
-                velocity /= elapsedTime;
                 float timeToSpend = TimeLeftOver + elapsedTime;
                 float currentTime = -TimeLeftOver;
                 while (timeToSpend > TimeBetweenParticles)

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -1201,7 +1201,7 @@ namespace Ship_Game.Ships
             AI.ScanForTargets(timeStep);
         }
 
-        public void UpdateModulePositions(FixedSimTime timeStep, bool isSystemView, bool forceUpdate = false)
+        public void UpdateModulePositions(FixedSimTime timeStep, bool forceUpdate = false)
         {
             bool visible = IsVisibleToPlayer;
             if (Active && (AI.BadGuysNear || visible || forceUpdate))
@@ -1221,14 +1221,15 @@ namespace Ship_Game.Ships
                 if (Active)
                 {
                     bool enableVisualizeDamage = PlanetCrash == null;
+                    bool visibleForVisuals = visible && Universe.IsPlanetViewOrCloser;
                     for (int i = 0; i < ModuleSlotList.Length; ++i)
                     {
                         ShipModule m = ModuleSlotList[i];
                         m.UpdateEveryFrame(a);
                         if (enableVisualizeDamage && m.CanVisualizeDamage)
-                            m.UpdateDamageVisualization(timeStep, a.ParentScale, visible);
+                            m.UpdateDamageVisualization(timeStep, a.ParentScale, visibleForVisuals);
 
-                        if (visible && IsMiningStation)
+                        if (visibleForVisuals && IsMiningStation)
                             Carrier.MiningBays.UpdateMiningVisuals(timeStep);
                     }
                 }

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -1211,8 +1211,6 @@ namespace Ship_Game.Ships
                     TimeStep = timeStep,
                     ParentX = Position.X,
                     ParentY = Position.Y,
-                    // TODO: Figure out a more accurate, yet FAST way to approximate hull height
-                    ParentZ = BaseHull.ModelZ.Clamped(0, 200) * -1f,
                     ParentRotation = Rotation,
                     ParentScale = PlanetCrash?.Scale ?? 1f,
                     Cos = RadMath.Cos(Rotation),

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -1228,10 +1228,13 @@ namespace Ship_Game.Ships
                         m.UpdateEveryFrame(a);
                         if (enableVisualizeDamage && m.CanVisualizeDamage)
                             m.UpdateDamageVisualization(timeStep, a.ParentScale, visibleForVisuals);
-
-                        if (visibleForVisuals && IsMiningStation)
-                            Carrier.MiningBays.UpdateMiningVisuals(timeStep);
                     }
+
+                    // Mining visuals are per-ship, not per-module — UpdateMiningVisuals
+                    // iterates every bay internally, so calling it inside the module loop
+                    // made it O(modules × bays).
+                    if (visibleForVisuals && IsMiningStation)
+                        Carrier.MiningBays.UpdateMiningVisuals(timeStep);
                 }
                 else
                 {

--- a/Ship_Game/Ships/ShipHull.cs
+++ b/Ship_Game/Ships/ShipHull.cs
@@ -14,6 +14,7 @@ using Vector2 = SDGraphics.Vector2;
 using Vector3 = SDGraphics.Vector3;
 using Point = SDGraphics.Point;
 using Vector4 = SDGraphics.Vector4;
+using XnaVector3 = Microsoft.Xna.Framework.Vector3;
 
 namespace Ship_Game.Ships
 {
@@ -115,8 +116,10 @@ namespace Ship_Game.Ships
             shipSO = null;
             lock (HullSlots)
             {
-                // The mesh is cached by content manager
-                StaticMesh mesh = StaticMesh.LoadMesh(content, ModelPath, Animated);
+                // The mesh is cached by content manager. extractVertexPositions
+                // only pays the per-vertex copy on hull loads — planets / asteroids /
+                // projectile meshes skip it.
+                StaticMesh mesh = StaticMesh.LoadMesh(content, ModelPath, Animated, extractVertexPositions: true);
                 if (mesh == null)
                     return false;
 
@@ -132,7 +135,15 @@ namespace Ship_Game.Ships
                 }
 
                 if (SurfaceMap == null)
-                    BuildSurfaceMap(mesh);
+                {
+                    // Claim the positions array into a local before any other thread
+                    // that shares this cached StaticMesh can null it — protects
+                    // BuildSurfaceMap's read from racing the post-build cleanup.
+                    var positions = mesh.VertexPositions;
+                    mesh.VertexPositions = null;
+                    if (positions != null)
+                        BuildSurfaceMap(positions);
+                }
                 return true;
             }
         }
@@ -142,10 +153,9 @@ namespace Ship_Game.Ships
         // (vx, vy, vz) sits at world XY (vx+MeshOffset.X, vy+MeshOffset.Y) when
         // the ship is at origin, and ShipModule.LocalCenter recenters world XY
         // on hull.GridCenter at 16 units per cell.
-        void BuildSurfaceMap(StaticMesh mesh)
+        void BuildSurfaceMap(XnaVector3[] positions)
         {
-            var positions = mesh.VertexPositions;
-            if (positions == null || positions.Length == 0 || Size.X <= 0 || Size.Y <= 0)
+            if (positions.Length == 0 || Size.X <= 0 || Size.Y <= 0)
                 return;
 
             int w = Size.X, h = Size.Y;

--- a/Ship_Game/Ships/ShipHull.cs
+++ b/Ship_Game/Ships/ShipHull.cs
@@ -66,6 +66,15 @@ namespace Ship_Game.Ships
         public HullBonus Bonuses { get; private set; }
         public bool IsValidForCurrentMod => GlobalStats.IsValidForCurrentMod(ModName);
 
+        // Per-grid-cell most-negative mesh Z (the hull surface facing the
+        // camera). NaN cells = no vertex sampled. Populated lazily on first
+        // LoadModel; null until the mesh is in memory.
+        float[,] SurfaceMap;
+
+        // Lift VFX slightly toward the camera so emitters sit just above the
+        // deck instead of co-planar with the mesh surface.
+        const float SurfaceLift = -2f;
+
         public override string ToString() => $"ShipHull={HullName} Source={Source?.FullName} Model={ModelPath}";
 
         public struct ThrusterZone
@@ -121,8 +130,66 @@ namespace Ship_Game.Ships
                     Volume = new Vector3(mesh.Bounds.Max - mesh.Bounds.Min);
                     ModelZ = Volume.Z;
                 }
+
+                if (SurfaceMap == null)
+                    BuildSurfaceMap(mesh);
                 return true;
             }
+        }
+
+        // Bins mesh vertices into module-grid cells, keeping the most-negative
+        // Z (camera-facing surface) per cell. Mapping: a vertex at object-space
+        // (vx, vy, vz) sits at world XY (vx+MeshOffset.X, vy+MeshOffset.Y) when
+        // the ship is at origin, and ShipModule.LocalCenter recenters world XY
+        // on hull.GridCenter at 16 units per cell.
+        void BuildSurfaceMap(StaticMesh mesh)
+        {
+            var positions = mesh.VertexPositions;
+            if (positions == null || positions.Length == 0 || Size.X <= 0 || Size.Y <= 0)
+                return;
+
+            int w = Size.X, h = Size.Y;
+            var map = new float[w, h];
+            for (int y = 0; y < h; ++y)
+                for (int x = 0; x < w; ++x)
+                    map[x, y] = float.NaN;
+
+            for (int i = 0; i < positions.Length; ++i)
+            {
+                var v = positions[i];
+                int gx = (int)Math.Floor((v.X + MeshOffset.X) / 16f) + GridCenter.X;
+                int gy = (int)Math.Floor((v.Y + MeshOffset.Y) / 16f) + GridCenter.Y;
+                if ((uint)gx >= (uint)w || (uint)gy >= (uint)h)
+                    continue;
+
+                float current = map[gx, gy];
+                if (float.IsNaN(current) || v.Z < current)
+                    map[gx, gy] = v.Z;
+            }
+
+            SurfaceMap = map;
+        }
+
+        // Most-negative Z under the module's footprint, plus SurfaceLift. Falls
+        // back to 0 (play-plane) for empty cells and for hulls whose mesh hasn't
+        // loaded yet — SurfaceLift is applied either way for consistency.
+        public float SampleSurfaceZ(Point pos, int xSize, int ySize)
+        {
+            float[,] map = SurfaceMap;
+            if (map == null) return SurfaceLift;
+
+            int w = map.GetLength(0), h = map.GetLength(1);
+            float best = float.NaN;
+            for (int dy = 0; dy < ySize; ++dy)
+                for (int dx = 0; dx < xSize; ++dx)
+                {
+                    int gx = pos.X + dx, gy = pos.Y + dy;
+                    if ((uint)gx >= (uint)w || (uint)gy >= (uint)h) continue;
+                    float z = map[gx, gy];
+                    if (!float.IsNaN(z) && (float.IsNaN(best) || z < best))
+                        best = z;
+                }
+            return (float.IsNaN(best) ? 0f : best) + SurfaceLift;
         }
 
         public ShipHull()

--- a/Ship_Game/Ships/ShipModule.cs
+++ b/Ship_Game/Ships/ShipModule.cs
@@ -59,6 +59,11 @@ namespace Ship_Game.Ships
         float ZPos;
         public Vector3 Center3D => new(Position, ZPos);
 
+        // Sampled from the hull's mesh-surface map at InstallModule time and
+        // refreshed once after the mesh actually loads (Ship.RefreshHullSurfaceZ).
+        // Includes ShipHull.SurfaceLift so the runtime formula stays a single sub.
+        public float HullSurfaceZ;
+
         public int Area => XSize * YSize;
 
         public bool CanVisualizeDamage;
@@ -505,6 +510,10 @@ namespace Ship_Game.Ships
                 Position = LocalCenter;
                 if (parent != null)
                     Position += parent.Position;
+
+                // Returns SurfaceLift until the mesh loads; Ship.RefreshHullSurfaceZ
+                // overwrites with the real sample once the surface map exists.
+                HullSurfaceZ = hull.SampleSurfaceZ(gridPos, XSize, YSize);
             }
 
             if (IsWeaponOrBomb)
@@ -629,7 +638,6 @@ namespace Ship_Game.Ships
             public FixedSimTime TimeStep;
             public float ParentX;
             public float ParentY;
-            public float ParentZ;
             public float ParentRotation;
             public float ParentScale;
             public float Cos;
@@ -645,7 +653,7 @@ namespace Ship_Game.Ships
             float cy = a.ParentY + offset.X * a.Sin + offset.Y * a.Cos;
             Position.X = cx;
             Position.Y = cy;
-            ZPos = a.ParentZ - a.Tan * offset.X;
+            ZPos = HullSurfaceZ - a.Tan * offset.X;
             Rotation = a.ParentRotation; // assume parent rotation is already normalized
         }
 

--- a/Ship_Game/Ships/ShipModuleDamageVisualization.cs
+++ b/Ship_Game/Ships/ShipModuleDamageVisualization.cs
@@ -27,15 +27,15 @@ namespace Ship_Game.Ships
 
             switch (type) // FB: other special effects based on some module types, use main moduletypes for performance sake
             {
-                case ShipModuleType.Shield: Lightning = p.Lightning.NewEmitter(4, center, 0.1f*area); break;
-                case ShipModuleType.PowerPlant: Lightning = p.PhotonExplosion.NewEmitter(area, center, 0.25f); break;
-                case ShipModuleType.PowerConduit: Lightning = p.Sparks.NewEmitter(12, center); return; // no other effects!
+                case ShipModuleType.Shield: Lightning = p.Lightning.NewEmitter(40, center, 0.1f*area); break;
+                case ShipModuleType.PowerPlant: Lightning = p.PhotonExplosion.NewEmitter(area * 6f, center, 0.25f); break;
+                case ShipModuleType.PowerConduit: Lightning = p.Sparks.NewEmitter(25, center); return; // no other effects!
             }
 
-            Dust = p.SmokePlume.NewEmitter(0.5f, center);
+            Dust = p.SmokePlume.NewEmitter(area * 0.7f, center);
 
             bool smokeOnly = p.Random.Int(0, 1) == 1;
-            Smoke = p.ExplosionSmoke.NewEmitter(0.5f, center);
+            Smoke = p.ExplosionSmoke.NewEmitter(area * 3f, center);
 
             // armor doesnt produce flames
             if (!smokeOnly && type != ShipModuleType.Armor)
@@ -46,17 +46,18 @@ namespace Ship_Game.Ships
             }
         }
 
-        // This is called when module is OnFire /or/ completely dead
+        // This is called when module is OnFire /or/ completely dead.
+        // zVelocity is in units/sec; small values keep VFX anchored to the hull.
         public void Update(FixedSimTime timeStep, in Vector3 center, float scale, bool isAlive)
         {
-            Lightning?.Update(timeStep.FixedTime, center, zVelocity: -4f, scale: scale);
-            Flame?.Update(timeStep.FixedTime, center, zVelocity: -4f, scale: scale);
+            Lightning?.Update(timeStep.FixedTime, center, zVelocity: -5f, scale: scale);
+            Flame?.Update(timeStep.FixedTime, center, zVelocity: -5f, scale: scale);
 
             // only spawn smoke from dead modules
             if (!isAlive)
             {
-                Dust?.Update(timeStep.FixedTime, center, zVelocity: -0.1f, scale: scale);
-                Smoke?.Update(timeStep.FixedTime, center, zVelocity: -2f, scale: scale);
+                Dust?.Update(timeStep.FixedTime, center, zVelocity: -0.5f, scale: scale);
+                Smoke?.Update(timeStep.FixedTime, center, zVelocity: -3f, scale: scale);
             }
         }
     }

--- a/Ship_Game/Ships/Ship_Initialize.cs
+++ b/Ship_Game/Ships/Ship_Initialize.cs
@@ -452,7 +452,7 @@ namespace Ship_Game.Ships
                 InitializeStatus(fromSave: false);
             }
 
-            UpdateModulePositions(FixedSimTime.Zero, isSystemView: false, forceUpdate: true);
+            UpdateModulePositions(FixedSimTime.Zero, forceUpdate: true);
         }
 
         void InitDefendingTroopStrength()

--- a/Ship_Game/Ships/Ship_Update.cs
+++ b/Ship_Game/Ships/Ship_Update.cs
@@ -54,12 +54,34 @@ namespace Ship_Game.Ships
             if (!ShipData.LoadModel(out ShipSO, Universe.Screen.ContentManager))
                 return; // loading Ship SO failed
 
+            // Modules installed before the mesh loaded got a SurfaceLift fallback;
+            // snap each to its real hull-Z on first SO creation. Skip on later
+            // re-creates (ships re-enter the frustum after the 15s timer pruned
+            // their SO — values are already cached).
+            if (!HullSurfaceZRefreshed)
+            {
+                RefreshHullSurfaceZ();
+                HullSurfaceZRefreshed = true;
+            }
+
             if (!IsLaunching) // launch update will create the SO to avoid flickering
                 ShipSO.World = Matrix.CreateTranslation(new(Position + ShipData.BaseHull.MeshOffset, 0f));
 
             NotVisibleToPlayerTimer = 0;
             UpdateVisibilityToPlayer(FixedSimTime.Zero, forceVisible: true);
             ScreenManager.Instance.AddObject(ShipSO);
+        }
+
+        bool HullSurfaceZRefreshed;
+
+        void RefreshHullSurfaceZ()
+        {
+            ShipHull hull = ShipData.BaseHull;
+            for (int i = 0; i < ModuleSlotList.Length; ++i)
+            {
+                ShipModule m = ModuleSlotList[i];
+                m.HullSurfaceZ = hull.SampleSurfaceZ(m.Pos, m.XSize, m.YSize);
+            }
         }
 
         public void RemoveSceneObject()

--- a/Ship_Game/Spatial/Qtree.PerfTests.cs
+++ b/Ship_Game/Spatial/Qtree.PerfTests.cs
@@ -61,7 +61,7 @@ namespace Ship_Game.Spatial
         {
             var target = Ship.CreateShipAtPoint(null, name, loyalty, pos);
             target.Rotation = dir.Normalized().ToRadians();
-            target.UpdateModulePositions(new FixedSimTime(0.01f), true, forceUpdate: true);
+            target.UpdateModulePositions(new FixedSimTime(0.01f), forceUpdate: true);
             return target;
         }
 

--- a/Ship_Game/Thruster.cs
+++ b/Ship_Game/Thruster.cs
@@ -133,9 +133,15 @@ namespace Ship_Game
         {
             Vector2 dir2d = fwd.ToVec2();
             Vector2 right = dir2d.RightVector();
-            float zPos = thrusterPos.Z + (float)Math.Sin(yRotation) * -thrusterPos.X;
-            Vector2 pos = center - dir2d*thrusterPos.Y + right*thrusterPos.X;
-            return new Vector3(pos, zPos+deltaZ);
+            // Full RotateY(yRotation) on (X, _, Z) — matches the ship mesh
+            // transform in Ship_Update.cs. Without the Z*sin cross-term, back-
+            // of-deck thrusters (Z>0) drift the wrong way during bank turns.
+            float cosY = (float)Math.Cos(yRotation);
+            float sinY = (float)Math.Sin(yRotation);
+            float bankedX = thrusterPos.X*cosY + thrusterPos.Z*sinY;
+            float bankedZ = thrusterPos.Z*cosY - thrusterPos.X*sinY;
+            Vector2 pos = center - dir2d*thrusterPos.Y + right*bankedX;
+            return new Vector3(pos, bankedZ+deltaZ);
         }
 
         // 3D position calc is a bit different

--- a/Ship_Game/Universe/UniverseScreen/UniverseObjectManager.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseObjectManager.cs
@@ -377,7 +377,6 @@ namespace Ship_Game
         {
             ShipsPerf.Start();
 
-            bool isSystemView = UState.IsSystemViewOrCloser;
             Ship[] allShips = Ships.GetItems();
 
             void UpdateShips(int start, int end)
@@ -387,7 +386,7 @@ namespace Ship_Game
                 {
                     Ship ship = allShips[i];
                     ship.Update(timeStep);
-                    ship.UpdateModulePositions(timeStep, isSystemView);
+                    ship.UpdateModulePositions(timeStep);
                     // make sure dying ships can be seen. and show all ships in DEBUG
                     if ((ship.Loyalty.AlliedWithPlayer ||
                         ship.Dying && ship.KnownByEmpires.KnownByPlayer(UState))

--- a/UnitTests/Ships/ShipModuleGridTests.cs
+++ b/UnitTests/Ships/ShipModuleGridTests.cs
@@ -127,7 +127,7 @@ namespace UnitTests.Ships
             AssertEqual(4, ship.GridWidth);
             
             ship.RotationDegrees = -90; // facing towards left
-            ship.UpdateModulePositions(TestSimStep, true, forceUpdate:true);
+            ship.UpdateModulePositions(TestSimStep, forceUpdate:true);
 
             // pick a 1x1 module which should be at [0,2]
             AssertEqual(Pos(1,1), ship.GetModuleAt(0,2).GetSize());
@@ -165,7 +165,7 @@ namespace UnitTests.Ships
             AssertEqual(4, ship.GridWidth);
 
             ship.RotationDegrees = 180; // facing towards down
-            ship.UpdateModulePositions(TestSimStep, true, forceUpdate:true);
+            ship.UpdateModulePositions(TestSimStep, forceUpdate:true);
 
             // pick a 1x1 module which should be at [0,2]
             AssertEqual(Pos(1,1), ship.GetModuleAt(0,2).GetSize());

--- a/UnitTests/StarDriveTest.cs
+++ b/UnitTests/StarDriveTest.cs
@@ -332,7 +332,7 @@ public partial class StarDriveTest : IDisposable
         UState?.AddShip(ship);
         ship.Rotation = shipDirection.Normalized().ToRadians();
         ship.UpdateShipStatus(new FixedSimTime(0.01f)); // update module pos
-        ship.UpdateModulePositions(new FixedSimTime(0.01f), true, forceUpdate: true);
+        ship.UpdateModulePositions(new FixedSimTime(0.01f), forceUpdate: true);
         ship.System = null;
         AssertTrue(ship.Active, "Spawned ship is Inactive! This is a bug in Status update!");
 

--- a/UnitTests/Universe/SpatialVisualization.cs
+++ b/UnitTests/Universe/SpatialVisualization.cs
@@ -99,7 +99,7 @@ class SpatialVisualization : CommonVisualization
                 if (go is Ship ship)
                 {
                     ship.IntegratePosVelocityVerlet(fixedDeltaTime, Vector2.Zero);
-                    ship.UpdateModulePositions(simTime, true);
+                    ship.UpdateModulePositions(simTime);
                 }
                 else if (go is Projectile p && p.Active)
                 {

--- a/UnitTests/Universe/TestSpatialCommon.cs
+++ b/UnitTests/Universe/TestSpatialCommon.cs
@@ -235,7 +235,7 @@ namespace UnitTests.Universe
                 foreach (Ship ship in AllObjects)
                 {
                     ship.Position.X += 10f;
-                    ship.UpdateModulePositions(TestSimStep, true, forceUpdate: true);
+                    ship.UpdateModulePositions(TestSimStep, forceUpdate: true);
                 }
                 var t = new PerfTimer();
                 tree.UpdateAll(AllObjects);
@@ -306,7 +306,7 @@ namespace UnitTests.Universe
                         if (allObjects[i] is Ship ship)
                         {
                             ship.Position.X += 10f;
-                            ship.UpdateModulePositions(TestSimStep, true, forceUpdate: true);
+                            ship.UpdateModulePositions(TestSimStep, forceUpdate: true);
 
                             if (rand.RollDice(percent:10) && !spawned.Contains(ship))
                             {
@@ -410,7 +410,7 @@ namespace UnitTests.Universe
                     if (go is Ship s)
                     {
                         s.UpdateVelocityAndPosition(TestSimStep.FixedTime, Vector2.Zero, isZeroAcc:true);
-                        s.UpdateModulePositions(TestSimStep, true);
+                        s.UpdateModulePositions(TestSimStep);
                     }
                     else if (go is Projectile p)
                     {


### PR DESCRIPTION
## Summary

Mixed bag of fixes from a paired session on `jupiter-1.60/fixes_10`. Grouped roughly by area:

**Crash diagnostics / hardening**
- `13b406694` ScreenManager: capture DXGI `DeviceRemovedReason` on device-removed crashes so the next user report includes the actual HRESULT instead of a bare `0x887A0005`.
- `bc4dcc9fd` ProcessResearchStation: null-guard `BestResearchStationWeCanBuild` in the refit check (ProcessTurns NRE seen in the wild).
- `2581c357c` StarDriveGame: route the post-Draw RT safety net through the live `Game.GraphicsDevice` rather than the cached `ScreenManager.GraphicsDevice` (kills a "Cannot call Present when a render target is active" path after device resets).

**Particle / damage-VFX accuracy** (the big visible chunk)
- `b07f1a1e4` ParticleEmitter: move `velocity.Z = zVelocity` after the `/= elapsedTime` divide — the prior order made Z drift framerate-dependent and ~60× too fast at 60fps. Restores the damage-visualization emission rates and zVelocity constants that `78b8a462d` had nerfed to compensate for this bug.
- `828f14af9` TextureImporter: skip premul-at-load for `3DParticles/` PNG paths so straight-alpha-blend systems (`SrcDstBlend: [SourceAlpha, InverseSourceAlpha]`) don't square their alpha at composite. SmokePlume / ModuleSmoke now read brown/gray instead of black.
- `204e216f9` + `3403523ae` + `76ed1979c` Per-module hull-surface Z: extract object-space vertex positions at mesh import, bin them into a per-cell Z heightmap on `ShipHull`, sample once per module at install/SO-creation, drop the whole-ship `ParentZ = -ModelZ.Clamped(0,200)` and switch the hot loop to `ZPos = HullSurfaceZ - Tan*offset.X`. Damage VFX now emit at the actual mesh surface under each module instead of clamping to the tallest point of the hull.
- `80d8b33dc` Thruster: replace partial Z formula with the full row-vector `RotateY(YRotation)` cross-coupling (`bankedX = X*cosY + Z*sinY`, `bankedZ = Z*cosY - X*sinY`). Thrusters with non-zero hull-local Z (e.g. Catfish front-pair at Z=-80, back-pair at Z=+100) were drifting the wrong way during bank turns because the Z*sin term was missing from X. Matches the ship mesh transform exactly.

**Sim-thread cleanup**
- `35ee6d991` Ship.UpdateModulePositions: drop the dead `isSystemView` parameter (declared but never read inside the method) — sweeps the signature + 9 call sites including the unit tests. While there, tighten the damage-VFX / mining-bay visual gate from SystemView to PlanetView via a local `visibleForVisuals = visible && IsPlanetViewOrCloser`. The outer module-update gate stays at SystemView so AI / targeting still see fresh module positions at zoomed-out views.

## Test plan

- [ ] Smoke-test a save load: ships visible at SystemView still update module positions; damage emitters only spawn at PlanetView and closer.
- [ ] Bank-turn a couple of large hulls (Catfish, Battleship): thruster glows stay on the engine pods through the turn (no lateral drift, no back-thruster swing-opposite).
- [ ] Damage a module on a tall-finned hull and a flat-decked hull: smoke/fire emits at the actual mesh surface, not clamped to one whole-ship Z.
- [ ] Smoke + module-smoke render as brown / gray (not black) on burning modules.
- [ ] Zoom in/out across SystemView / PlanetView boundary repeatedly to confirm the new visibility gate doesn't leak emitters or stutter when ships re-enter the frustum after the 15s SO-pruning timer.
- [ ] Confirm crash diagnostics: trigger a graphics device removed event if possible, or just confirm `ScreenManager` logs the decoded HRESULT.
- [ ] UnitTests pass (the dead-parameter sweep touched 7 test files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)