### PR TITLE
Jupiter 1.60/fixes 13

### DIFF
--- a/SDAnalyzers/PremulColorAnalyzer.cs
+++ b/SDAnalyzers/PremulColorAnalyzer.cs
@@ -1,0 +1,158 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace SDAnalyzers;
+
+/// <summary>
+/// Flags non-premultiplied <c>new Color(R, G, B, A &lt; 255)</c> literals fed to SpriteBatch
+/// draws. The default MonoGame SpriteBatch BlendState is AlphaBlend (premultiplied), so a
+/// raw non-premul vertex Color with low alpha renders as additive RGB instead of as a faded
+/// tint. Append <c>.Premultiplied()</c> to the literal, or use <c>Color.Alpha(float)</c>
+/// (which premultiplies as of commit c966860fe).
+/// </summary>
+[DiagnosticAnalyzer(Microsoft.CodeAnalysis.LanguageNames.CSharp)]
+public class PremulColorAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "SD0001";
+
+    static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        title: "Non-premultiplied Color literal with alpha < 255",
+        messageFormat: "'new Color(...)' with alpha < 255 renders additive-bright under premul AlphaBlend; chain '.Premultiplied()' or use 'Color.Alpha(float)'",
+        category: "Rendering",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The default SpriteBatch BlendState is premultiplied AlphaBlend. " +
+                     "A raw 'new Color(R, G, B, A < 255)' literal feeds non-premul RGB through " +
+                     "the premul shader, rendering as additive RGB instead of a faded tint. " +
+                     "Append '.Premultiplied()' to the literal, or build the color via 'Color.Alpha(float)'.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeObjectCreation, Microsoft.CodeAnalysis.CSharp.SyntaxKind.ObjectCreationExpression);
+    }
+
+    static void AnalyzeObjectCreation(SyntaxNodeAnalysisContext context)
+    {
+        var creation = (ObjectCreationExpressionSyntax)context.Node;
+
+        // Resolve type — must be Microsoft.Xna.Framework.Color regardless of alias
+        var typeSymbol = context.SemanticModel.GetTypeInfo(creation, context.CancellationToken).Type;
+        if (typeSymbol is null || typeSymbol.ToDisplayString() != "Microsoft.Xna.Framework.Color")
+            return;
+
+        var argList = creation.ArgumentList;
+        if (argList is null) return;
+        var args = argList.Arguments;
+
+        // 4-arg byte ctor: new Color(R, G, B, A)
+        if (args.Count == 4)
+        {
+            if (!TryGetLiteralIntValue(args[3].Expression, out int alpha)) return;
+            if (alpha >= 255) return;
+
+            bool rIsLit = TryGetLiteralIntValue(args[0].Expression, out int r);
+            bool gIsLit = TryGetLiteralIntValue(args[1].Expression, out int g);
+            bool bIsLit = TryGetLiteralIntValue(args[2].Expression, out int b);
+
+            // Skip pure-black RGB — premul is a no-op on (0,0,0)
+            if (rIsLit && r == 0 && gIsLit && g == 0 && bIsLit && b == 0)
+                return;
+
+            // Skip RGB == alpha — premul of (R,G,B,A) equals (R,G,B,A) iff R==G==B==A,
+            // so the literal is already in premul form (intentional "pre-baked" tint).
+            if (rIsLit && gIsLit && bIsLit && r == alpha && g == alpha && b == alpha)
+                return;
+
+            if (IsAlreadyHandled(creation)) return;
+            context.ReportDiagnostic(Diagnostic.Create(Rule, creation.GetLocation()));
+            return;
+        }
+
+        // 2-arg ctor: new Color(Color, byte_or_float)
+        if (args.Count == 2)
+        {
+            // Skip if the first arg is Color.Black — pure black, premul is a no-op
+            if (IsColorBlackReference(args[0].Expression))
+                return;
+
+            if (TryGetLiteralIntValue(args[1].Expression, out int alphaByte))
+            {
+                if (alphaByte >= 255) return;
+                if (IsAlreadyHandled(creation)) return;
+                context.ReportDiagnostic(Diagnostic.Create(Rule, creation.GetLocation()));
+                return;
+            }
+
+            if (TryGetLiteralFloatValue(args[1].Expression, out double alphaFloat))
+            {
+                if (alphaFloat >= 1.0) return;
+                if (IsAlreadyHandled(creation)) return;
+                context.ReportDiagnostic(Diagnostic.Create(Rule, creation.GetLocation()));
+                return;
+            }
+        }
+    }
+
+    /// <summary>Returns true if the expression is a reference to Color.Black (e.g. <c>Color.Black</c>).</summary>
+    static bool IsColorBlackReference(ExpressionSyntax expr)
+    {
+        if (expr is MemberAccessExpressionSyntax member)
+            return member.Name.Identifier.ValueText == "Black";
+        return false;
+    }
+
+    /// <summary>
+    /// Returns true if <c>new Color(...)</c> is chained with .Premultiplied() or .Alpha(...),
+    /// walking through enclosing parentheses and ternary arms so patterns like
+    /// <c>(cond ? new Color(...) : new Color(...)).Premultiplied()</c> are recognized.
+    /// </summary>
+    static bool IsAlreadyHandled(ExpressionSyntax expr)
+    {
+        SyntaxNode? parent = expr.Parent;
+        while (parent is ParenthesizedExpressionSyntax or ConditionalExpressionSyntax)
+            parent = parent.Parent;
+
+        if (parent is MemberAccessExpressionSyntax memberAccess)
+        {
+            var name = memberAccess.Name.Identifier.ValueText;
+            return name == "Premultiplied" || name == "Alpha";
+        }
+        return false;
+    }
+
+    static bool TryGetLiteralIntValue(ExpressionSyntax expr, out int value)
+    {
+        value = 0;
+        // Strip casts like (byte)100
+        while (expr is CastExpressionSyntax cast)
+            expr = cast.Expression;
+
+        if (expr is LiteralExpressionSyntax lit && lit.Token.Value is int i)
+        {
+            value = i;
+            return true;
+        }
+        return false;
+    }
+
+    static bool TryGetLiteralFloatValue(ExpressionSyntax expr, out double value)
+    {
+        value = 0;
+        while (expr is CastExpressionSyntax cast)
+            expr = cast.Expression;
+
+        if (expr is LiteralExpressionSyntax lit)
+        {
+            if (lit.Token.Value is float f) { value = f; return true; }
+            if (lit.Token.Value is double d) { value = d; return true; }
+        }
+        return false;
+    }
+}

--- a/SDAnalyzers/PremulColorAnalyzer.cs
+++ b/SDAnalyzers/PremulColorAnalyzer.cs
@@ -6,11 +6,16 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace SDAnalyzers;
 
 /// <summary>
-/// Flags non-premultiplied <c>new Color(R, G, B, A &lt; 255)</c> literals fed to SpriteBatch
-/// draws. The default MonoGame SpriteBatch BlendState is AlphaBlend (premultiplied), so a
-/// raw non-premul vertex Color with low alpha renders as additive RGB instead of as a faded
-/// tint. Append <c>.Premultiplied()</c> to the literal, or use <c>Color.Alpha(float)</c>
-/// (which premultiplies as of commit c966860fe).
+/// Flags non-premultiplied <c>new Color(R, G, B, A &lt; 255)</c> and
+/// <c>new Color(Color, A &lt; 255)</c> literals regardless of how they're consumed.
+/// The default MonoGame SpriteBatch BlendState is AlphaBlend (premultiplied), so a raw
+/// non-premul vertex Color with low alpha renders as additive RGB instead of as a faded
+/// tint. The flag is broad on purpose: a low-alpha Color literal is almost never what you
+/// want under premul rendering, and erring toward false positives is cheaper than missing
+/// new sites. Append <c>.Premultiplied()</c> to the literal, or use <c>Color.Alpha(float)</c>
+/// (which premultiplies as of commit c966860fe). The trivial no-op cases — pure-black RGB,
+/// RGB == alpha (already in premul form), and <c>Color.Black</c> base in the 2-arg form —
+/// are skipped.
 /// </summary>
 [DiagnosticAnalyzer(Microsoft.CodeAnalysis.LanguageNames.CSharp)]
 public class PremulColorAnalyzer : DiagnosticAnalyzer
@@ -79,7 +84,7 @@ public class PremulColorAnalyzer : DiagnosticAnalyzer
         if (args.Count == 2)
         {
             // Skip if the first arg is Color.Black — pure black, premul is a no-op
-            if (IsColorBlackReference(args[0].Expression))
+            if (IsColorBlackReference(args[0].Expression, context.SemanticModel, context.CancellationToken))
                 return;
 
             if (TryGetLiteralIntValue(args[1].Expression, out int alphaByte))
@@ -100,12 +105,22 @@ public class PremulColorAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    /// <summary>Returns true if the expression is a reference to Color.Black (e.g. <c>Color.Black</c>).</summary>
-    static bool IsColorBlackReference(ExpressionSyntax expr)
+    /// <summary>
+    /// Returns true if the expression resolves to the field
+    /// <c>Microsoft.Xna.Framework.Color.Black</c> specifically. Syntactic name matching
+    /// alone is not enough — any unrelated <c>X.Black</c> would otherwise suppress SD0001.
+    /// </summary>
+    static bool IsColorBlackReference(ExpressionSyntax expr, SemanticModel semanticModel, System.Threading.CancellationToken ct)
     {
-        if (expr is MemberAccessExpressionSyntax member)
-            return member.Name.Identifier.ValueText == "Black";
-        return false;
+        if (expr is not MemberAccessExpressionSyntax member)
+            return false;
+        if (member.Name.Identifier.ValueText != "Black")
+            return false;
+
+        var symbol = semanticModel.GetSymbolInfo(member, ct).Symbol;
+        return symbol is (IFieldSymbol or IPropertySymbol)
+            && symbol.Name == "Black"
+            && symbol.ContainingType?.ToDisplayString() == "Microsoft.Xna.Framework.Color";
     }
 
     /// <summary>

--- a/SDAnalyzers/SDAnalyzers.csproj
+++ b/SDAnalyzers/SDAnalyzers.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <!-- RS2008: analyzer release tracking is a NuGet-publishing convention, not
+         meaningful for an internal in-repo analyzer. -->
+    <NoWarn>$(NoWarn);RS2008</NoWarn>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <Configurations>Debug;Release;Debug - Auto Fast;Release - Auto Fast;Deploy</Configurations>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/SDGraphics/SDGraphics.csproj
+++ b/SDGraphics/SDGraphics.csproj
@@ -68,6 +68,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SDUtils\SDUtils.csproj" />
+    <!-- Compile-time only: SD0001 fails build on non-premultiplied
+         `new Color(R,G,B,A<255)` literals fed to SpriteBatch draws.
+         Not copied into game/ output. -->
+    <ProjectReference Include="..\SDAnalyzers\SDAnalyzers.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Ship_Game/Commands/Goals/MarkForColonization.cs
+++ b/Ship_Game/Commands/Goals/MarkForColonization.cs
@@ -46,7 +46,7 @@ namespace Ship_Game.Commands.Goals
                 CheckNewOwnersInSystem = true;
             }
 
-            if (AIControlsColonization && PositiveEnemyPresence(out _)) 
+            if (AIControlsColonization && PositiveEnemyPresence(out _))
                 return;
 
             // Fast track to colonize if planet is safe and we have a ready Colony Ship
@@ -64,6 +64,11 @@ namespace Ship_Game.Commands.Goals
             TargetPlanet = toColonize;
             FinishedShip = colonyShip;
             IsManualColonizationOrder = true;
+
+            Goal prior = owner.AI.FindGoal(g => g.Type == GoalType.MarkForColonization
+                                             && g.FinishedShip == colonyShip);
+            if (prior != null)
+                owner.AI.RemoveGoal(prior);
 
             colonyShip.AI.OrderColonization(toColonize);
             ChangeToStep(WaitForColonizationComplete);
@@ -249,6 +254,13 @@ namespace Ship_Game.Commands.Goals
 
         GoalStep WaitForColonizationComplete()
         {
+            if (TargetPlanet.Owner == Owner)
+            {
+                Owner.DecreaseFleetStrEmpireMultiplier(TargetEmpire);
+                ReleaseColonyShipAndTask();
+                return GoalStep.GoalComplete;
+            }
+
             if (!PlanetCanBeColonized())
             {
                 ReleaseColonyShipAndTask();
@@ -263,14 +275,7 @@ namespace Ship_Game.Commands.Goals
                 return GoalStep.GoalFailed;
             }
 
-            if (TargetPlanet.Owner == Owner)
-            {
-                Owner.DecreaseFleetStrEmpireMultiplier(TargetEmpire);
-                ReleaseColonyShipAndTask();
-                return GoalStep.GoalComplete;
-            }
-
-            if (FinishedShip == null 
+            if (FinishedShip == null
                 || !FinishedShip.AI.FindGoal(ShipAI.Plan.Colonize, out ShipAI.ShipGoal goal)
                 || goal.TargetPlanet != TargetPlanet)
             {
@@ -283,6 +288,9 @@ namespace Ship_Game.Commands.Goals
 
         bool PlanetCanBeColonized()
         {
+            if (TargetPlanet.Owner == Owner)
+                return false;
+
             if (!Owner.isPlayer && (PlanetRanker.IsColonizeBlockedByMorals(TargetPlanet.System, Owner)
                                    || TargetPlanet.Owner?.ParentEmpire != null && !Owner.IsAtWarWith(TargetPlanet.Owner.ParentEmpire)))
             {

--- a/Ship_Game/Debug/Page/PerfDebug.cs
+++ b/Ship_Game/Debug/Page/PerfDebug.cs
@@ -130,8 +130,8 @@ public class PerfDebug : DebugPage
             if (IsHeader)
             {
                 // dark blueish transparent background for Headers
-                var edgeColor = new Color(75, 99, 125, 100);
-                Color bkgColor = Hovered ? edgeColor : new Color(35, 59, 85, 50);
+                var edgeColor = new Color(75, 99, 125, 100).Premultiplied();
+                Color bkgColor = Hovered ? edgeColor : new Color(35, 59, 85, 50).Premultiplied();
                 new Selector(Rect, bkgColor, edgeColor).Draw(batch, elapsed);
             }
             base.Draw(batch, elapsed);

--- a/Ship_Game/DeepSpaceBuildingWindow.cs
+++ b/Ship_Game/DeepSpaceBuildingWindow.cs
@@ -241,7 +241,7 @@ namespace Ship_Game
                 if (OkToBuild(planet, null))
                 {
                     float radius = 2500f * planet.Scale;
-                    Screen.DrawCircleProjected(planet.Position, radius, new Color(255, 165, 0, 100), 2f,
+                    Screen.DrawCircleProjected(planet.Position, radius, new Color(255, 165, 0, 100).Premultiplied(), 2f,
                                                nodeTex, new Color(0, 0, 255, 100).Premultiplied());
                 }
             }
@@ -252,13 +252,13 @@ namespace Ship_Game
                 {
                     if (ShipToBuild?.IsResearchStation == true)
                     {
-                        Screen.DrawCircleProjected(system.Position, system.Radius * 0.3f, new Color(255, 165, 0, 100), 2f,
+                        Screen.DrawCircleProjected(system.Position, system.Radius * 0.3f, new Color(255, 165, 0, 100).Premultiplied(), 2f,
                             nodeTex, new Color(0, 0, 255, 100).Premultiplied());
                     }
                 }
 
                 Screen.DrawCircleProjected(system.Position, system.SunDangerRadius.LowerBound(MinimumBuildDistanceFromSun),
-                    new Color(255, 0, 0, 100), 2f, nodeTex, new Color(255, 0, 0, 50).Premultiplied());
+                    new Color(255, 0, 0, 100).Premultiplied(), 2f, nodeTex, new Color(255, 0, 0, 50).Premultiplied());
             }
 
             base.Draw(batch, elapsed);
@@ -298,7 +298,7 @@ namespace Ship_Game
                             TargetPlanet = planet;
 
                             Vector2 planetScreenPos = Screen.ProjectToScreenPosition(planet.Position).ToVec2f();
-                            batch.DrawLine(planetScreenPos, cursorPos, new Color(255, 165, 0, 150), 3f);
+                            batch.DrawLine(planetScreenPos, cursorPos, new Color(255, 165, 0, 150).Premultiplied(), 3f);
                             batch.DrawString(Fonts.Arial20Bold, "Will Orbit " + planet.Name, cursorPos + new Vector2(0, 34f), Color.White);
                             break;
                         }
@@ -316,7 +316,7 @@ namespace Ship_Game
                     TargetSystem = null;
                 }
 
-                Color shipColor = OkToBuild(TargetPlanet, TargetSystem) ? new Color(0, 255, 0, 100) : Color.Red.Alpha(100);
+                Color shipColor = OkToBuild(TargetPlanet, TargetSystem) ? new Color(0, 255, 0, 100).Premultiplied() : Color.Red.Alpha(100);
                 batch.Draw(platform, cursorPos, shipColor, 0f, IconOrigin, (float)scale, SpriteEffects.None, 1f);
             }
         }

--- a/Ship_Game/DropDownMenu.cs
+++ b/Ship_Game/DropDownMenu.cs
@@ -1,5 +1,6 @@
 using Microsoft.Xna.Framework.Graphics;
 using Color = Microsoft.Xna.Framework.Color;
+using SDGraphics;
 using SDUtils;
 using Vector2 = SDGraphics.Vector2;
 using Rectangle = SDGraphics.Rectangle;
@@ -67,7 +68,7 @@ namespace Ship_Game
 			bool hover = r.HitTest(GameBase.Base.Manager.input.CursorPosition);
 			if (hover)
 			{
-				batch.FillRectangle(r, new Color(128, 87, 43, 50));
+				batch.FillRectangle(r, new Color(128, 87, 43, 50).Premultiplied());
 			}
 			foreach (RecTexPair r in container)
 			{

--- a/Ship_Game/DropOptions.cs
+++ b/Ship_Game/DropOptions.cs
@@ -180,7 +180,7 @@ namespace Ship_Game
 
             bool hover = IsMouseHoveringOver(Rect);
             if (hover) // draw border if mouse is hovering
-                batch.FillRectangle(Rect, new Color(128, 87, 43, 50));
+                batch.FillRectangle(Rect, new Color(128, 87, 43, 50).Premultiplied());
 
             for (int i = 0; i < BorderCount; ++i) // draw borders
                 Border[i].Draw(batch, Color.White);

--- a/Ship_Game/ExplosionManager.cs
+++ b/Ship_Game/ExplosionManager.cs
@@ -227,7 +227,7 @@ namespace Ship_Game
             if (screen < 2) // Low-res explosion marker
             {
                 r.Width = r.Height = 1;
-                batch.Draw(ExplosionPixel, r, new Color(Color.LightYellow, a));
+                batch.Draw(ExplosionPixel, r, new Color(Color.LightYellow, a).Premultiplied());
                 return;
             }
 

--- a/Ship_Game/ExtensionMethods/HelperFunctions.cs
+++ b/Ship_Game/ExtensionMethods/HelperFunctions.cs
@@ -178,7 +178,7 @@ namespace Ship_Game
         {
             int xsize = xGridSize / numberXs;
             int ysize = yGridSize / numberYs;
-            var color  = new Color(211, 211, 211, 70);
+            var color  = new Color(211, 211, 211, 70).Premultiplied();
             var origin = new Vector2(xpos + 1, ypos);
             var end    = new Vector2(xpos, ypos + yGridSize - 1);
             for (int x = 0; x < numberXs; ++x)

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -399,7 +399,7 @@ namespace Ship_Game.Fleets
                 Ship s = Ships[x];
                 AssignExistingOrCreateNewNode(s);
             }
-            
+
             var centerSize = ArrangeSquad(CenterFlank, Vector2.Zero, FlankType.Center);
             ArrangeSquad(ScreenFlank, centerSize * -1, FlankType.Screen);
             var screenSize = ArrangeSquad(RearFlank, centerSize, FlankType.Rear);
@@ -552,50 +552,61 @@ namespace Ship_Game.Fleets
         {
             int upOrDown = flank == FlankType.Screen ? -1 : 1;
             float spacer = 1000 * upOrDown;
-            Vector2 squadOffset = new(0,spacer);
+            Vector2 squadOffset = new(0, spacer);
             int row = 0;
             int columns = flank == FlankType.Screen ? 9 : 5;
-            int rowMax = 1 +(squads.Count / columns).LowerBound(columns);
+            int rowMax = columns - 1; // wrap to a new row after `columns` squads
             float tallestSquad = 0;
-            Vector2 previousSizeLeft = Vector2.Zero;
-            Vector2 previousSizeRight = Vector2.Zero;
+
+            // Cumulative outer edges of squads placed on each side this row.
+            // Each squad's center is placed past the prior squad's edge by its
+            // own half-width so the bounding boxes touch but don't overlap.
+            float rightEdge = 0f; // running right-most X of odd-index squads
+            float leftEdge  = 0f; // running left-most X of even-index squads (row > 0)
 
             for (int index = 0; index < squads.Count; ++index)
             {
                 var squad = squads[index];
+                Vector2 sz = squad.GetSquadSize();
+                float halfX = sz.X * 0.5f;
+
                 if (row == 0)
                 {
                     int dir = upOrDown == 1 ? 1 : -1;
                     int wantedIndex = dir == 1 ? 0 : 3;
-                    int wantedShip = squad.Ships.Count >= wantedIndex + 1? wantedIndex  : -1;
+                    int wantedShip = squad.Ships.Count >= wantedIndex + 1 ? wantedIndex : -1;
                     float height = dir == -1 ? 0 : squad.Ships[wantedShip].GridHeight * 16 * dir;
-                    squad.SetOffSets(new(previousSizeLeft.X, squadOffset.Y + height));
-                    previousSizeLeft = squad.GetSquadSize();
-                    previousSizeRight = -squad.GetSquadSize();
+                    squad.SetOffSets(new(0, squadOffset.Y + height));
+                    rightEdge = halfX;
+                    leftEdge = -halfX;
                 }
                 else if (index % 2 == 1)
                 {
                     int dir = squad.Ships.Count >= 3 ? 2 : -1;
                     float width = dir == -1 ? 0 : squad.Ships[dir].GridWidth * 16;
-                    squad.SetOffSets(new(previousSizeLeft.X + width, squadOffset.Y));
-                    previousSizeLeft = squad.GetSquadSize();
+                    squad.SetOffSets(new(rightEdge + halfX + width, squadOffset.Y));
+                    rightEdge += sz.X + width;
                 }
                 else
                 {
                     int dir = squad.Ships.Count >= 2 ? 1 : -1;
                     float width = dir == -1 ? 0 : squad.Ships[dir].GridWidth * 16;
-                    squad.SetOffSets(new(previousSizeRight.X - width, squadOffset.Y));
-                    previousSizeRight = -squad.GetSquadSize();
+                    squad.SetOffSets(new(leftEdge - halfX - width, squadOffset.Y));
+                    leftEdge -= sz.X + width;
                 }
 
-                tallestSquad = Math.Max(tallestSquad, squad.GetSquadSize().Y);
+                tallestSquad = Math.Max(tallestSquad, sz.Y);
                 row++;
-                
+
                 if (row > rowMax)
                 {
                     row = 0;
-                    squadOffset.Y = (flank == FlankType.Screen ? -1 : 1) * tallestSquad;
-                    previousSizeLeft = previousSizeRight = Vector2.Zero;
+                    // accumulate Y instead of reassigning so subsequent rows
+                    // stack outward from the fleet center instead of snapping
+                    // back to a fixed offset.
+                    squadOffset.Y += upOrDown * tallestSquad;
+                    rightEdge = 0f;
+                    leftEdge = 0f;
                     tallestSquad = 0;
                 }
             }

--- a/Ship_Game/GameScreens/ColonyScreen.cs
+++ b/Ship_Game/GameScreens/ColonyScreen.cs
@@ -241,7 +241,7 @@ namespace Ship_Game
             {
                 if (!pgs.Habitable)
                     batch.FillRectangle(pgs.ClickRect, new Color(0, 0, 0, 200));
-                batch.DrawRectangle(pgs.ClickRect, new Color(211, 211, 211, 70), 2f);
+                batch.DrawRectangle(pgs.ClickRect, new Color(211, 211, 211, 70).Premultiplied(), 2f);
                 if (pgs.building != null)
                 {
                     Rectangle destinationRectangle2 = new Rectangle(pgs.ClickRect.X + pgs.ClickRect.Width / 2 - 32, pgs.ClickRect.Y + pgs.ClickRect.Height / 2 - 32, 64, 64);

--- a/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
@@ -429,7 +429,7 @@ namespace Ship_Game
                 if (!pgs.Habitable)
                     batch.FillRectangle(pgs.ClickRect, new Color(0, 0, 0, 200));
 
-                batch.DrawRectangle(pgs.ClickRect, new Color(211, 211, 211, 70), 2f);
+                batch.DrawRectangle(pgs.ClickRect, new Color(211, 211, 211, 70).Premultiplied(), 2f);
                 if (pgs.Building != null)
                 {
                     var buildingIcon = new Rectangle(pgs.ClickRect.X + pgs.ClickRect.Width / 2 - 32,

--- a/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
@@ -413,7 +413,7 @@ namespace Ship_Game
                 color = Color.Gray;
 
             if (enroute == 0)
-                color = new Color(color, 128);
+                color = new Color(color, 128).Premultiplied();
 
             string puncText = punctuation ? ": " : "";
             batch.DrawString(TextFont, $"{goodsType.Text}{puncText}{enroute}/{openSlots} {amount}", pos, color);

--- a/Ship_Game/GameScreens/Colors.cs
+++ b/Ship_Game/GameScreens/Colors.cs
@@ -16,7 +16,7 @@ namespace Ship_Game
         public static Color Warning(byte alpha = 255)       => new Color(Color.Yellow, alpha);       //indicate to user that command may fail
 
         public static readonly Color Cream = new Color(255, 239, 208);
-        public static readonly Color TransparentDarkGray = new Color(50, 50, 50, 128);
+        public static readonly Color TransparentDarkGray = new Color(50, 50, 50, 128).Premultiplied();
 
         // used as background colors for multiple 
         public static readonly Color TransparentBlackFill = new Color(0, 0, 0, 210);

--- a/Ship_Game/GameScreens/CombatScreen/CombatScreen.cs
+++ b/Ship_Game/GameScreens/CombatScreen/CombatScreen.cs
@@ -343,7 +343,7 @@ namespace Ship_Game
                         {
                             foreach (PlanetGridSquare moveTile in MovementTiles)
                             {
-                                batch.FillRectangle(moveTile.ClickRect, new Color(255, 255, 255, 30));
+                                batch.FillRectangle(moveTile.ClickRect, new Color(255, 255, 255, 30).Premultiplied());
                                 Vector2 center = moveTile.ClickRect.CenterF;
                                 DrawCircle(center, 5f, Color.White, 5f);
                                 DrawCircle(center, 5f, Color.Black);

--- a/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen.cs
+++ b/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen.cs
@@ -53,6 +53,14 @@ namespace Ship_Game
         RectF SelectedStuffRect;
         RectF OperationsRect;
         RectF PrioritiesRect;
+
+        // Both the per-node Target Priority sliders and the Operational Radius
+        // slider are currently disconnected from gameplay in practice — combat
+        // state changes overwrite the weights and the OrdersRadius slider has a
+        // relative/absolute unit mismatch that the AI ignores. Hide the panels
+        // until the underlying systems are reworked; flip back to true when the
+        // weights actually persist and OrdersRadius is honored.
+        static bool ShowTargetingPanels = false;
         RectF FleetOverviewRect;
         UITextBox FleetOverviewText;
         WeightSlider SliderAssist;

--- a/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_Draw.cs
+++ b/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_Draw.cs
@@ -307,25 +307,28 @@ namespace Ship_Game
                     batch.DrawString(Fonts.Arial20Bold, text, cursor, Colors.Cream);
                 }
 
-                cursor.Y = OperationsRect.Y + 10;
-                batch.DrawString(Fonts.Pirulen12, "Movement Orders", cursor, Colors.Cream);
+                if (ShowTargetingPanels)
+                {
+                    cursor.Y = OperationsRect.Y + 10;
+                    batch.DrawString(Fonts.Pirulen12, "Movement Orders", cursor, Colors.Cream);
 
-                OperationsSelector = new Selector(OperationsRect, new Color(0, 0, 0, 180));
-                OperationsSelector.Draw(batch, elapsed);
-                cursor = new Vector2(OperationsRect.X + 20, OperationsRect.Y + 10);
-                batch.DrawString(Fonts.Pirulen12, "Target Selection", cursor, Colors.Cream);
-                SliderArmor.Draw(batch);
-                SliderAssist.Draw(batch);
-                SliderDefend.Draw(batch);
-                SliderDps.Draw(batch);
-                SliderShield.Draw(batch);
-                SliderVulture.Draw(batch);
-                PrioritySelector = new Selector(PrioritiesRect, new Color(0, 0, 0, 180));
-                PrioritySelector.Draw(batch, elapsed);
-                cursor = new Vector2(PrioritiesRect.X + 20, PrioritiesRect.Y + 10);
-                batch.DrawString(Fonts.Pirulen12, "Priorities", cursor, Colors.Cream);
-                OperationalRadius.Draw(batch, elapsed);
-                SliderSize.Draw(ScreenManager);
+                    OperationsSelector = new Selector(OperationsRect, new Color(0, 0, 0, 180));
+                    OperationsSelector.Draw(batch, elapsed);
+                    cursor = new Vector2(OperationsRect.X + 20, OperationsRect.Y + 10);
+                    batch.DrawString(Fonts.Pirulen12, "Target Selection", cursor, Colors.Cream);
+                    SliderArmor.Draw(batch);
+                    SliderAssist.Draw(batch);
+                    SliderDefend.Draw(batch);
+                    SliderDps.Draw(batch);
+                    SliderShield.Draw(batch);
+                    SliderVulture.Draw(batch);
+                    PrioritySelector = new Selector(PrioritiesRect, new Color(0, 0, 0, 180));
+                    PrioritySelector.Draw(batch, elapsed);
+                    cursor = new Vector2(PrioritiesRect.X + 20, PrioritiesRect.Y + 10);
+                    batch.DrawString(Fonts.Pirulen12, "Priorities", cursor, Colors.Cream);
+                    OperationalRadius.Draw(batch, elapsed);
+                    SliderSize.Draw(ScreenManager);
+                }
             }
             else if (SelectedNodeList.Count > 1)
             {
@@ -335,25 +338,28 @@ namespace Ship_Game
 
                 batch.DrawString(Fonts.Arial20Bold, $"Group of {SelectedNodeList.Count} ships selected", cursor, Colors.Cream);
 
-                cursor.Y = OperationsRect.Y + 10;
-                batch.DrawString(Fonts.Pirulen12, "Group Movement Orders", cursor, Colors.Cream);
+                if (ShowTargetingPanels)
+                {
+                    cursor.Y = OperationsRect.Y + 10;
+                    batch.DrawString(Fonts.Pirulen12, "Group Movement Orders", cursor, Colors.Cream);
 
-                OperationsSelector = new Selector(OperationsRect, new Color(0, 0, 0, 180));
-                OperationsSelector.Draw(batch, elapsed);
-                cursor = new Vector2(OperationsRect.X + 20, OperationsRect.Y + 10);
-                batch.DrawString(Fonts.Pirulen12, "Group Target Selection", cursor, Colors.Cream);
-                SliderArmor.Draw(batch);
-                SliderAssist.Draw(batch);
-                SliderDefend.Draw(batch);
-                SliderDps.Draw(batch);
-                SliderShield.Draw(batch);
-                SliderVulture.Draw(batch);
-                PrioritySelector = new Selector(PrioritiesRect, new Color(0, 0, 0, 180));
-                PrioritySelector.Draw(batch, elapsed);
-                cursor = new Vector2(PrioritiesRect.X + 20, PrioritiesRect.Y + 10);
-                batch.DrawString(Fonts.Pirulen12, "Group Priorities", cursor, Colors.Cream);
-                OperationalRadius.Draw(batch, elapsed);
-                SliderSize.Draw(ScreenManager);
+                    OperationsSelector = new Selector(OperationsRect, new Color(0, 0, 0, 180));
+                    OperationsSelector.Draw(batch, elapsed);
+                    cursor = new Vector2(OperationsRect.X + 20, OperationsRect.Y + 10);
+                    batch.DrawString(Fonts.Pirulen12, "Group Target Selection", cursor, Colors.Cream);
+                    SliderArmor.Draw(batch);
+                    SliderAssist.Draw(batch);
+                    SliderDefend.Draw(batch);
+                    SliderDps.Draw(batch);
+                    SliderShield.Draw(batch);
+                    SliderVulture.Draw(batch);
+                    PrioritySelector = new Selector(PrioritiesRect, new Color(0, 0, 0, 180));
+                    PrioritySelector.Draw(batch, elapsed);
+                    cursor = new Vector2(PrioritiesRect.X + 20, PrioritiesRect.Y + 10);
+                    batch.DrawString(Fonts.Pirulen12, "Group Priorities", cursor, Colors.Cream);
+                    OperationalRadius.Draw(batch, elapsed);
+                    SliderSize.Draw(ScreenManager);
+                }
             }
             else
             {

--- a/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_HandleInput.cs
+++ b/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_HandleInput.cs
@@ -115,6 +115,8 @@ namespace Ship_Game
             if (input.LeftMouseClick && !ShipSL.HitTest(input.CursorPosition))
             {
                 Vector2 pickedPosition = CursorWorldPosition2D;
+                if (WouldOverlap(pickedPosition, ActiveShipDesign.Radius))
+                    return false;
                 AddDesignToFleet(ActiveShipDesign, pickedPosition);
 
                 // if we're holding shift key down, allow placing multiple designs
@@ -173,6 +175,65 @@ namespace Ship_Game
                 ActiveShipDesign = null;
             }
             // else: otherwise we will just have a data node
+
+            AssignNodeToSquad(node);
+        }
+
+        // Make sure the new node lives in a Squad so the squad rect/drag works
+        // (matches Ctrl+# fleet creation, which goes through AutoArrange). Prefer
+        // the nearest existing squad in any flank; if none are close enough,
+        // create a fresh single-node squad in the CenterFlank at the drop point.
+        void AssignNodeToSquad(FleetDataNode node)
+        {
+            if (SelectedFleet == null)
+                return;
+
+            // AllFlanks must contain refs to the individual flank arrays so
+            // that AllSquads enumeration sees squads we add via CenterFlank.
+            // On a fresh fleet (no AutoArrange) it's empty; on a save-loaded
+            // fleet the entries may not be identity-equal to the individual
+            // flank fields after StarData round-trip. Rebuild defensively.
+            SelectedFleet.AllFlanks.Clear();
+            SelectedFleet.AllFlanks.Add(SelectedFleet.CenterFlank);
+            SelectedFleet.AllFlanks.Add(SelectedFleet.LeftFlank);
+            SelectedFleet.AllFlanks.Add(SelectedFleet.RightFlank);
+            SelectedFleet.AllFlanks.Add(SelectedFleet.ScreenFlank);
+            SelectedFleet.AllFlanks.Add(SelectedFleet.RearFlank);
+
+            // already a member of some squad? nothing to do
+            foreach (Squad existing in AllSquads)
+                if (existing.DataNodes.ContainsRef(node))
+                    return;
+
+            const float JoinDistance = Squad.SquadSpacing * 2f;
+            Squad nearest = null;
+            float bestDist = float.MaxValue;
+            foreach (Squad candidate in AllSquads)
+            {
+                float d = candidate.Offset.Distance(node.RelativeFleetOffset);
+                if (d < bestDist)
+                {
+                    bestDist = d;
+                    nearest = candidate;
+                }
+            }
+
+            if (nearest != null && bestDist <= JoinDistance)
+            {
+                nearest.DataNodes.Add(node);
+                if (node.Ship != null) nearest.Ships.AddUnique(node.Ship);
+                return;
+            }
+
+            // No nearby squad — spin up a new one in the Center flank at the drop point.
+            var fresh = new Squad
+            {
+                Fleet = SelectedFleet,
+                Offset = node.RelativeFleetOffset,
+            };
+            fresh.DataNodes.Add(node);
+            if (node.Ship != null) fresh.Ships.Add(node.Ship);
+            SelectedFleet.CenterFlank.Add(fresh);
         }
 
         // delete all selected ships
@@ -369,7 +430,11 @@ namespace Ship_Game
         {
             if (GetRoundedNodeMove(newSpot, node.RelativeFleetOffset, out Vector2 difference))
             {
-                node.RelativeFleetOffset += difference;
+                Vector2 candidate = node.RelativeFleetOffset + difference;
+                (_, float radius) = GetNodeOffsetAndRadius(node);
+                if (WouldOverlap(candidate, radius, exclude: node))
+                    return;
+                node.RelativeFleetOffset = candidate;
                 if (node.Ship != null)
                 {
                     node.Ship.RelativeFleetOffset = node.RelativeFleetOffset;
@@ -401,6 +466,13 @@ namespace Ship_Game
             Vector2 newSpot = CursorWorldPosition2D;
             if (GetRoundedNodeMove(newSpot, selectedSquad.Offset, out Vector2 difference))
             {
+                foreach (FleetDataNode node in selectedSquad.DataNodes)
+                {
+                    (Vector2 oldPos, float radius) = GetNodeOffsetAndRadius(node);
+                    if (WouldOverlap(oldPos + difference, radius, excludeAll: selectedSquad.DataNodes))
+                        return;
+                }
+
                 selectedSquad.Offset += difference;
                 foreach (FleetDataNode node in selectedSquad.DataNodes)
                 {
@@ -412,6 +484,26 @@ namespace Ship_Game
                     }
                 }
             }
+        }
+
+        bool WouldOverlap(Vector2 candidateOffset, float candidateRadius,
+                          FleetDataNode exclude = null,
+                          IReadOnlyList<FleetDataNode> excludeAll = null)
+        {
+            if (SelectedFleet == null)
+                return false;
+
+            for (int i = 0; i < SelectedFleet.DataNodes.Count; i++)
+            {
+                FleetDataNode other = SelectedFleet.DataNodes[i];
+                if (other == exclude) continue;
+                if (excludeAll != null && excludeAll.Contains(other)) continue;
+
+                (Vector2 oPos, float oRadius) = GetNodeOffsetAndRadius(other);
+                if (candidateOffset.Distance(oPos) < candidateRadius + oRadius)
+                    return true;
+            }
+            return false;
         }
 
         void UpdateHoveredNodesList(InputState input)

--- a/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_HandleInput.cs
+++ b/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_HandleInput.cs
@@ -65,7 +65,7 @@ namespace Ship_Game
             if (HandleSingleNodeSelection(input, input.CursorPosition))
                 return false;
 
-            if (SelectedNodeList.Count > 1)
+            if (ShowTargetingPanels && SelectedNodeList.Count > 1)
             {
                 SliderDps.HandleInput(input);
                 SliderVulture.HandleInput(input);
@@ -334,6 +334,9 @@ namespace Ship_Game
         bool HandleSingleNodeSelection(InputState input, Vector2 mousePos)
         {
             if (SelectedNodeList.Count != 1)
+                return false;
+
+            if (!ShowTargetingPanels)
                 return false;
 
             var node = SelectedNodeList[0];

--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignScreenDraw.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignScreenDraw.cs
@@ -162,7 +162,7 @@ namespace Ship_Game
 
                     if (!HullEditMode && DesignedShip.PwrGrid.IsPowered(slot.Pos))
                     {
-                        Color yellow = ActiveModule != null ? new Color(Color.Yellow, 150) : Color.Yellow;
+                        Color yellow = ActiveModule != null ? new Color(Color.Yellow, 150).Premultiplied() : Color.Yellow;
                         batch.Draw(concreteGlass, rect, yellow);
                     }
 

--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignStat.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignStat.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Xna.Framework.Graphics;
 using Color = Microsoft.Xna.Framework.Color;
+using SDGraphics;
 namespace Ship_Game.GameScreens.ShipDesign
 {
     public class ShipDesignStat : ScrollListItem<ShipDesignStat>
@@ -43,8 +44,8 @@ namespace Ship_Game.GameScreens.ShipDesign
             if (IsHeader)
             {
                 // dark blueish transparent background for Headers
-                var edgeColor = new Color(75, 99, 125, 100);
-                Color bkgColor = Hovered ? edgeColor : new Color(35, 59, 85, 50);
+                var edgeColor = new Color(75, 99, 125, 100).Premultiplied();
+                Color bkgColor = Hovered ? edgeColor : new Color(35, 59, 85, 50).Premultiplied();
                 new Selector(Rect, bkgColor, edgeColor).Draw(batch, elapsed);
             }
             base.Draw(batch, elapsed);

--- a/Ship_Game/GameScreens/Universe/ColoniesListItem.cs
+++ b/Ship_Game/GameScreens/Universe/ColoniesListItem.cs
@@ -210,8 +210,8 @@ namespace Ship_Game
         {
             ProdStorage.Progress = P.ProdHere;
             FoodStorage.Progress = P.FoodHere;
-            var TextColor2 = new Color(118, 102, 67, 50);
-            var smallHighlight = new Color(118, 102, 67, 25);
+            var TextColor2 = new Color(118, 102, 67, 50).Premultiplied();
+            var smallHighlight = new Color(118, 102, 67, 25).Premultiplied();
             if (ItemIndex % 2 == 0)
             {
                 batch.FillRectangle(Rect, smallHighlight);

--- a/Ship_Game/GameScreens/Universe/EmpireManagementScreen.cs
+++ b/Ship_Game/GameScreens/Universe/EmpireManagementScreen.cs
@@ -172,7 +172,7 @@ namespace Ship_Game
                 {
                     batch.FillRectangle(rect, new Color(0, 0, 0, 200));
                 }
-                batch.DrawRectangle(rect, new Color(211, 211, 211, 100), 0.5f);
+                batch.DrawRectangle(rect, new Color(211, 211, 211, 100).Premultiplied(), 0.5f);
 
                 if (tile.Building != null)
                 {
@@ -231,16 +231,16 @@ namespace Ship_Game
             batch.DrawLine(topLeftSL, botSL, lineColor);
             topLeftSL = new Vector2(e1.FoodRect.X, columnTop);
             botSL     = new Vector2(topLeftSL.X, columnBot);
-            batch.DrawLine(topLeftSL, botSL, new Color(lineColor, 100));
+            batch.DrawLine(topLeftSL, botSL, new Color(lineColor, 100).Premultiplied());
             topLeftSL = new Vector2(e1.ProdRect.X, columnTop);
             botSL     = new Vector2(topLeftSL.X, columnBot);
-            batch.DrawLine(topLeftSL, botSL, new Color(lineColor, 100));
+            batch.DrawLine(topLeftSL, botSL, new Color(lineColor, 100).Premultiplied());
             topLeftSL = new Vector2(e1.ResRect.X, columnTop);
             botSL     = new Vector2(topLeftSL.X, columnBot);
-            batch.DrawLine(topLeftSL, botSL, new Color(lineColor, 100));
+            batch.DrawLine(topLeftSL, botSL, new Color(lineColor, 100).Premultiplied());
             topLeftSL = new Vector2(e1.MoneyRect.X, columnTop);
             botSL     = new Vector2(topLeftSL.X, columnBot);
-            batch.DrawLine(topLeftSL, botSL, new Color(lineColor, 100));
+            batch.DrawLine(topLeftSL, botSL, new Color(lineColor, 100).Premultiplied());
             topLeftSL = new Vector2(e1.SliderRect.X, columnTop);
             botSL     = new Vector2(topLeftSL.X, columnBot);
             batch.DrawLine(topLeftSL, botSL, lineColor);

--- a/Ship_Game/GameScreens/Universe/EmpireManagementScreen.cs
+++ b/Ship_Game/GameScreens/Universe/EmpireManagementScreen.cs
@@ -176,7 +176,7 @@ namespace Ship_Game
 
                 if (tile.Building != null)
                 {
-                    Color c = tile.QItem != null ? White : new Color(White, 128);
+                    Color c = tile.QItem != null ? White : new Color(White, 128).Premultiplied();
                     batch.Draw(tile.Building.IconTex, rect.CenterF - new Vector2(18), new Vector2(36), c);
                 }
 

--- a/Ship_Game/GameScreens/Universe/EmpireScreen.cs
+++ b/Ship_Game/GameScreens/Universe/EmpireScreen.cs
@@ -213,7 +213,7 @@ namespace Ship_Game
                 {
                     batch.FillRectangle(pgs.ClickRect, new Color(0, 0, 0, 200));
                 }
-                batch.DrawRectangle(pgs.ClickRect, new Color(211, 211, 211, 70), 2f);
+                batch.DrawRectangle(pgs.ClickRect, new Color(211, 211, 211, 70).Premultiplied(), 2f);
                 if (pgs.building != null)
                 {
                     Rectangle bRect = new Rectangle(pgs.ClickRect.X + pgs.ClickRect.Width / 2 - 24, pgs.ClickRect.Y + pgs.ClickRect.Height / 2 - 24, 48, 48);
@@ -369,11 +369,11 @@ namespace Ship_Game
                 var entry = (EmpireScreenEntry)e.item;
                 if (i % 2 == 0)
                 {
-                    batch.FillRectangle(entry.TotalEntrySize, smallHighlight);
+                    batch.FillRectangle(entry.TotalEntrySize, smallHighlight.Premultiplied());
                 }
                 if (entry.p == SelectedPlanet)
                 {
-                    batch.FillRectangle(entry.TotalEntrySize, TextColor);
+                    batch.FillRectangle(entry.TotalEntrySize, TextColor.Premultiplied());
                 }
                 entry.SetNewPos(eRect.X + 22, e.Y);
                 entry.Draw(batch);
@@ -392,16 +392,16 @@ namespace Ship_Game
             batch.DrawLine(topLeftSL, botSL, lineColor);
             topLeftSL = new Vector2(e1.FoodRect.X, eRect.Y + 35);
             botSL = new Vector2(topLeftSL.X, PlanetInfoRect.Y);
-            batch.DrawLine(topLeftSL, botSL, new Color(lineColor, 100));
+            batch.DrawLine(topLeftSL, botSL, new Color(lineColor, 100).Premultiplied());
             topLeftSL = new Vector2(e1.ProdRect.X, eRect.Y + 35);
             botSL = new Vector2(topLeftSL.X, PlanetInfoRect.Y);
-            batch.DrawLine(topLeftSL, botSL, new Color(lineColor, 100));
+            batch.DrawLine(topLeftSL, botSL, new Color(lineColor, 100).Premultiplied());
             topLeftSL = new Vector2(e1.ResRect.X, eRect.Y + 35);
             botSL = new Vector2(topLeftSL.X, PlanetInfoRect.Y);
-            batch.DrawLine(topLeftSL, botSL, new Color(lineColor, 100));
+            batch.DrawLine(topLeftSL, botSL, new Color(lineColor, 100).Premultiplied());
             topLeftSL = new Vector2(e1.MoneyRect.X, eRect.Y + 35);
             botSL = new Vector2(topLeftSL.X, PlanetInfoRect.Y);
-            batch.DrawLine(topLeftSL, botSL, new Color(lineColor, 100));
+            batch.DrawLine(topLeftSL, botSL, new Color(lineColor, 100).Premultiplied());
             topLeftSL = new Vector2(e1.SliderRect.X, eRect.Y + 35);
             botSL = new Vector2(topLeftSL.X, PlanetInfoRect.Y);
             batch.DrawLine(topLeftSL, botSL, lineColor);

--- a/Ship_Game/RefitToWindow.cs
+++ b/Ship_Game/RefitToWindow.cs
@@ -88,15 +88,18 @@ namespace Ship_Game
             RefitShipList.EnableItemHighlight = true;
             RefitShipList.OnClick = OnRefitShipItemClicked;
 
-            foreach (IShipDesign design in ShipToRefit.Loyalty.ShipsWeCanBuildSnapshot)
+            if (!ShipToRefit.IsSubspaceProjector)
             {
-                if ((design.Hull == ShipToRefit.ShipData.Hull || ShipToRefit.IsResearchStation || ShipToRefit.IsMiningStation) 
-                    && design != ShipToRefit.ShipData 
-                    && !design.ShipRole.Protected
-                    && ShipToRefit.IsResearchStation == design.IsResearchStation
-                    && ShipToRefit.IsMiningStation == design.IsMiningStation)
+                foreach (IShipDesign design in ShipToRefit.Loyalty.ShipsWeCanBuildSnapshot)
                 {
-                    RefitShipList.AddItem(new RefitShipListItem(this, design));
+                    if ((design.Hull == ShipToRefit.ShipData.Hull || ShipToRefit.IsResearchStation || ShipToRefit.IsMiningStation)
+                        && design != ShipToRefit.ShipData
+                        && !design.ShipRole.Protected
+                        && ShipToRefit.IsResearchStation == design.IsResearchStation
+                        && ShipToRefit.IsMiningStation == design.IsMiningStation)
+                    {
+                        RefitShipList.AddItem(new RefitShipListItem(this, design));
+                    }
                 }
             }
 

--- a/Ship_Game/ReplayElement.cs
+++ b/Ship_Game/ReplayElement.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework.Graphics;
 using Color = Microsoft.Xna.Framework.Color;
+using SDGraphics;
 using SDUtils;
 using SDGraphics.Input;
 using Ship_Game.Universe;
@@ -112,13 +113,13 @@ namespace Ship_Game
                 {
                     Vector2 origin = new Vector2(x * MapRect.Width / 20f, 0f) + new Vector2(MapRect.X, MapRect.Y);
                     Vector2 end    = new Vector2(x * MapRect.Width / 20f, MapRect.Height) + new Vector2(MapRect.X, MapRect.Y);
-                    batch.DrawLine(origin, end, new Color(100, 100, 100, 70));
+                    batch.DrawLine(origin, end, new Color(100, 100, 100, 70).Premultiplied());
                 }
                 for (int y = 0; y < 21; y++)
                 {
                     Vector2 origin = new Vector2(0f, y * MapRect.Height / 20f) + new Vector2(MapRect.X, MapRect.Y);
                     Vector2 end    = new Vector2(MapRect.Width, y * MapRect.Height / 20f) + new Vector2(MapRect.X, MapRect.Y);
-                    batch.DrawLine(origin, end, new Color(100, 100, 100, 40));
+                    batch.DrawLine(origin, end, new Color(100, 100, 100, 40).Premultiplied());
                 }
             }
             batch.Draw(ResourceManager.Texture("EndGameScreen/TextBox"), TextRect, Color.White);

--- a/Ship_Game/ReplayElement.cs
+++ b/Ship_Game/ReplayElement.cs
@@ -236,7 +236,7 @@ namespace Ship_Game
                                 (int) (nro.Radius * scale * 2f),
                                 (int) (nro.Radius * scale * 2f));
                             var empire = UState.Empires[entry.Key];
-                            batch.Draw(ResourceManager.Texture("UI/node"), starRect, new Color(empire.EmpireColor, 128));
+                            batch.Draw(ResourceManager.Texture("UI/node"), starRect, new Color(empire.EmpireColor, 128).Premultiplied());
                         }
                     }
                 }

--- a/Ship_Game/ShipListInfoUIElement.cs
+++ b/Ship_Game/ShipListInfoUIElement.cs
@@ -122,10 +122,10 @@ namespace Ship_Game
                 {
                     Ship s = (Ship)button.ReferenceObject;
                     if (s.HealthPercent < 0.75f)
-                        button.UpdateBackGroundTexColor(new Color(Color.Yellow, alpha));
+                        button.UpdateBackGroundTexColor(new Color(Color.Yellow, alpha).Premultiplied());
 
                     if (s.InternalSlotsHealthPercent < 0.75f)
-                        button.UpdateBackGroundTexColor(new Color(Color.Red, alpha));
+                        button.UpdateBackGroundTexColor(new Color(Color.Red, alpha).Premultiplied());
                 }
             }
 

--- a/Ship_Game/ShipListScreenItem.cs
+++ b/Ship_Game/ShipListScreenItem.cs
@@ -169,7 +169,8 @@ namespace Ship_Game
                 ExploreButton.Draw(batch);
                 //PatrolButton.Draw(batch); // FB - Disabled until we make it better
             }
-            RefitButton.Draw(batch);
+            if (!Ship.IsSubspaceProjector)
+                RefitButton.Draw(batch);
             ScrapButton.Draw(batch);
 
             batch.DrawRectangle(TotalEntrySize, new Color(118, 102, 67, 50).Premultiplied());
@@ -372,7 +373,7 @@ namespace Ship_Game
                 }
             }
 
-            if (RefitButton.HandleInput(input))
+            if (!Ship.IsSubspaceProjector && RefitButton.HandleInput(input))
             {
                 GameAudio.EchoAffirmative();
                 Screen.ScreenManager.AddScreen(new RefitToWindow(Screen, this));

--- a/Ship_Game/ShipListScreenItem.cs
+++ b/Ship_Game/ShipListScreenItem.cs
@@ -172,7 +172,7 @@ namespace Ship_Game
             RefitButton.Draw(batch);
             ScrapButton.Draw(batch);
 
-            batch.DrawRectangle(TotalEntrySize, new Color(118, 102, 67, 50));
+            batch.DrawRectangle(TotalEntrySize, new Color(118, 102, 67, 50).Premultiplied());
         }
 
         public static string GetStatusText(Ship ship)

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -1385,7 +1385,7 @@ namespace Ship_Game.Ships
 
             float newShipCost = newShip.GetCost(Loyalty);
             int cost          = Math.Max((int)(newShipCost - oldShipCost), 0);
-            return cost + (int)(10 * Universe.ProductionPace); // extra refit cost: accord for GamePace;
+            return cost + (int)(newShipCost * 0.1f); // 10% of new ship cost as refit overhead (already paced via GetCost)
         }
 
         public bool IsTethered => TetheredTo != null;

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -1455,21 +1455,37 @@ namespace Ship_Game.Ships
         }
 
         // Base chance to evade and exploding ship
-        public int ExplosionEvadeBaseChance()
+        // FB: Ships will be lucky to not get caught in the explosion, based on their level as well.
+        // Point-blank (closest module inside the exploding ship's hull radius) drops evade to 10% of normal.
+        public float ExplosionEvadeBaseChance(bool pointBlank)
         {
+            float explosionEvadeBaseChance = 0;
             switch (ShipData.HullRole)
             {
                 default:
-                case RoleName.drone:      return 80;
-                case RoleName.scout:      return 80;
-                case RoleName.fighter:    return 70;
-                case RoleName.corvette:   return 60;
-                case RoleName.frigate:    return 40;
-                case RoleName.cruiser:    return 20;
-                case RoleName.battleship: return 10;
+                case RoleName.drone:     
+                case RoleName.scout:      explosionEvadeBaseChance = 80; break;
+                case RoleName.fighter:    explosionEvadeBaseChance = 70; break;
+                case RoleName.corvette:   explosionEvadeBaseChance = 60; break;
+                case RoleName.frigate:    explosionEvadeBaseChance = 40; break;
+                case RoleName.cruiser:    explosionEvadeBaseChance = 20; break;
+                case RoleName.battleship: explosionEvadeBaseChance = 10; break;
                 case RoleName.capital: 
-                case RoleName.station:    return 0;
+                case RoleName.station:    explosionEvadeBaseChance = 0; break;
             }
+
+            explosionEvadeBaseChance += Level;
+            if (pointBlank)
+                switch (ShipData.HullRole)
+                {
+                    case RoleName.drone:
+                    case RoleName.scout:   
+                    case RoleName.fighter: return explosionEvadeBaseChance;
+                    default:               return explosionEvadeBaseChance * 0.1f;
+
+                }
+
+            return explosionEvadeBaseChance;
         }
 
         void AddExplosionEffect(bool addWarpExplode)
@@ -1608,7 +1624,7 @@ namespace Ship_Game.Ships
                 if (PlanetCrash == null)
                 {
                     float explosionDamage = GetExplosionDamage();
-                    Universe.Spatial.ShipExplode(this, explosionDamage, Position, Radius + explosionDamage / 500);
+                    Universe.Spatial.ShipExplode(this, explosionDamage, Position, Radius + explosionDamage * 0.01f);
                     if (visible)
                     {
                         // Added by RedFox - spawn flaming spacejunk when a ship dies

--- a/Ship_Game/Ships/ShipInfoUIElement.cs
+++ b/Ship_Game/Ships/ShipInfoUIElement.cs
@@ -689,7 +689,7 @@ namespace Ship_Game.Ships
             }
             if (s.CanBeScrapped)
             {
-                if (!s.IsConstructor)
+                if (!s.IsConstructor && !s.IsSubspaceProjector)
                 {
                     var rf = new OrdersButton(s, OrderType.Refit, GameText.OrderShipRefit)
                     {

--- a/Ship_Game/Ships/Ship_ModuleGrid.cs
+++ b/Ship_Game/Ships/Ship_ModuleGrid.cs
@@ -470,9 +470,25 @@ namespace Ship_Game.Ships
         public ShipModule FindClosestModule(Vector2 worldPos)
         {
             if (!Active) return null;
-            foreach (ModuleQuadrant mq in EnumModulesQuadrants(worldPos, Radius, checkShields:false))
-                return mq.Module;
-            return null;
+
+            // The search rect in EnumModulesQuadrants is worldPos +/- searchRadius;
+            // it must reach the ship's grid (centered at Position, extent Radius)
+            // even when worldPos is far outside the hull, otherwise the overlap
+            // check short-circuits and we get null.
+            float searchRadius = worldPos.Distance(Position) + Radius;
+
+            ShipModule closest = null;
+            float bestDistSq = float.MaxValue;
+            foreach (ModuleQuadrant mq in EnumModulesQuadrants(worldPos, searchRadius, checkShields: false))
+            {
+                float distSq = mq.Module.Position.SqDist(worldPos);
+                if (distSq < bestDistSq)
+                {
+                    bestDistSq = distSq;
+                    closest = mq.Module;
+                }
+            }
+            return closest;
         }
 
         // find the first module that falls under the hit radius at given position

--- a/Ship_Game/Spatial/SpatialManager.cs
+++ b/Ship_Game/Spatial/SpatialManager.cs
@@ -231,11 +231,24 @@ namespace Ship_Game.Gameplay
             // find any nearby ship -- even allies
             SpatialObjectBase[] nearby = FindNearby(GameObjectType.Ship, thisShip, damageRadius + 64, maxResults:32);
 
-            for (int i = 0; i < nearby.Length && damageAmount > 0f; ++i)
+            for (int i = 0; i < nearby.Length; ++i)
             {
                 var otherShip = (Ship)nearby[i];
-                // FB: Ships will be lucky to not get caught in the explosion, based on their level as well
-                if (thisShip.Loyalty.Random.RollDice(otherShip.ExplosionEvadeBaseChance() + otherShip.Level))
+
+                ShipModule nearest = otherShip.FindClosestModule(explosionCenter);
+                if (nearest == null)
+                    continue;
+
+                float distToNearest = explosionCenter.Distance(nearest.Position);
+                float reducedRadius = damageRadius - distToNearest;
+                float evadeChance = otherShip.ExplosionEvadeBaseChance(distToNearest < thisShip.Radius);
+                if (reducedRadius < 0f || thisShip.Loyalty.Random.RollDice(evadeChance))
+                    continue;
+
+                // Per-target damage: each ship gets the full damage scaled by its own falloff.
+                float falloff = ShipModule.DamageFalloff(explosionCenter, nearest.Position, damageRadius, nearest.Radius);
+                float localDamage = damageAmount * falloff;
+                if (localDamage <= 0f)
                     continue;
 
                 // First damage all shields covering the explosion center
@@ -243,27 +256,17 @@ namespace Ship_Game.Gameplay
                 {
                     ShipModule shield = otherShip.HitTestShields(explosionCenter, 16f);
                     if (shield == null) break;
-                    shield.DamageShield(damageAmount, null, out damageAmount);
-                    if (damageAmount <= 0f)
-                        return;
+                    shield.DamageShield(localDamage, null, out localDamage);
+                    if (localDamage <= 0f)
+                        break;
                 }
 
-                ShipModule nearest = otherShip.FindClosestModule(explosionCenter);
-                if (nearest == null)
-                    continue;
-
-                float reducedRadius = damageRadius - explosionCenter.Distance(nearest.Position);
-                if (reducedRadius <= 0f)
-                    continue;
-
-                float falloff = ShipModule.DamageFalloff(explosionCenter, nearest.Position, damageRadius, nearest.Radius);
-                damageAmount *= falloff;
-                if (damageAmount <= 0f)
-                    return;
+                if (localDamage <= 0f)
+                    continue; // shields absorbed everything for this ship
 
                 // Then explode at the module if any excess damage left
                 // Ignoring shields because we already checked shields above
-                otherShip.DamageExplosive(thisShip, damageAmount, nearest.Position, reducedRadius, true);
+                otherShip.DamageExplosive(thisShip, localDamage, nearest.Position, reducedRadius, true);
 
                 if (!otherShip.Dying)
                 {
@@ -273,7 +276,7 @@ namespace Ship_Game.Gameplay
                 }
 
                 // apply some impulse from the explosion
-                Vector2 impulse = 3f * (otherShip.Position - explosionCenter);
+                Vector2 impulse = 10f * (otherShip.Position - explosionCenter);
                 if (impulse.Length() > 200f)
                     impulse = impulse.Normalized() * 200f;
 

--- a/Ship_Game/ToolTip.cs
+++ b/Ship_Game/ToolTip.cs
@@ -199,7 +199,7 @@ namespace Ship_Game
                 var sel = new Selector(Rect, new Color(Color.Black, (byte)alpha),  alpha);
                 sel.Draw(batch, elapsed);
 
-                var textColor = new Color((byte)102, (byte)178, (byte)255, (byte)alpha);
+                var textColor = new Color((byte)102, (byte)178, (byte)255, (byte)alpha).Premultiplied();
                 if (HotKey.NotEmpty())
                 {
                     string title = Localizer.Token(GameText.Hotkey) + ": ";
@@ -209,7 +209,7 @@ namespace Ship_Game
                     Vector2 hotKey = textPos;
                     hotKey.X += TipFont.MeasureString(title).X;
 
-                    batch.DrawString(TipFont, HotKey, hotKey, new Color(Color.Gold, (byte)alpha));
+                    batch.DrawString(TipFont, HotKey, hotKey, new Color(Color.Gold, (byte)alpha).Premultiplied());
                     textPos.Y += TipFont.LineSpacing * 2;
                 }
 

--- a/Ship_Game/UI/UIGraphView.cs
+++ b/Ship_Game/UI/UIGraphView.cs
@@ -131,8 +131,8 @@ namespace Ship_Game
 
             Rectangle inner = Rect.Bevel(-15);
 
-            var brown = new Color(Color.SaddleBrown, 150);
-            var backBrown = new Color(Color.SaddleBrown, 75);
+            var brown = new Color(Color.SaddleBrown, 150).Premultiplied();
+            var backBrown = new Color(Color.SaddleBrown, 75).Premultiplied();
             batch.DrawRectangle(Rect, brown);  // outer
             batch.DrawRectangle(inner, brown); // inner
 

--- a/Ship_Game/Universe/MiniMap.cs
+++ b/Ship_Game/Universe/MiniMap.cs
@@ -158,7 +158,7 @@ namespace Ship_Game
             lookingAt.X = (int)lookingAt.X.LowerBound(ActualMap.X);
             lookingAt.Y = (int)lookingAt.Y.LowerBound(ActualMap.Y);
 
-            batch.FillRectangle(lookingAt, new Color(255, 255, 255, 30));
+            batch.FillRectangle(lookingAt, new Color(255, 255, 255, 30).Premultiplied());
             batch.DrawRectangle(lookingAt, Color.White);
             var topMiddleView   = new Vector2(lookingAt.X +  lookingAt.Width / 2, lookingAt.Y);
             var botMiddleView   = new Vector2(topMiddleView.X - 1f, lookingAt.Y + lookingAt.Height);
@@ -208,7 +208,7 @@ namespace Ship_Game
             {
                 var point = WorldToMiniPos(c.Position);
                 radius = 0.025f * Universe.SlowFlashTimer;
-                var warningColor = new Color(Color.Yellow, 200);
+                var warningColor = new Color(Color.Yellow, 200).Premultiplied();
                 batch.Draw(Node1, point, warningColor, 0f, Node.CenterF, radius, SpriteEffects.None, 1f);
                 batch.Draw(Node1, point, Color.Black, 0f, Node.CenterF, radius - 0.005f, SpriteEffects.None, 1f);
                 batch.Draw(Node1, point, c.Loyalty.EmpireColor, 0f, Node.CenterF, 0.012f, SpriteEffects.None, 1f);

--- a/Ship_Game/Universe/SolarBodies/SolarsystemOverlay.cs
+++ b/Ship_Game/Universe/SolarBodies/SolarsystemOverlay.cs
@@ -121,7 +121,7 @@ namespace Ship_Game
                     Vector2d planetPos = pPos.PointFromAngle(p.OrbitalAngle, 40 + 40 * i);
                     planetPos -= ((planetPos - pPos).Normalized() * (40 + 40 * i) * transitionOffset);
 
-                    Color color = p.Owner == null ? new Color(50, 50, 50, 90) : new Color(p.Owner.EmpireColor, 100);
+                    Color color = p.Owner == null ? new Color(50, 50, 50, 90).Premultiplied() : new Color(p.Owner.EmpireColor, 100).Premultiplied();
                     batch.DrawCircle(pPos, pPos.Distance(planetPos), color, 2f);
                 }
 

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
@@ -1060,7 +1060,7 @@ namespace Ship_Game
                 {
                     Vector2d screenPos = DrawLineProjected(start, ship.AI.ColonizeTarget.Position, color, 2500f, 0);
                     string text = $"Colonize\nSystem : {ship.AI.ColonizeTarget.System.Name}\nPlanet : {ship.AI.ColonizeTarget.Name}";
-                    DrawPointerWithText(screenPos.ToVec2f(), ResourceManager.Texture("UI/planetNamePointer"), color, text, new Color(ship.Loyalty.EmpireColor, alpha));
+                    DrawPointerWithText(screenPos.ToVec2f(), ResourceManager.Texture("UI/planetNamePointer"), color, text, new Color(ship.Loyalty.EmpireColor, alpha).Premultiplied());
                     return;
                 }
                 if (ship.AI.State == AIState.Orbit && ship.AI.OrbitTarget != null)
@@ -1119,7 +1119,7 @@ namespace Ship_Game
                     DrawLineToPlanet(start, planet.Position, Colors.Error(alpha));
                     ToolTip.PlanetLandingSpotsTip($"{planet.Name}: Critical!", spots);
                 }
-                DrawWayPointLines(ship, new Color(Color.Lime, alpha));
+                DrawWayPointLines(ship, new Color(Color.Lime, alpha).Premultiplied());
                 return;
             }
 

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
@@ -22,7 +22,7 @@ namespace Ship_Game
 {
     public partial class UniverseScreen
     {
-        static readonly Color FleetLineColor    = new Color(255, 255, 255, 20);
+        static readonly Color FleetLineColor    = new Color(255, 255, 255, 20).Premultiplied();
         static readonly Vector2 FleetNameOffset = new Vector2(10f, -6f);
         public static float PulseTimer { get; private set; }
 
@@ -957,7 +957,7 @@ namespace Ship_Game
             if (!Project.Started || CurrentGroup == null)
                 return;
 
-            var projectedColor = new Color(0, 255, 0, 100);
+            var projectedColor = new Color(0, 255, 0, 100).Premultiplied();
             foreach (Ship ship in CurrentGroup.Ships)
             {
                 if (ship.Active)

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
@@ -638,18 +638,17 @@ namespace Ship_Game
                 {
                     if (ship is { WeaponsMaxRange: > 0f, IsVisibleToPlayer: true })
                     {
-                        Color color = ship.Loyalty == Player
-                                        ? new Color(0, 200, 0, 30)
-                                        : new Color(200, 0, 0, 30);
+                        Color baseTint = ship.Loyalty == Player ? new Color(0, 200, 0) : new Color(200, 0, 0);
+                        Color color = new Color(baseTint, (byte)30).Premultiplied();
 
                         byte edgeAlpha = 70;
-                        DrawCircleProjected(ship.Position, ship.WeaponsMaxRange, new Color(color, edgeAlpha));
+                        DrawCircleProjected(ship.Position, ship.WeaponsMaxRange, new Color(baseTint, edgeAlpha).Premultiplied());
                         if (SelectedShip == ship)
                         {
                             edgeAlpha = 70;
                             DrawTextureProjected(shipRangeTex, ship.Position, ship.WeaponsMaxRange, color);
-                            DrawCircleProjected(ship.Position, ship.WeaponsAvgRange, new Color(Color.Orange, edgeAlpha));
-                            DrawCircleProjected(ship.Position, ship.WeaponsMinRange, new Color(Color.Yellow, edgeAlpha));
+                            DrawCircleProjected(ship.Position, ship.WeaponsAvgRange, new Color(Color.Orange, edgeAlpha).Premultiplied());
+                            DrawCircleProjected(ship.Position, ship.WeaponsMinRange, new Color(Color.Yellow, edgeAlpha).Premultiplied());
                         }
                     }
 
@@ -658,11 +657,11 @@ namespace Ship_Game
                         if (SelectedShip == ship)
                         {
                             Color color = (ship.Loyalty.isPlayer)
-                                ? new Color(0, 100, 200, 20)
-                                : new Color(200, 0, 0, 10);
+                                ? new Color(0, 100, 200, 20).Premultiplied()
+                                : new Color(200, 0, 0, 10).Premultiplied();
                             float sensorRange = ship.AI.GetSensorRadius();
                             DrawTextureProjected(shipRangeTex, ship.Position, sensorRange, color);
-                            DrawCircleProjected(ship.Position, sensorRange, new Color(Color.Blue, 85));
+                            DrawCircleProjected(ship.Position, sensorRange, new Color(Color.Blue, 85).Premultiplied());
                         }
                     }
                 }
@@ -682,7 +681,7 @@ namespace Ship_Game
                     if (planet.System.IsExploredBy(Player))
                     {
                         DrawCircleProjected(planet.Position, planet.GravityWellRadius,
-                                            new Color(255, 50, 0, 150), 1f, inhibit, new Color(200, 0, 0, 50));
+                                            new Color(255, 50, 0, 150).Premultiplied(), 1f, inhibit, new Color(200, 0, 0, 50).Premultiplied());
                     }
                 }
 
@@ -690,16 +689,16 @@ namespace Ship_Game
                 {
                     if (ship is { InhibitionRadius: > 0f, IsVisibleToPlayer: true })
                     {
-                        DrawCircleProjected(ship.Position, ship.InhibitionRadius, 
-                                            new Color(255, 50, 0, 150), 1f, inhibit, new Color(200, 0, 0, 40));
+                        DrawCircleProjected(ship.Position, ship.InhibitionRadius,
+                                            new Color(255, 50, 0, 150).Premultiplied(), 1f, inhibit, new Color(200, 0, 0, 40).Premultiplied());
                     }
                 }
 
                 // draw blue positive influence nodes from bordernodes
                 if (viewState >= UnivScreenState.SectorView)
                 {
-                    var transparentBlue = new Color(30, 30, 150, 150);
-                    var transparentGreen = new Color(0, 200, 0, 20);
+                    var transparentBlue = new Color(30, 30, 150, 150).Premultiplied();
+                    var transparentGreen = new Color(0, 200, 0, 20).Premultiplied();
                     var frustum = VisibleWorldRect;
 
                     foreach (ref Empire.InfluenceNode n in Player.BorderNodes.AsSpan())

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
@@ -1296,7 +1296,7 @@ namespace Ship_Game
                     if (troopCount > 0)
                     {
                         posOffSet.X += (18 * drawLocationOffset);
-                        DrawTextureWithToolTip(icon_troop, new Color((byte)255, (byte)255, (byte)255, (byte)0), $"Troops {troopCount}", mousePos,
+                        DrawTextureWithToolTip(icon_troop, new Color((byte)255, (byte)255, (byte)255, (byte)0).Premultiplied(), $"Troops {troopCount}", mousePos,
                                                (int)posOffSet.X, (int)posOffSet.Y, 14, 14);
                         ++drawLocationOffset;
                     }

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Menus.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Menus.cs
@@ -48,7 +48,7 @@ namespace Ship_Game
                 var followIcon = ResourceManager.Texture("UI/FollowIcon");
                 var holdPosition = ResourceManager.Texture("UI/HoldPositionIcon");
                 var other = new PieMenuNode(GameText.Other, followIcon, null);
-                if (s is {IsPlatformOrStation: false, CanBeScrapped: true})
+                if (s is {IsPlatformOrStation: false, IsSubspaceProjector: false, CanBeScrapped: true})
                 {
                     other.Add(new(GameText.RefitTo, followIcon, () => RefitTo(s)));
                 }

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Render.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Render.cs
@@ -87,7 +87,7 @@ namespace Ship_Game
 
                 if (viewState > UnivScreenState.ShipView && !IsCinematicModeEnabled)
                 {
-                    var transparentDarkGray = new Color(50, 50, 50, 90);
+                    var transparentDarkGray = new Color(50, 50, 50, 90).Premultiplied();
                     DrawCircle(sysScreenPos, planetOrbitRadius, transparentDarkGray, 3f);
 
                     if (planet.Owner == null)
@@ -96,7 +96,7 @@ namespace Ship_Game
                     }
                     else
                     {
-                        var empireColor = new Color(planet.Owner.EmpireColor, 100);
+                        var empireColor = new Color(planet.Owner.EmpireColor, 100).Premultiplied();
                         DrawCircle(sysScreenPos, planetOrbitRadius, empireColor, 3f);
                     }
                 }
@@ -185,9 +185,9 @@ namespace Ship_Game
 
         void DrawSystemThreatCirclesAnimation(SpriteBatch batch)
         {
-            var red = new Color(Color.Red, 80);
-            var orange = new Color(Color.Orange, 80);
-            var black = new Color(Color.Black, 40);
+            var red = new Color(Color.Red, 80).Premultiplied();
+            var orange = new Color(Color.Orange, 80).Premultiplied();
+            var black = new Color(Color.Black, 40); // black premul is a no-op
 
             foreach (IncomingThreat threat in Player.SystemsWithThreat)
             {
@@ -402,7 +402,7 @@ namespace Ship_Game
                     DrawZones(Fonts.Pirulen16, $"Current list of planets in trade route: {numRoutes}", ref cursorY, Color.White);
 
                 foreach (Rectangle ao in SelectedShip.AreaOfOperation)
-                    DrawRectangleProjected(new RectF(ao), Color.Red, new Color(Color.Red, 50));
+                    DrawRectangleProjected(new RectF(ao), Color.Red, new Color(Color.Red, 50).Premultiplied());
 
                 // Draw Specific Trade Routes to planets
                 if (SelectedShip.IsFreighter)

--- a/StarDrive.csproj
+++ b/StarDrive.csproj
@@ -991,6 +991,11 @@
   <ItemGroup>
     <ProjectReference Include="SDGraphics\SDGraphics.csproj" />
     <ProjectReference Include="SDUtils\SDUtils.csproj" />
+    <!-- Compile-time only: build-fails on non-premultiplied `new Color(R,G,B,A<255)`
+         literals fed to SpriteBatch draws (SD0001). Not copied into game/ output. -->
+    <ProjectReference Include="SDAnalyzers\SDAnalyzers.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <!-- Phase 2.6.A: net8 imports System.Range by default which collides with the


### PR DESCRIPTION
## Summary

Post-Jupiter 1.60 batch covering a premul-alpha audit + analyzer to prevent regressions, several combat and fleet-UX fixes, a colonization-goal bug, and a refit-cost rebalance.

## Premultiplied-alpha sweep + SDAnalyzers SD0001

Default MonoGame SpriteBatch is `AlphaBlend` (premul), so inline `new Color(R,G,B,A<255)` literals on direct-draw paths rendered additive-bright instead of as faded tints. The fixes_09 audit caught the obvious cases; this batch catches the rest and adds a Roslyn analyzer to fail the build on new offenders.

- **`SDAnalyzers/SD0001`** — Roslyn analyzer flagging non-premul `new Color(...)` literals on draw paths. Recognizes `.Premultiplied()` / `.Alpha(...)` chains through parens and ternaries. Skips no-op cases (`rgb == 0`, `rgb == A`, `Color.Black` base). Wired into `StarDrive.csproj` and `SDGraphics.csproj` as compile-time-only (`OutputItemType=\"Analyzer\"`, `ReferenceOutputAssembly=\"false\"`). Severity Error.
- **Tint fixes across the map + UI layer**:
  - Universe: F2/F3 range + FTL-inhibition overlays, fleet spokes, formation-preview icons, orbit rings, threat pulses, AoO fill, system-overlay orbit lines, minimap viewport + faction halo.
  - Colony/Empire screens: tile-grid lines, alternating row highlights, column separators (`smallHighlight` kept non-premul at source so the byte-halve derivation still works).
  - Shared widgets: `DropOptions` / `DropDownMenu` hover fills, `ShipListScreenItem` row border, `HelperFunctions.DrawGrid`, `UIGraphView`.
  - ShipDesign + Combat: stat-header Selectors, powered-slot yellow on `ActiveModule` path, troop-move tile highlight.
  - Debug + Replay: `PerfDebug` header, replay-map grid lines.
  - Dynamic-alpha (runtime byte/float) fades: ship-order pointer + waypoint, ToolTip body + hotkey, ShipList blink backgrounds, `ExplosionManager` low-res pixel marker.
  - 10 additional sites the analyzer caught after `rgb==alpha` / `Color.Black` special-cases landed.

## Combat

- **`ShipExplode`** — per-target falloff replaces shared-budget so `FindNearby` order no longer biases who eats the brunt. Shields drain locally per target. Point-blank rule: when the target's closest module sits inside the exploding ship's hull radius, evade drops to 10% for medium+ hulls; drone/scout/fighter keep full evade. `+Level` XP bonus folded into `ExplosionEvadeBaseChance`. Fixed an old `FindClosestModule` null-return bug (search radius was the ship's own hull radius, so the AABB never reached the grid when `worldPos` was farther than that). Bumped damage-radius scaling (`Radius + damage/100`, was `/500`) and knockback impulse 3× → 10× (still capped at 200).

## FleetDesignScreen

- **Reject overlapping placement / movement** — placing or dragging a node/squad through another ship is now rejected at the touch threshold (`Distance < r1 + r2`). Silent — no audio cue. Applies to design-drop, single-node drag, and squad drag (all-or-nothing).
- **Auto-assign newly-placed nodes to a Squad** — so the squad rect, label, and squad-drag actually work in the design screen, matching what Ctrl+# fleet creation does via `Fleet.AutoArrange`. Joins the nearest squad within `Squad.SquadSpacing*2` of the drop, else spawns a fresh squad in `CenterFlank`. `AllFlanks` rebuilt defensively on each assign (StarData save/load can drift the collection identity).
- **`Fleet.ArrangeSquad` overlapping-squads fix** — three coupled bugs caused squads to stack on the same X with 4+ in one flank: `previousSizeLeft/Right` tracked size instead of running edge; `rowMax` evaluated to ~10 so rows never wrapped; row-wrap reset Y to center instead of accumulating outward.
- **Hide Target Priority + Operational Radius panels** — both are currently misleading (combat states overwrite priority weights; OrdersRadius has a relative/absolute unit mismatch the AI doesn't honor). Gated behind `ShowTargetingPanels = false` (and the click-handling guarded so the empty rect doesn't swallow input) until the underlying systems are reworked.

## Colonization

- **`MarkForColonization` — stop two goals owning the same colony ship.** Player manual-ctor now retires any prior `MarkForColonization` with the same `FinishedShip` before stamping in the new one. `PlanetCanBeColonized` rejects targets we already own. `WaitForColonizationComplete` checks the success path before `PlanetCanBeColonized` so `DecreaseFleetStrEmpireMultiplier` still fires on successful colonization. Symptom: a colony ship would bounce between targets because two goals kept re-issuing `OrderShipToColonize`.

## Refit

- **`Ship.RefitCost`** — was `10 * Universe.ProductionPace` (flat ~10 production); now `newShipCost * 0.1f`. `IShipDesign.GetCost` already applies `ProductionPace` internally so the explicit multiplier is dropped (no double-pacing).
- **Hide refit entry points for SubspaceProjector ships** — SSPs aren't a sensible refit source (typically one design per empire, nowhere to migrate). Gates the universe pie-menu, ship-info Orders panel, and ship-list row icon. Defensive guard in `RefitToWindow.LoadContent` so any programmatic opener gets an empty list.

## Test plan

- [x] Build clean, zero warnings (SD0001 enforced)
- [x] Universe map: F2/F3 overlays, orbit rings, fleet spokes render as faded tints (not additive-bright)
- [x] Colony/Empire screen grid lines + alternating rows render correctly
- [x] ShipExplode: large blast doesn't one-shot all neighbors regardless of FindNearby order; scouts/fighters still evade at point-blank
- [x] Fleet design: cannot drop overlapping ships; newly-placed nodes show squad rect and respond to squad drag
- [x] AutoArrange a fleet with 4+ same-flank squads → no stacked squads
- [x] Re-order a colony ship to a new target → only one goal owns the ship, no ping-pong
- [x] Refit a small ship → cost scales with target design, not flat
- [x] Subspace Projectors have no Refit entry points anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)