### PR TITLE
Jupiter 1.60 fixes 11: espionage, lighting, UI legibility, alt-tab, troop atlas

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+[assembly: InternalsVisibleTo("UnitTests")]
 [assembly: AssemblyCompany("Zero Sum Games")]
 [assembly: AssemblyCopyright("Copyright � Zero Sum Games 2022")]
 [assembly: AssemblyDescription("")]

--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -4693,6 +4693,8 @@ namespace Ship_Game
         SpiralMagellanicGalaxyGame = 4532,
         /// <summary>Most empires start in the off-center bulge; the rest along the single asymmetric arm</summary>
         SpiralMagellanicGalaxyGameTip = 4533,
+        /// <summary>Total credits leeched lifetime; per-turn amount is on the Budget screen.</summary>
+        EspionageTotalMoneyLeechedTip = 4534,
 
 
 

--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -4695,6 +4695,8 @@ namespace Ship_Game
         SpiralMagellanicGalaxyGameTip = 4533,
         /// <summary>Total credits leeched lifetime; per-turn amount is on the Budget screen.</summary>
         EspionageTotalMoneyLeechedTip = 4534,
+        /// <summary>Research output is being slowed by enemy infiltration this turn.</summary>
+        ResearchDisruptedByInfiltrationTip = 4535,
 
 
 

--- a/Ship_Game/Data/Mesh/LightingEffectBinder.cs
+++ b/Ship_Game/Data/Mesh/LightingEffectBinder.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework.Graphics;
 using SDUtils;
 using SynapseGaming.LightingSystem.Core;
 using SynapseGaming.LightingSystem.Effects.Forward;
+using SynapseGaming.LightingSystem.Rendering;
 using SunBurnLights = SynapseGaming.LightingSystem.Lights;
 using XnaDirectionalLight = Microsoft.Xna.Framework.Graphics.DirectionalLight;
 
@@ -105,7 +106,16 @@ public static class LightingEffectBinder
                         ambient += a.DiffuseColor * a.Intensity;
                         break;
 
-                    case SunBurnLights.PointLight p when p.Enabled && p.Radius >= 1000f && p.Radius < 1_000_000f:
+                    // ObjectType.Static filter: warp/station explosions can have
+                    // Radius >= 1000 and sit at the camera XY, which would
+                    // otherwise displace the actual system sun (far in XY)
+                    // from `bestSun`. Sun-rig lights are tagged Static in
+                    // UniverseScreen.AddLight; explosion/projectile lights
+                    // are tagged Dynamic. Big-battle regression: hulls beyond
+                    // the explosion radius rendered nearly black because the
+                    // sun PointLight slots stayed empty for ~2s.
+                    case SunBurnLights.PointLight p when p.Enabled && p.Radius >= 1000f && p.Radius < 1_000_000f
+                                                         && p.ObjectType == ObjectType.Static:
                         float dx = p.Position.X - cameraPos.X;
                         float dy = p.Position.Y - cameraPos.Y;
                         float dist2 = dx*dx + dy*dy;

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -1348,8 +1348,9 @@ namespace Ship_Game
             UpdateShipMaintenance();
             UpdatePlanetStorageStats();
             EspionageCostLastTurn = LegacyEspionageEnabled ? 0 : GetEspionageCost();
-            float remainingMoney = MoneyAfterLeech(NetIncome);
-            AddMoney(remainingMoney - EspionageCostLastTurn);
+            // AllSpending already includes EspionageCostLastTurn, so NetIncome
+            // has it subtracted. Don't subtract again here.
+            AddMoney(MoneyAfterLeech(NetIncome));
         }
 
         float MoneyAfterLeech(float money)

--- a/Ship_Game/EmpireResearch.cs
+++ b/Ship_Game/EmpireResearch.cs
@@ -124,8 +124,15 @@ namespace Ship_Game
 
 
 
+        // 1f when this turn took no disruption hits, else the product of
+        // (1 - SlowResearchBy) for each enemy whose roll landed. Surfaces to
+        // the universe top-bar as a spy icon + percentage so the player can
+        // see when their research is being slowed.
+        public float DisruptionMultiplier { get; private set; } = 1f;
+
         void UpdateNetResearchDisruption()
         {
+            DisruptionMultiplier = 1f;
             if (Empire.LegacyEspionageEnabled)
                 return;
 
@@ -135,7 +142,10 @@ namespace Ship_Game
                 Empire empire = empires[i];
                 Espionage espionage = empire.GetEspionage(Empire);
                 if (espionage.CanSlowResearch && empire.Random.RollDice(espionage.SlowResearchChance))
+                {
                     NetResearch *= 1 - Espionage.SlowResearchBy;
+                    DisruptionMultiplier *= 1 - Espionage.SlowResearchBy;
+                }
             }
         }
 

--- a/Ship_Game/Espionage/InfiltrationOperation.cs
+++ b/Ship_Game/Espionage/InfiltrationOperation.cs
@@ -98,11 +98,11 @@ namespace Ship_Game
             int defense = (int)(them.EspionageDefenseRatio * 25) + (int)them.data.DefensiveSpyBonus;
             int modifiedResult = (int)(baseResult - defense + owner.data.OffensiveSpyBonus + owner.data.SpyModifier);
 
-            if (modifiedResult >= targetNumber*2) return InfiltrationOpsResult.GreatSuccess;
-            if (modifiedResult < targetNumber/20) return InfiltrationOpsResult.CriticalFail;
-            if (modifiedResult < targetNumber/10) return InfiltrationOpsResult.MiserableFail;
-            if (modifiedResult < targetNumber)    return InfiltrationOpsResult.Fail;
-            else                                  return InfiltrationOpsResult.Success;
+            if (modifiedResult >= targetNumber*2)    return InfiltrationOpsResult.GreatSuccess;
+            if (modifiedResult < targetNumber*0.05f) return InfiltrationOpsResult.CriticalFail;
+            if (modifiedResult < targetNumber*0.1f)  return InfiltrationOpsResult.MiserableFail;
+            if (modifiedResult < targetNumber)       return InfiltrationOpsResult.Fail;
+            else                                     return InfiltrationOpsResult.Success;
         }
 
         protected float CalcRelationDamage(float baseDamage, Espionage espionage, bool withLevelMultiplier = false)

--- a/Ship_Game/Espionage/InfiltrationOpsPlantMole.cs
+++ b/Ship_Game/Espionage/InfiltrationOpsPlantMole.cs
@@ -29,7 +29,7 @@ namespace Ship_Game
 
         public override void CompleteOperation()
         {
-            var result = RollMissionResult(Owner, Them, Owner.IsAlliedWith(Them) ? (int)(SuccessTargetNumber * 0.5f) : SuccessTargetNumber);
+            var result = RollMissionResult(Owner, Them, Owner.IsAlliedWith(Them) ? SuccessTargetNumber / 2 : SuccessTargetNumber);
             InfiltrationOpsResolve aftermath = new InfiltrationOpsResolve(Owner, Them, result);
             switch (result)
             {

--- a/Ship_Game/Espionage/InfiltrationOpsPlantMole.cs
+++ b/Ship_Game/Espionage/InfiltrationOpsPlantMole.cs
@@ -29,7 +29,7 @@ namespace Ship_Game
 
         public override void CompleteOperation()
         {
-            var result = RollMissionResult(Owner, Them, Owner.IsAlliedWith(Them) ? SuccessTargetNumber / 2 : SuccessTargetNumber);
+            var result = RollMissionResult(Owner, Them, Owner.IsAlliedWith(Them) ? (int)(SuccessTargetNumber * 0.5f) : SuccessTargetNumber);
             InfiltrationOpsResolve aftermath = new InfiltrationOpsResolve(Owner, Them, result);
             switch (result)
             {

--- a/Ship_Game/ExplosionManager.cs
+++ b/Ship_Game/ExplosionManager.cs
@@ -153,6 +153,19 @@ namespace Ship_Game
                 ActiveExplosions.Add(exp);
         }
 
+        internal const float IntensityDecayPerSecond = 10f;
+
+        // Decay the explosion's light intensity towards 0. Clamping at 0 is
+        // load-bearing: without it DiffuseColor*Intensity goes negative in
+        // LightingEffectBinder and the dynamic slot subtracts light in
+        // MeshLighting.fx, turning hulls inside the explosion radius black
+        // for the tail of the lifetime (~1s for ship explosions).
+        internal static void TickLightIntensity(PointLight light, float elapsedTime)
+        {
+            if (light == null) return;
+            light.Intensity = (light.Intensity - IntensityDecayPerSecond * elapsedTime).LowerBound(0f);
+        }
+
         public static void Update(UniverseScreen us, float elapsedTime)
         {
             using (Lock.AcquireWriteLock())
@@ -167,10 +180,7 @@ namespace Ship_Game
                         continue;
                     }
 
-                    if (e.Light != null)
-                    {
-                        e.Light.Intensity -= 10f * elapsedTime;
-                    }
+                    TickLightIntensity(e.Light, elapsedTime);
 
                     // cheap and inaccurate integration
                     e.Pos.X += e.Vel.X * elapsedTime;

--- a/Ship_Game/ExtensionMethods/HelperFunctions.cs
+++ b/Ship_Game/ExtensionMethods/HelperFunctions.cs
@@ -228,18 +228,26 @@ namespace Ship_Game
             GC.Collect();
         }
 
-        // Gets a more human readable number string that also supports large numbers
-        // ex: 950.7k 
+        // Gets a more human readable number string that also supports large numbers.
+        // Examples: 0.25, 95.75, 950.7, 9500, 57.75k, 950.7k, 1.5M, 950.7M, 1000M
         public static string GetNumberString(this float stat)
         {
             CultureInfo invariant = CultureInfo.InvariantCulture;
-            if (Math.Abs(stat) < 100f)   return stat.ToString("0.##", invariant); // 95.75  or 0.25
-            if (Math.Abs(stat) < 1000f)  return stat.ToString("0.#", invariant);  // 950.7  or 0.5
-            if (Math.Abs(stat) < 10000f) return stat.ToString("#", invariant);    // 9500
-            float single = stat / 1000f;
-            if (Math.Abs(single) < 100f)  return single.ToString("0.##", invariant) + "k"; // 57.75k or 0.5k
-            if (Math.Abs(single) < 1000f) return single.ToString("0.#", invariant) + "k";  // 950.7k
-            return single.ToString("#", invariant) + "k"; // 1000k
+            float abs = Math.Abs(stat);
+            if (abs < 100f)   return stat.ToString("0.##", invariant);
+            if (abs < 1000f)  return stat.ToString("0.#", invariant);
+            if (abs < 10000f) return stat.ToString("#", invariant);
+
+            float k = stat / 1000f;
+            float absK = Math.Abs(k);
+            if (absK < 100f)  return k.ToString("0.##", invariant) + "k";
+            if (absK < 1000f) return k.ToString("0.#", invariant) + "k";
+
+            float m = stat / 1_000_000f;
+            float absM = Math.Abs(m);
+            if (absM < 100f)  return m.ToString("0.##", invariant) + "M";
+            if (absM < 1000f) return m.ToString("0.#", invariant) + "M";
+            return m.ToString("#", invariant) + "M";
         }
 
         public static bool DataVisibleToPlayer(Empire empire)

--- a/Ship_Game/ExtensionMethods/HelperFunctions.cs
+++ b/Ship_Game/ExtensionMethods/HelperFunctions.cs
@@ -229,7 +229,7 @@ namespace Ship_Game
         }
 
         // Gets a more human readable number string that also supports large numbers.
-        // Examples: 0.25, 95.75, 950.7, 9500, 57.75k, 950.7k, 1.5M, 950.7M, 1000M
+        // Examples: 0.25, 95.75, 950.7, 9500, 57.8k, 950.7k, 1.5M, 950.7M, 1000M
         public static string GetNumberString(this float stat)
         {
             CultureInfo invariant = CultureInfo.InvariantCulture;
@@ -239,14 +239,10 @@ namespace Ship_Game
             if (abs < 10000f) return stat.ToString("#", invariant);
 
             float k = stat / 1000f;
-            float absK = Math.Abs(k);
-            if (absK < 100f)  return k.ToString("0.##", invariant) + "k";
-            if (absK < 1000f) return k.ToString("0.#", invariant) + "k";
+            if (Math.Abs(k) < 1000f) return k.ToString("0.#", invariant) + "k";
 
             float m = stat / 1_000_000f;
-            float absM = Math.Abs(m);
-            if (absM < 100f)  return m.ToString("0.##", invariant) + "M";
-            if (absM < 1000f) return m.ToString("0.#", invariant) + "M";
+            if (Math.Abs(m) < 1000f) return m.ToString("0.#", invariant) + "M";
             return m.ToString("#", invariant) + "M";
         }
 

--- a/Ship_Game/GameScreens/ColonyScreen.cs
+++ b/Ship_Game/GameScreens/ColonyScreen.cs
@@ -1839,7 +1839,7 @@ namespace Ship_Game
                     }
                 }
 
-                if (e.WasApplyHovered(input) && !P.RecentCombat && P.CrippledTurns <= 0)
+                if (e.WasApplyHovered(input) && !P.IsCrippled)
                 {
                     if (!input.IsCtrlKeyDown || input.LeftMouseDown || input.LeftMouseReleased) // @todo WTF??
                     {

--- a/Ship_Game/GameScreens/ColonyScreen/ColonySliderGroup.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/ColonySliderGroup.cs
@@ -117,7 +117,7 @@ namespace Ship_Game
                     && (P.CType is Planet.ColonyType.Colony or Planet.ColonyType.TradeHub);
             }
 
-            Prod.IsCrippled = P.CrippledTurns > 0;
+            Prod.IsCrippled = P.IsSabotaged;
             Prod.IsInvasion = P.RecentCombat;
 
             // prioritize currently dragging slider for input events

--- a/Ship_Game/GameScreens/GameBase.cs
+++ b/Ship_Game/GameScreens/GameBase.cs
@@ -117,6 +117,13 @@ namespace Ship_Game
             return deviceChanged;
         }
 
+        // Last graphics settings successfully applied via ApplyGraphics.
+        // Captured so OnActivated can re-apply them when the WindowsDX
+        // OnClientSizeChanged handler shrinks the backbuffer during an
+        // alt-tab minimize from exclusive fullscreen.
+        GraphicsSettings LastAppliedSettings;
+        bool Restoring; // re-entrancy guard for OnActivated → ApplyGraphics → ApplyChanges
+
         // @return TRUE if graphics device changed
         public bool ApplyGraphics(GraphicsSettings settings)
         {
@@ -223,7 +230,36 @@ namespace Ship_Game
             PresentationParameters pp = GraphicsDevice.PresentationParameters;
             Log.Write(ConsoleColor.Cyan, $"ApplyGraphics: backbuffer={pp.BackBufferWidth}x{pp.BackBufferHeight} form={form.ClientSize.Width}x{form.ClientSize.Height}");
 
+            LastAppliedSettings = settings;
             return deviceChanged;
+        }
+
+        // After an alt-tab cycle out of exclusive fullscreen, MonoGame's
+        // WindowsDX OnClientSizeChanged handler auto-calls Graphics.ApplyChanges
+        // with the form's transient (minimized/restored) ClientSize, shrinking
+        // the backbuffer. On alt-tab back the backbuffer stays small, the form
+        // is again at fullscreen extents but only the top-left ClientSize-sized
+        // region renders. Detect the drift here and re-apply the last user
+        // settings to restore the proper backbuffer.
+        protected override void OnActivated(object sender, EventArgs args)
+        {
+            base.OnActivated(sender, args);
+
+            if (Restoring) return;
+            if (LastAppliedSettings == null || Graphics == null || GraphicsDevice == null)
+                return;
+            if (LastAppliedSettings.Mode != WindowMode.Fullscreen)
+                return;
+
+            PresentationParameters p = GraphicsDevice.PresentationParameters;
+            if (p.BackBufferWidth == LastAppliedSettings.Width
+                && p.BackBufferHeight == LastAppliedSettings.Height)
+                return;
+
+            Log.Warning($"Alt-tab restore: backbuffer drifted to {p.BackBufferWidth}x{p.BackBufferHeight}, restoring to {LastAppliedSettings.Width}x{LastAppliedSettings.Height}");
+            Restoring = true;
+            try { ApplyGraphics(LastAppliedSettings); }
+            finally { Restoring = false; }
         }
 
         // DXGI_ERROR_NOT_CURRENTLY_AVAILABLE — SetFullscreenState rejected the

--- a/Ship_Game/GameScreens/Infiltration/InfiltrationOpsLevel5.cs
+++ b/Ship_Game/GameScreens/Infiltration/InfiltrationOpsLevel5.cs
@@ -44,6 +44,7 @@ namespace Ship_Game.GameScreens.EspionageNew
             RebellionTurnsRemaining  = Add(new UILabel("", Font, Color.White));
             ProjectionTurnsRemaining = Add(new UILabel("", Font, Color.White));
             MoneyLeeched = Add(new UILabel("", Font, Color.White));
+            MoneyLeeched.Tooltip = GameText.EspionageTotalMoneyLeechedTip;
         }
 
         public override void PerformLayout()

--- a/Ship_Game/GameScreens/Universe/ResearchScreenNew.cs
+++ b/Ship_Game/GameScreens/Universe/ResearchScreenNew.cs
@@ -266,7 +266,7 @@ namespace Ship_Game
 
             // fill a small rectangle at the beginning of the research line
             // to cover up some stupid artifacts caused by XNA transparent sprite renderer
-            batch.FillRectangle(new(left.X, left.Y, 5, 1), (complete ? new(110, 171, 227) : new(194, 194, 194)));
+            batch.FillRectangle(new Rectangle((int)left.X, (int)left.Y, 5, 1), (complete ? new(110, 171, 227) : new(194, 194, 194)));
         }
 
         static void DrawResearchLineVertical(SpriteBatch batch, Vector2 top, Vector2 bottom, bool complete)

--- a/Ship_Game/ResearchQueueUIComponent.cs
+++ b/Ship_Game/ResearchQueueUIComponent.cs
@@ -17,6 +17,8 @@ namespace Ship_Game
         readonly Submenu CurrentResearchPanel;
         readonly UIPanel TimeLeft;
         readonly UILabel TimeLeftLabel;
+        readonly UIPanel SpyDisruption;
+        readonly UILabel SpyDisruptionLabel;
 
         ResearchQItem CurrentResearch;
         readonly ScrollList<ResearchQItem> ResearchQueueList;
@@ -38,6 +40,23 @@ namespace Ship_Game
             TimeLeftLabel = TimeLeft.Label(labelPos, "", Fonts.Verdana14Bold, new Color(205, 229, 255));
 
             CurrentResearchPanel = Add(new Submenu(current, GameText.CurrentResearch, SubmenuStyle.Blue));
+
+            // Disruption indicator inline with the "Current Research" tab
+            // title. 80% of the 25px tab height. Added AFTER the Submenu so
+            // it draws on top of the tab bar.
+            const int spyIconSize = 20;
+            float titleW = Fonts.Pirulen12.MeasureString(Localizer.Token(GameText.CurrentResearch)).X;
+            var spyIconRect = new Rectangle((int)(current.X + titleW + 50),
+                                            (int)current.Y -3 + (25 - spyIconSize) / 2,
+                                            spyIconSize, spyIconSize);
+            SpyDisruption = Add(new UIPanel(spyIconRect, ResourceManager.Texture("UI/icon_spy")));
+            SpyDisruption.Tooltip = GameText.ResearchDisruptedByInfiltrationTip;
+            var spyLabelPos = new Vector2(spyIconRect.X + spyIconRect.Width + 4,
+                                          spyIconRect.Y + 3 + spyIconRect.Height / 2 - Fonts.Arial12Bold.LineSpacing / 2);
+            SpyDisruptionLabel = Add(new UILabel(spyLabelPos, "", Fonts.Arial12Bold, new Color(255, 96, 96),
+                                                 GameText.ResearchDisruptedByInfiltrationTip));
+            SpyDisruption.Visible = false;
+            SpyDisruptionLabel.Visible = false;
             
             RectF queue = new(current.X, current.Y + 165, container.Width, container.Height - 165);
             var queueSub = Add(new SubmenuScrollList<ResearchQItem>(queue, GameText.ResearchQueue, 125, ListStyle.Blue));
@@ -76,6 +95,11 @@ namespace Ship_Game
             ResearchQueueList.Visible = visible;
             ResearchQueueList.Parent.Visible = visible;
             CurrentResearchPanel.Visible = visible;
+            if (!visible)
+            {
+                SpyDisruption.Visible = false;
+                SpyDisruptionLabel.Visible = false;
+            }
             BtnShowQueue.Text = ResearchQueueList.Visible ? GameText.HideQueue : GameText.ShowQueue;
         }
 
@@ -107,6 +131,13 @@ namespace Ship_Game
                 float remaining = CurrentResearch.Tech.TechCost - CurrentResearch.Tech.Progress;
                 float numTurns = (float)Math.Ceiling(remaining / (0.01f + Screen.Player.Research.NetResearch));
                 TimeLeftLabel.Text = (numTurns > 999f) ? ">999 turns" : numTurns.String(0)+" turns";
+
+                float multiplier = Screen.Player.Research.DisruptionMultiplier;
+                bool disrupted = multiplier < 1f;
+                SpyDisruption.Visible = disrupted;
+                SpyDisruptionLabel.Visible = disrupted;
+                if (disrupted)
+                    SpyDisruptionLabel.Text = $"({(int)Math.Round(multiplier * 100f)}%)";
             }
         }
 

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -1221,7 +1221,7 @@ namespace Ship_Game.Ships
                 if (Active)
                 {
                     bool enableVisualizeDamage = PlanetCrash == null;
-                    bool visibleForVisuals = visible && Universe.IsPlanetViewOrCloser;
+                    bool visibleForVisuals = visible && Universe.IsPlanetViewOrCloser && !IsInWarp;
                     for (int i = 0; i < ModuleSlotList.Length; ++i)
                     {
                         ShipModule m = ModuleSlotList[i];

--- a/Ship_Game/TreeNode.cs
+++ b/Ship_Game/TreeNode.cs
@@ -136,7 +136,7 @@ namespace Ship_Game
                 completeTitleColor = new Color(163, 198, 236);
             }
 
-            batch.FillRectangle(UnlocksRect, new Color(26, 26, 28));
+            batch.FillRectangle((Rectangle)UnlocksRect, new Color(26, 26, 28));
             batch.DrawRectangle(UnlocksRect, unlocksRectBorderColor);
 
             if (Entry.MaxLevel > 1)

--- a/Ship_Game/Troops/Troop.cs
+++ b/Ship_Game/Troops/Troop.cs
@@ -238,7 +238,9 @@ namespace Ship_Game
 
         public void Draw(UniverseState us, SpriteBatch sb, Rectangle drawRect)
         {
-            if (TroopAnim == null)
+            // TransientContent.Unload() (load-from-in-game) disposes the cached atlas;
+            // without the IsDisposed check the stale ref serves x_red forever.
+            if (TroopAnim == null || TroopAnim.IsDisposed)
                 InitializeAtlas(us.Screen);
 
             if (!animated)

--- a/Ship_Game/Universe/EmpireUIOverlay.cs
+++ b/Ship_Game/Universe/EmpireUIOverlay.cs
@@ -264,17 +264,15 @@ namespace Ship_Game
                 gradientSourceRect.X = 159 - xOffset;
                 Universe.ScreenManager.SpriteBatch.Draw(ResourceManager.Texture("EmpireTopBar/empiretopbar_res2_gradient"), new Rectangle(res2.X, res2.Y, res2.Width, res2.Height), gradientSourceRect, Color.White);
                 Universe.ScreenManager.SpriteBatch.Draw(ResourceManager.Texture("EmpireTopBar/empiretopbar_res2_over"), res2, Color.White);
-                int research = (int)Player.Research.Current.Progress;
-                int resCost = (int)Player.Research.Current.TechCost;
+                string research = Player.Research.Current.Progress.GetNumberString();
+                string resCost = Player.Research.Current.TechCost.GetNumberString();
                 float plusRes = Player.Research.NetResearch;
                 float x = res2.X + res2.Width - 30;
                 Graphics.Font arial12Bold = Fonts.Arial12Bold;
-                object[] str = { research, "/", resCost, " (+", plusRes.String(1), ")" };
-                textCursor.X = x - arial12Bold.MeasureString(string.Concat(str)).X;
+                string text = $"{research}/{resCost} (+{plusRes.String(1)})";
+                textCursor.X = x - arial12Bold.MeasureString(text).X;
                 textCursor.Y = res2.Height / 2 - Fonts.Arial12Bold.LineSpacing / 2;
-                Graphics.Font spriteFont = Fonts.Arial12Bold;
-                object[] objArray = { research, "/", resCost, " (+", plusRes.String(1), ")" };
-                batch.DrawString(spriteFont, string.Concat(objArray), textCursor, new Color(255, 240, 189));
+                batch.DrawString(arial12Bold, text, textCursor, new Color(255, 240, 189));
             }
         }
 

--- a/Ship_Game/Universe/EmpireUIOverlay.cs
+++ b/Ship_Game/Universe/EmpireUIOverlay.cs
@@ -232,20 +232,13 @@ namespace Ship_Game
                 }
             }
 
-            int money = (int)Player.Money;
+            string money = Player.Money.GetNumberString();
             float damoney = Player.EstimateNetIncomeAtTaxRate(Player.data.TaxRate);
-            if (damoney <= 0f)
-            {
-                textCursor.X = res4.X + res2.Width - 30 - Fonts.Arial12Bold.MeasureString(string.Concat(money.ToString(), " (", damoney.ToString("#.0"), ")")).X;
-                textCursor.Y = res2.Height / 2 - Fonts.Arial12Bold.LineSpacing / 2;
-                batch.DrawString(Fonts.Arial12Bold, string.Concat(money.ToString(), " (", damoney.String(), ")"), textCursor, new Color(255, 240, 189));
-            }
-            else
-            {
-                textCursor.X = res4.X + res2.Width - 30 - Fonts.Arial12Bold.MeasureString(string.Concat(money.ToString(), " (+", damoney.ToString("#.0"), ")")).X;
-                textCursor.Y = res2.Height / 2 - Fonts.Arial12Bold.LineSpacing / 2;
-                batch.DrawString(Fonts.Arial12Bold, string.Concat(money.ToString(), " (+", damoney.String(), ")"), textCursor, new Color(255, 240, 189));
-            }
+            string sign = damoney > 0f ? "+" : "";
+            string moneyText = $"{money} ({sign}{damoney.String(1)})";
+            textCursor.X = res4.X + res2.Width - 30 - Fonts.Arial12Bold.MeasureString(moneyText).X;
+            textCursor.Y = res2.Height / 2 - Fonts.Arial12Bold.LineSpacing / 2;
+            batch.DrawString(Fonts.Arial12Bold, moneyText, textCursor, new Color(255, 240, 189));
 
             var starDatePos = new Vector2(res5.X + 75, textCursor.Y);
             string starDateText = LowRes ? Universe.StarDateString : "StarDate: " + Universe.StarDateString;

--- a/Ship_Game/Universe/EmpireUIOverlay.cs
+++ b/Ship_Game/Universe/EmpireUIOverlay.cs
@@ -262,10 +262,32 @@ namespace Ship_Game
                 float plusRes = Player.Research.NetResearch;
                 float x = res2.X + res2.Width - 30;
                 Graphics.Font arial12Bold = Fonts.Arial12Bold;
-                string text = $"{research}/{resCost} (+{plusRes.String(1)})";
-                textCursor.X = x - arial12Bold.MeasureString(text).X;
+                bool disrupted = Player.Research.DisruptionMultiplier < 1f;
+                Color baseColor = new Color(255, 240, 189);
                 textCursor.Y = res2.Height / 2 - Fonts.Arial12Bold.LineSpacing / 2;
-                batch.DrawString(arial12Bold, text, textCursor, new Color(255, 240, 189));
+                if (disrupted)
+                {
+                    string baseText = $"{research}/{resCost} ";
+                    string netText = $"(+{plusRes.String(1)})";
+                    int iconSize = (int)((res2.Height - 6) * 0.6f);
+                    const int iconPad = 4;
+                    Color netColor = new Color(255, 96, 96);
+                    float baseW = arial12Bold.MeasureString(baseText).X;
+                    float netW  = arial12Bold.MeasureString(netText).X;
+                    textCursor.X = x - (baseW + netW + iconPad + iconSize);
+                    batch.DrawString(arial12Bold, baseText, textCursor, baseColor);
+                    float netX = textCursor.X + baseW;
+                    batch.DrawString(arial12Bold, netText, new Vector2(netX, textCursor.Y), netColor);
+                    float iconX = netX + netW + iconPad;
+                    var iconRect = new Rectangle((int)iconX, res2.Y -3 + (res2.Height - iconSize) / 2, iconSize, iconSize);
+                    batch.Draw(ResourceManager.Texture("UI/icon_spy_small"), iconRect, netColor);
+                }
+                else
+                {
+                    string text = $"{research}/{resCost} (+{plusRes.String(1)})";
+                    textCursor.X = x - arial12Bold.MeasureString(text).X;
+                    batch.DrawString(arial12Bold, text, textCursor, baseColor);
+                }
             }
         }
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -117,6 +117,10 @@ namespace Ship_Game
         public bool HasCommodities => HasBuilding(b => b.IsCommodity || b.IsVolcano || b.IsCrater);
         public bool Governor => CType != ColonyType.Colony;
         public bool IsCrippled => CrippledTurns > 0 || RecentCombat;
+        // Narrower form: sabotage only. Build queue is fully frozen; combat
+        // alone still allows 10% queue progress, so callers that care about
+        // the full freeze (worker assignment, prod export gating) use this.
+        public bool IsSabotaged => CrippledTurns > 0;
         public bool CanLaunchBuilderShips => !SpaceCombatNearPlanet && NumBuildShipsLaunched < NumBuildShipsCanLaunch;
         public int NumBuildShipsCanLaunchperTurn => NumBuildShipsCanLaunch / 4;
         public bool IsMineable => Mining != null;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_WorkDistribution.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_WorkDistribution.cs
@@ -62,14 +62,13 @@ namespace Ship_Game
 
 
         // Core world aims to balance everything, without maximizing food/prod/res
-        void AssignCoreWorldWorkers()
+        internal void AssignCoreWorldWorkers()
         {
             float remainingWork;
             if (IsCybernetic) // Filthy Opteris
             {
                 AssignCoreWorldProduction(1f);
-                //WorkToPercentage(1);
-                remainingWork = 1;
+                remainingWork = 1 - Prod.Percent;
             }
             else // Strategy for Flesh-bags:
             {
@@ -79,16 +78,21 @@ namespace Ship_Game
 
             if (NonCybernetic)
             {
-                if (ConstructionQueue.Count > 0)
+                // Sabotage freezes the queue, so the queue-biased over-investment
+                // path would just pile prod into storage and get taxed away. Route
+                // to the storage-driven sizing instead — modest production keeps
+                // exports/Dyson/scrap-refund paths working without over-spending.
+                if (ConstructionQueue.Count > 0 && !IsSabotaged)
                     Prod.Percent = (remainingWork * EvaluateProductionQueue()).UpperBound(remainingWork);
                 else
                     AssignCoreWorldProduction(remainingWork - MinimumResearchNoQueue(remainingWork, 0.5f));
             }
+
             Res.AutoBalanceWorkers(); // rest goes to research
         }
 
         // Work for Anything that is not a Core World or Trade Hub is dealt here
-        void AssignOtherWorldsWorkers(float percentFood, float percentProd, float wantedFoodIncome, float wantedProdIncome)
+        internal void AssignOtherWorldsWorkers(float percentFood, float percentProd, float wantedFoodIncome, float wantedProdIncome)
         {
             Food.Percent        = FarmToPercentage(percentFood, wantedFoodIncome);
             Food.CalculateAveragePercentage();
@@ -96,10 +100,11 @@ namespace Ship_Game
             Prod.Percent        = WorkToPercentage(percentProd, wantedProdIncome).UpperBound(remainingWork);
             if (NonCybernetic)
             {
-                if (ConstructionQueue.Count > 0)
+                if (ConstructionQueue.Count > 0 && !IsSabotaged)
                 {
-                    Prod.Percent = CType is ColonyType.Agricultural && Storage.FoodRatio < percentFood * 0.9f 
-                        ? remainingWork 
+                    // Same freezes queue as AssignCoreWorldWorkers
+                    Prod.Percent = CType is ColonyType.Agricultural && Storage.FoodRatio < percentFood * 0.9f
+                        ? remainingWork
                         : (remainingWork * EvaluateProductionQueue()).UpperBound(remainingWork);
                 }
                 else
@@ -183,7 +188,7 @@ namespace Ship_Game
             float workers    = Prod.EstPercentForNetIncome(minPerTurn);
 
             workers = workers.Clamped(0.1f, 1.0f);
-            if (IsCybernetic & ConstructionQueue.Count > 0)
+            if (IsCybernetic && ConstructionQueue.Count > 0 && !IsSabotaged)
                  workers *= 1.2f;
 
             Prod.Percent = workers * labor;

--- a/Ship_Game/Universe/SolarBodies/SBProduction.cs
+++ b/Ship_Game/Universe/SolarBodies/SBProduction.cs
@@ -242,7 +242,7 @@ namespace Ship_Game.Universe.SolarBodies
         {
             // surplus will be reset every turn and consumed at first opportunity
             SurplusThisTurn = surplusFromPlanet;
-            if (ConstructionQueue.IsEmpty || P.CrippledTurns > 0)
+            if (ConstructionQueue.IsEmpty || P.IsSabotaged)
                 return; // Massive sabotage to planetary facilities or no items
 
             float percentToApply = P.RecentCombat ? 0.1f : 1f; // Ongoing combat is hindering logistics
@@ -253,7 +253,7 @@ namespace Ship_Game.Universe.SolarBodies
 
         void TryPlayerRush() // Apply rush if player marked items as continuous rush
         {
-            if (!P.OwnerIsPlayer || Count == 0 || P.CrippledTurns > 0 || P.RecentCombat)
+            if (!P.OwnerIsPlayer || Count == 0 || P.IsCrippled)
                 return;
 
             QueueItem item = ConstructionQueue[0];

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
@@ -214,6 +214,50 @@ namespace Ship_Game
             }
         }
 
+        // Re-create backbuffer-sized RTs when the backbuffer has been resized
+        // (e.g., after the alt-tab restore path in GameBase.OnActivated). The
+        // RTs are allocated to backbuffer dimensions at LoadContent time and
+        // MonoGame's DXGI ResizeBuffers path doesn't dispose them, so a stale
+        // size or IsContentLost flag will silently render at the wrong scale.
+        void EnsureBackbufferSizedRTs(GraphicsDevice device)
+        {
+            PresentationParameters pp = device.PresentationParameters;
+            int w = pp.BackBufferWidth;
+            int h = pp.BackBufferHeight;
+
+            if (RtNeedsRebuild(MainTarget, w, h))
+            {
+                MainTarget?.Dispose();
+                MainTarget = RenderTargets.Create(device, RenderTargetUsage.PreserveContents);
+            }
+            if (RtNeedsRebuild(LightsTarget, w, h))
+            {
+                LightsTarget?.Dispose();
+                LightsTarget = RenderTargets.Create(device);
+            }
+            if (RtNeedsRebuild(BorderRT, w, h))
+            {
+                BorderRT?.Dispose();
+                BorderRT = RenderTargets.Create(device);
+            }
+            if (GlobalStats.RenderBloom && RtNeedsRebuild(PostBloomTarget, w, h))
+            {
+                PostBloomTarget?.Dispose();
+                PostBloomTarget = RenderTargets.Create(device);
+            }
+            if (GlobalStats.RenderShieldDistortion && RtNeedsRebuild(PostDistortTarget, w, h))
+            {
+                PostDistortTarget?.Dispose();
+                PostDistortTarget = RenderTargets.Create(device);
+            }
+        }
+
+        static bool RtNeedsRebuild(RenderTarget2D rt, int w, int h)
+        {
+            return rt == null || rt.IsDisposed || rt.IsContentLost
+                || rt.Width != w || rt.Height != h;
+        }
+
         void UpdateFogMap(SpriteBatch batch, GraphicsDevice device)
         {
             EnsureFogMapRenderTargets(device);
@@ -308,6 +352,7 @@ namespace Ship_Game
             SpriteRenderer sr = ScreenManager.SpriteRenderer;
 
             GraphicsDevice graphics = ScreenManager.GraphicsDevice;
+            EnsureBackbufferSizedRTs(graphics);
             graphics.SetRenderTarget(MainTarget);
             // §4.6 #1.b regression follow-up: MainTarget is now PreserveContents
             // so the shadow pre-pass's RT swap in SunBurnStubs.RenderScene doesn't

--- a/UnitTests/Graphics/ExplosionLightIntensityTests.cs
+++ b/UnitTests/Graphics/ExplosionLightIntensityTests.cs
@@ -1,0 +1,49 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ship_Game;
+using SynapseGaming.LightingSystem.Lights;
+
+namespace UnitTests.Graphics;
+
+// Big-battle regression: explosion lights decay 10/sec for the full
+// 2.25s lifetime. Pre-fix this drove Intensity negative for the tail
+// ~1s of a ship explosion, which LightingEffectBinder pushed to the
+// shader as a subtractive DiffuseColor*Intensity — hulls inside the
+// explosion radius rendered fully black until the explosion expired.
+[TestClass]
+public class ExplosionLightIntensityTests
+{
+    [TestMethod]
+    public void TickLightIntensity_NeverGoesNegative_OverShipExplosionLifetime()
+    {
+        var light = new PointLight { Intensity = 12f, Enabled = true };
+        const float dt = 1f / 60f;
+        // 2.25s @ 60fps = 135 ticks; oversample to 200 to cover one
+        // full ship explosion duration plus headroom.
+        for (int i = 0; i < 200; ++i)
+        {
+            ExplosionManager.TickLightIntensity(light, dt);
+            Assert.IsTrue(light.Intensity >= 0f,
+                $"Intensity went negative on tick {i}: {light.Intensity}");
+        }
+
+        Assert.AreEqual(0f, light.Intensity, 0.0001f);
+    }
+
+    [TestMethod]
+    public void TickLightIntensity_NullLight_DoesNotThrow()
+    {
+        ExplosionManager.TickLightIntensity(null, 1f / 60f);
+    }
+
+    [TestMethod]
+    public void TickLightIntensity_DecaysAtExpectedRate()
+    {
+        var light = new PointLight { Intensity = 12f, Enabled = true };
+        // 0.5s @ 60fps → expected intensity = 12 - 10*0.5 = 7
+        const float dt = 1f / 60f;
+        for (int i = 0; i < 30; ++i)
+            ExplosionManager.TickLightIntensity(light, dt);
+
+        Assert.AreEqual(7f, light.Intensity, 0.01f);
+    }
+}

--- a/UnitTests/Graphics/LightingEffectBinderTests.cs
+++ b/UnitTests/Graphics/LightingEffectBinderTests.cs
@@ -4,6 +4,7 @@ using Ship_Game.Data.Mesh;
 using SunBurnLights = SynapseGaming.LightingSystem.Lights;
 using SynapseGaming.LightingSystem.Core;
 using SynapseGaming.LightingSystem.Effects.Forward;
+using SynapseGaming.LightingSystem.Rendering;
 
 namespace UnitTests.Graphics;
 
@@ -76,5 +77,52 @@ public class LightingEffectBinderTests : StarDriveTest
         Assert.IsFalse(fx.DirectionalLight0.Enabled);
         Assert.IsFalse(fx.DirectionalLight1.Enabled);
         Assert.IsFalse(fx.DirectionalLight2.Enabled);
+    }
+
+    // Big-battle regression: warp/station explosion lights can carry
+    // Radius >= 1000 and sit at the camera's XY. Without the ObjectType.Static
+    // filter on sun candidacy they win bestSun, displace the actual system
+    // sun from the 3 PointLight slots, and ships beyond the explosion radius
+    // render with only ambient — i.e. nearly black.
+    [TestMethod]
+    public void DynamicPointLight_DoesNotDisplaceSystemSun()
+    {
+        var lightManager = new SunBurnLights.LightManager();
+
+        // Real system sun far away in XY (camera is focused on the battle).
+        var sun = new SunBurnLights.PointLight
+        {
+            Name = "Key",
+            Position = new Vector3(100000f, 100000f, -50000f),
+            Radius = 150000f,
+            DiffuseColor = new Vector3(1f, 0.95f, 0.9f),
+            Intensity = 1f,
+            Enabled = true,
+            ObjectType = ObjectType.Static,
+        };
+        lightManager.Submit(sun);
+
+        // Warp explosion sitting right at the camera — Radius > 1000 means
+        // it qualifies as a sun candidate by radius alone, and it's much
+        // closer in XY than the real sun.
+        var explosionSun = new SunBurnLights.PointLight
+        {
+            Name = "Warp Explosion",
+            Position = new Vector3(0f, 0f, -100f),
+            Radius = 1500f,
+            DiffuseColor = new Vector3(0.9f, 0.8f, 0.7f),
+            Intensity = 8f,
+            Enabled = true,
+            ObjectType = ObjectType.Dynamic,
+        };
+        lightManager.Submit(explosionSun);
+
+        using var fx = new LightingEffect(Game.GraphicsDevice);
+        LightingEffectBinder.Apply(fx, lightManager.ActiveLights, new SceneEnvironment(), Vector3.Zero);
+
+        Assert.IsTrue(fx.PointLight0.Enabled, "System sun should fill PointLight0.");
+        Assert.AreEqual(sun.Position.X, fx.PointLight0.Position.X, 0.01f,
+            "PointLight0 should be the Static system sun, not the Dynamic explosion.");
+        Assert.AreEqual(sun.Position.Y, fx.PointLight0.Position.Y, 0.01f);
     }
 }

--- a/UnitTests/Planets/TestSabotageWorkDistribution.cs
+++ b/UnitTests/Planets/TestSabotageWorkDistribution.cs
@@ -1,0 +1,102 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ship_Game;
+using Vector2 = SDGraphics.Vector2;
+#pragma warning disable CA2213
+
+namespace UnitTests.Planets;
+
+// Verifies that the auto-governor labor split adapts to sabotage:
+// a sabotaged planet should NOT take the queue-biased "over-invest in
+// production" branch, because SBProduction.AutoApplyProduction bails
+// while IsSabotaged is true. See Planet_WorkDistribution.cs.
+[TestClass]
+public class TestSabotageWorkDistribution : StarDriveTest
+{
+    Planet Homeworld;
+    Building NanoMine;
+
+    public TestSabotageWorkDistribution()
+    {
+        CreateUniverseAndPlayerEmpire();
+        Homeworld = AddHomeWorldToEmpire(new Vector2(2000), Player);
+        NanoMine = ResourceManager.GetBuildingTemplate("Nano Mine");
+        Assert.IsNotNull(NanoMine, "Nano Mine template missing from ResourceManager");
+        // Seed a research topic so Res.AutoBalanceWorkers doesn't fall into
+        // AutoBalanceWithZeroResearch (which dumps all leftover labor into
+        // Prod and masks the difference between the work-distribution branches).
+        Player.Research.SetTopic("FrigateConstruction");
+        Assert.IsFalse(Player.Research.NoTopic, "Research topic should be set");
+    }
+
+    [TestMethod]
+    public void IsSabotaged_TracksCrippledTurns()
+    {
+        Assert.IsFalse(Homeworld.IsSabotaged, "Fresh homeworld should not be sabotaged");
+        Assert.IsFalse(Homeworld.IsCrippled, "Fresh homeworld should not be crippled");
+
+        Homeworld.AddCrippledTurns(50);
+        Assert.IsTrue(Homeworld.IsSabotaged, "Adding CrippledTurns should set IsSabotaged");
+        Assert.IsTrue(Homeworld.IsCrippled, "IsCrippled includes the CrippledTurns case");
+    }
+
+    [TestMethod]
+    public void AssignCoreWorldWorkers_SabotagedQueueBehavesLikeNoQueue()
+    {
+        Homeworld.CType = Planet.ColonyType.Core;
+        FillProdStorage();
+
+        // (1) No queue → storage-driven branch.
+        Assert.IsTrue(Homeworld.ConstructionQueue.Count == 0, "Precondition: queue is empty");
+        ResetLaborPercents();
+        Homeworld.AssignCoreWorldWorkers();
+        float noQueueProd = Homeworld.Prod.Percent;
+
+        // (2) Queue + no sabotage → queue-biased branch.
+        Homeworld.Construction.Enqueue(NanoMine);
+        Assert.IsFalse(Homeworld.IsSabotaged, "Precondition (2): not sabotaged");
+        FillProdStorage();
+        ResetLaborPercents();
+        Homeworld.AssignCoreWorldWorkers();
+        float queuedNotSabotagedProd = Homeworld.Prod.Percent;
+
+        string diag = $" [pop={Homeworld.PopulationBillion} prodMax={Homeworld.Prod.NetMaxPotential}" +
+                      $" prodRatio={Homeworld.Storage.ProdRatio} resYPC={Homeworld.Res.YieldPerColonist}" +
+                      $" noTopic={Player.Research.NoTopic}]";
+
+        Assert.AreNotEqual(noQueueProd, queuedNotSabotagedProd, 0.0001f,
+            "Sanity: with a queue and no sabotage, queue-biased branch should diverge " +
+            $"from no-queue. noQueue={noQueueProd}, queued={queuedNotSabotagedProd}.{diag}");
+
+        // (3) Queue + sabotage → should land back on the no-queue branch (gate skips bias).
+        Homeworld.AddCrippledTurns(50);
+        Assert.IsTrue(Homeworld.IsSabotaged, "Precondition (3): sabotaged");
+        FillProdStorage();
+        ResetLaborPercents();
+        Homeworld.AssignCoreWorldWorkers();
+        float sabotagedQueueProd = Homeworld.Prod.Percent;
+
+        Assert.AreEqual(noQueueProd, sabotagedQueueProd, 0.0001f,
+            "Sabotaged colony with a queued item should produce the same Prod.Percent " +
+            "as a colony with no queue at all (storage-driven branch). " +
+            $"noQueue={noQueueProd}, sabotagedQueue={sabotagedQueueProd}.");
+    }
+
+    void ResetLaborPercents()
+    {
+        Homeworld.Food.Percent = 0;
+        Homeworld.Prod.Percent = 0;
+        Homeworld.Res.Percent  = 0;
+        // Refresh per-resource caches (NetMaxPotential, YieldPerColonist) — the
+        // worker-assignment math reads them and they're 0-initialized until
+        // UpdateIncomes() runs.
+        Homeworld.UpdateIncomes();
+    }
+
+    // Fills ProdHere to cap. MinIncomePerTurn early-returns 0 once ratio > 0.9999,
+    // so EstPercentForNetIncome(0) lands the storage-driven branch at its floor
+    // (workers clamped to 0.1) — well below the queue-biased path.
+    void FillProdStorage()
+    {
+        Homeworld.ProdHere = Homeworld.Storage.Max;
+    }
+}

--- a/UnitTests/SDUnitTests.csproj
+++ b/UnitTests/SDUnitTests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Planets\CapitalTransfer.cs" />
     <Compile Include="Planets\LandOnTiles.cs" />
     <Compile Include="Planets\TestOrbitalBomb.cs" />
+    <Compile Include="Planets\TestSabotageWorkDistribution.cs" />
     <Compile Include="Serialization\BinaryReadWriteTests.cs" />
     <Compile Include="Serialization\ObjectScannerTests.cs" />
     <Compile Include="Serialization\SerializationRegressionTests.cs" />

--- a/UnitTests/SDUnitTests.csproj
+++ b/UnitTests/SDUnitTests.csproj
@@ -176,6 +176,7 @@
     <Compile Include="Utils\BitArrayTests.cs" />
     <Compile Include="Utils\PerfTimerTests.cs" />
     <Compile Include="Utils\SmallBitSetTests.cs" />
+    <Compile Include="Utils\TestGetNumberString.cs" />
     <Compile Include="Utils\TypesTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/UnitTests/SDUnitTests.csproj
+++ b/UnitTests/SDUnitTests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Graphics\PostProcessChainTests.cs" />
     <Compile Include="Graphics\ShadowMapTests.cs" />
     <Compile Include="Graphics\SkinnedLightingEffectTests.cs" />
+    <Compile Include="Graphics\ExplosionLightIntensityTests.cs" />
     <Compile Include="ImpactSimulation.cs" />
     <Compile Include="Collections\ArrayT_Tests.cs" />
     <Compile Include="Collections\TestCollectionExt.cs" />

--- a/UnitTests/Utils/TestGetNumberString.cs
+++ b/UnitTests/Utils/TestGetNumberString.cs
@@ -1,0 +1,42 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ship_Game;
+
+namespace UnitTests.Utils;
+
+// Locks the format contract of HelperFunctions.GetNumberString so UI labels
+// (research bar, money leech, ship stats, etc.) stay consistent.
+[TestClass]
+public class TestGetNumberString
+{
+    [TestMethod]
+    [DataRow(0f, "0")]
+    [DataRow(0.25f, "0.25")]
+    [DataRow(95.75f, "95.75")]
+    [DataRow(100f, "100")]
+    [DataRow(950.7f, "950.7")]
+    [DataRow(999f, "999")]
+    [DataRow(1000f, "1000")]
+    [DataRow(9500f, "9500")]
+    [DataRow(10000f, "10k")]
+    [DataRow(57750f, "57.75k")]
+    [DataRow(950700f, "950.7k")]
+    [DataRow(1_000_000f, "1M")]
+    [DataRow(1_500_000f, "1.5M")]
+    [DataRow(100_000_000f, "100M")]
+    [DataRow(950_700_000f, "950.7M")]
+    [DataRow(1_000_000_000f, "1000M")]
+    public void FormatsExpectedString(float value, string expected)
+    {
+        Assert.AreEqual(expected, value.GetNumberString());
+    }
+
+    [TestMethod]
+    [DataRow(-0.25f, "-0.25")]
+    [DataRow(-9500f, "-9500")]
+    [DataRow(-57750f, "-57.75k")]
+    [DataRow(-1_500_000f, "-1.5M")]
+    public void FormatsNegativeValues(float value, string expected)
+    {
+        Assert.AreEqual(expected, value.GetNumberString());
+    }
+}

--- a/UnitTests/Utils/TestGetNumberString.cs
+++ b/UnitTests/Utils/TestGetNumberString.cs
@@ -18,7 +18,7 @@ public class TestGetNumberString
     [DataRow(1000f, "1000")]
     [DataRow(9500f, "9500")]
     [DataRow(10000f, "10k")]
-    [DataRow(57750f, "57.75k")]
+    [DataRow(57750f, "57.8k")]
     [DataRow(950700f, "950.7k")]
     [DataRow(1_000_000f, "1M")]
     [DataRow(1_500_000f, "1.5M")]
@@ -33,7 +33,7 @@ public class TestGetNumberString
     [TestMethod]
     [DataRow(-0.25f, "-0.25")]
     [DataRow(-9500f, "-9500")]
-    [DataRow(-57750f, "-57.75k")]
+    [DataRow(-57750f, "-57.8k")]
     [DataRow(-1_500_000f, "-1.5M")]
     public void FormatsNegativeValues(float value, string expected)
     {

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -12464,6 +12464,9 @@ SpiralMagellanicGalaxyGame:
 SpiralMagellanicGalaxyGameTip:
  Id: 4533
  ENG: "A visibly lopsided galaxy with a single fat asymmetric arm wrapping around an off-center bulge. Most empires start inside the dense central bulge; the rest spread along the arm."
+EspionageTotalMoneyLeechedTip:
+ Id: 4534
+ ENG: "Total credits leeched from this empire since infiltration reached Level 5. The per-turn amount is shown under 'Money Leeched' on the Budget screen."
 FlatIncomePerTurn:
  Id: 4384
  ENG: "Flat Income Per Turn" 
@@ -15285,7 +15288,7 @@ CounterEspioangeOpsFailedDetected:
  ENG: "Our Counter-Espioange effort has badly failed and our agents were detected.\nThey might have expanded their Spy Network on us."        
 CounterEspioangeOpsFailedAgentCaught:
  Id: 6270
- ENG: "A foreign Counter-Espioange effort has badly failed.\nTheir spy networked suffered a setback."         
+ ENG: "A foreign Counter-Espioange effort has badly failed."
 CounterEspioangeOpsFailedWipeout:
  Id: 6271
  ENG: "Our Counter-Espioange was a disaster.\n Our agents were detected our Infiltration Level was reduced.\Moreover, it is possible they gained Infiltration Level."         

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -12467,6 +12467,9 @@ SpiralMagellanicGalaxyGameTip:
 EspionageTotalMoneyLeechedTip:
  Id: 4534
  ENG: "Total credits leeched from this empire since infiltration reached Level 5. The per-turn amount is shown under 'Money Leeched' on the Budget screen."
+ResearchDisruptedByInfiltrationTip:
+ Id: 4535
+ ENG: "Research output is being slowed by enemy infiltration this turn. The percentage shows how much research is getting through. Each successful disruption mission cuts research by 10%."
 FlatIncomePerTurn:
  Id: 4384
  ENG: "Flat Income Per Turn" 


### PR DESCRIPTION
## Summary

Jupiter 1.60 patch batch — bug fixes reported by players plus a couple of long-standing migration regressions.

**Espionage & research**
- Sabotage now redirects labor away from frozen build queue (player no longer loses prod silently)
- Fix double-cost deduction, false setback claim, and leech label in InfiltrationOperation
- Float band coefficients in `RollMissionResult` so success rolls aren't rounded off
- Surface research disruption to the victim: red `(+XX)` net research + spy icon in top-bar, plus disruption % + tooltip on the Current Research tab

**Lighting / VFX (big-battle "ships go black")**
- `ExplosionManager`: clamp PointLight intensity at 0 during decay (subtractive lighting was draining the dynamic slot)
- `LightingEffectBinder`: exclude `Dynamic` point lights from system-sun candidacy (warp explosion lights were hijacking the sun slot)
- `Ship`: skip damage/mining visuals while at warp (stale emitters were lagging behind warping ships)

**UI legibility**
- `GetNumberString`: drop second decimal in k/M bands (10.45k → 10.5k); add M suffix and wire into research top-bar
- `EmpireUIOverlay`: fix measure/draw mismatch in top-bar money column
- `ResearchScreen` / `TreeNode`: force int `Rectangle` `FillRectangle` path for the unlocks-panel backdrop and inter-tree line anchor (the `RectF` overload silently renders nothing under the current MonoGame port)

**Long-standing regressions**
- `GameBase` + `UniverseScreen.Draw`: alt-tab from exclusive fullscreen now restores the backbuffer and rebuilds size-mismatched render targets (user-reported "fullscreen 1680x1050 alt-tab and back goes completely bork"). Shipped blind — `Log.Warning` fires when the restore path activates so we can verify in user logs.
- `Troop`: reload atlas when `TextureAtlas.IsDisposed` so ground troops stop rendering as red X after load-from-in-game

## Test plan
- [x] Big fleet battle with multiple simultaneous explosions — confirm ships no longer black-flash
- [x] Big fleet battle near a system — confirm system sun doesn't get displaced by warp-explosion lights
- [x] Espionage: run a sabotage op and verify the target's production redistributes (no silent loss)
- [x] Espionage: run a research-disrupt op as attacker AND victim — red `(+XX)` net + spy icon visible in victim's top-bar; Current Research tab shows disruption % + tooltip
- [x] Money/research K/M readouts — single decimal everywhere
- [x] Research tree: unlocks panel has black backdrop again; inter-node connection lines join cleanly (no 5px gap)
- [ ] Fullscreen 1680x1050 → alt-tab to desktop → alt-tab back → game still renders correctly. If anything misbehaves, check logs for `Alt-tab restore: backbuffer drifted ...` line.
- [x] In an ongoing game with troops on a planet, load a save — open the ColonyScreen / CombatScreen and confirm troop sprites animate (no red X)

🤖 Generated with [Claude Code](https://claude.com/claude-code)