### PR TITLE
Jupiter 1.60/fixes 14: lighting, FillRectangle root-cause, FleetDesign tweaks

### DIFF
--- a/Ship_Game/Data/Mesh/LightingEffectBinder.cs
+++ b/Ship_Game/Data/Mesh/LightingEffectBinder.cs
@@ -40,7 +40,9 @@ public static class LightingEffectBinder
         // OverSaturationKey) all bind into the slots so per-pixel parallax +
         // each light's native radius falloff replicate SunBurn's deferred
         // multi-light scene.
-        Vector3 ambient = env?.AmbientLightColor ?? new Vector3(0.2f, 0.2f, 0.2f);
+        // Fallback for null SceneEnvironment — matches the MinAmbient floor applied
+        // below, so a missing env yields the same baseline as one with zero ambient.
+        Vector3 ambient = env?.AmbientLightColor ?? new Vector3(0.3f, 0.3f, 0.3f);
         XnaDirectionalLight[] slots = { fx.DirectionalLight0, fx.DirectionalLight1, fx.DirectionalLight2 };
         int dirIndex = 0;
 
@@ -259,10 +261,10 @@ public static class LightingEffectBinder
         // visible against pure black hull. Component-wise max preserves
         // any stronger authored ambient (MainMenu's violet, etc.) and
         // only lifts channels that fall below the floor. User-tuned to
-        // 0.20 against pre-migration footage; raise for more lift in
+        // 0.30 against pre-migration footage; raise for more lift in
         // shadow-side hull, lower if the floor visibly washes out the
         // dark texture detail.
-        const float MinAmbient = 0.2f;
+        const float MinAmbient = 0.3f;
         ambient = Vector3.Max(ambient, new Vector3(MinAmbient, MinAmbient, MinAmbient));
 
         // LightingEnabled gates the per-pixel lighting math entirely. Enable

--- a/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_HandleInput.cs
+++ b/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_HandleInput.cs
@@ -175,65 +175,6 @@ namespace Ship_Game
                 ActiveShipDesign = null;
             }
             // else: otherwise we will just have a data node
-
-            AssignNodeToSquad(node);
-        }
-
-        // Make sure the new node lives in a Squad so the squad rect/drag works
-        // (matches Ctrl+# fleet creation, which goes through AutoArrange). Prefer
-        // the nearest existing squad in any flank; if none are close enough,
-        // create a fresh single-node squad in the CenterFlank at the drop point.
-        void AssignNodeToSquad(FleetDataNode node)
-        {
-            if (SelectedFleet == null)
-                return;
-
-            // AllFlanks must contain refs to the individual flank arrays so
-            // that AllSquads enumeration sees squads we add via CenterFlank.
-            // On a fresh fleet (no AutoArrange) it's empty; on a save-loaded
-            // fleet the entries may not be identity-equal to the individual
-            // flank fields after StarData round-trip. Rebuild defensively.
-            SelectedFleet.AllFlanks.Clear();
-            SelectedFleet.AllFlanks.Add(SelectedFleet.CenterFlank);
-            SelectedFleet.AllFlanks.Add(SelectedFleet.LeftFlank);
-            SelectedFleet.AllFlanks.Add(SelectedFleet.RightFlank);
-            SelectedFleet.AllFlanks.Add(SelectedFleet.ScreenFlank);
-            SelectedFleet.AllFlanks.Add(SelectedFleet.RearFlank);
-
-            // already a member of some squad? nothing to do
-            foreach (Squad existing in AllSquads)
-                if (existing.DataNodes.ContainsRef(node))
-                    return;
-
-            const float JoinDistance = Squad.SquadSpacing * 2f;
-            Squad nearest = null;
-            float bestDist = float.MaxValue;
-            foreach (Squad candidate in AllSquads)
-            {
-                float d = candidate.Offset.Distance(node.RelativeFleetOffset);
-                if (d < bestDist)
-                {
-                    bestDist = d;
-                    nearest = candidate;
-                }
-            }
-
-            if (nearest != null && bestDist <= JoinDistance)
-            {
-                nearest.DataNodes.Add(node);
-                if (node.Ship != null) nearest.Ships.AddUnique(node.Ship);
-                return;
-            }
-
-            // No nearby squad — spin up a new one in the Center flank at the drop point.
-            var fresh = new Squad
-            {
-                Fleet = SelectedFleet,
-                Offset = node.RelativeFleetOffset,
-            };
-            fresh.DataNodes.Add(node);
-            if (node.Ship != null) fresh.Ships.Add(node.Ship);
-            SelectedFleet.CenterFlank.Add(fresh);
         }
 
         // delete all selected ships

--- a/Ship_Game/SpriteSystem/SpriteExtensions.cs
+++ b/Ship_Game/SpriteSystem/SpriteExtensions.cs
@@ -28,8 +28,6 @@ namespace Ship_Game
 
     public static class SpriteExtensions
     {
-        static readonly XnaRect? NullRectangle = new();
-
         // Phase 2: XNA 3.1's internal SpriteBatch.InternalDraw took a Vector4 destination
         // (X, Y, W, H) for sub-pixel-precise quad drawing. MonoGame doesn't expose that
         // method, but its public Draw(Texture2D, Vector2 position, ..., Vector2 scale, ...)
@@ -40,6 +38,15 @@ namespace Ship_Game
         static void InternalDraw(SpriteBatch batch, Texture2D tex, in RectF dstRect, bool scaleDst, XnaRect? srcRect,
                                  Color color, float rotation, XnaVector2 origin, SpriteEffects effects, float depth)
         {
+            // Trap: C# target-typed `new()` on Nullable<Rectangle> produces
+            // HasValue=true wrapping a (0,0,0,0) Rectangle, NOT a HasValue=false
+            // null. A zeroed srcRect makes MonoGame sample a 0×0 source region
+            // (texture renders invisible) and the ??-fallback below returns 0
+            // (divide-by-zero in the scale math). Normalize to null so callers
+            // that meant "use whole texture" actually get it.
+            if (srcRect is { Width: 0, Height: 0 })
+                srcRect = null;
+
             XnaVector2 position = new(dstRect.X, dstRect.Y);
             int srcW = srcRect?.Width  ?? tex.Width;
             int srcH = srcRect?.Height ?? tex.Height;
@@ -130,7 +137,7 @@ namespace Ship_Game
                                 in RectF r)
         {
             CheckTextureDisposed(texture);
-            InternalDraw(batch, texture, r, false, NullRectangle, Color.White,
+            InternalDraw(batch, texture, r, false, null, Color.White,
                          0f, Vector2.Zero, SpriteEffects.None, 0f);
         }
 
@@ -138,7 +145,7 @@ namespace Ship_Game
                                 in RectF r, Color color)
         {
             CheckTextureDisposed(texture);
-            InternalDraw(batch, texture, r, false, NullRectangle, color,
+            InternalDraw(batch, texture, r, false, null, color,
                          0f, Vector2.Zero, SpriteEffects.None, 0f);
         }
 
@@ -146,7 +153,7 @@ namespace Ship_Game
                                 in RectF r, Color color, float angle)
         {
             CheckTextureDisposed(texture);
-            InternalDraw(batch, texture, r, false, NullRectangle, color,
+            InternalDraw(batch, texture, r, false, null, color,
                          angle, Vector2.Zero, SpriteEffects.None, 0f);
         }
 

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.cs
@@ -273,11 +273,22 @@ namespace Ship_Game
             // the light direction was nearly grazing — half-vector specular
             // peaks barely landed on top hull faces. Moving the sun far above
             // gives a more uniform overhead-light direction across the active
-            // system. Sun radius is ~150k so the new distance still falls in
-            // the ~89% intensity band of the smooth-quadratic falloff.
-            var light1 = AddLight("Key",               system, intensity,         radius,         color, -50000);
-            var light2 = AddLight("OverSaturationKey", system, intensity * 5.00f, radius * 0.05f, color, -1500);
-            var light3 = AddLight("LocalFill",         system, intensity * 0.55f, radius,         Color.White, 0);
+            // system.
+            //
+            // Scene-light radius decoupled from sun.Radius (the sprite size):
+            // SolarSystem.MinRadius is 150k, but most suns set Radius in the
+            // 40k–100k range — at d=150k, the shader's `1 - (d/R)^2` falloff
+            // clamps to zero and ships on the far side of the system get no
+            // sun light at all (only MinAmbient). 215k gives ~51% sun
+            // intensity at the system edge (1 - (150/215)^2) while still
+            // tapering toward the rim, and treats binaries (R=40k–50k
+            // sprite) the same as normal stars (R=100k). The
+            // OverSaturationKey stays tied to sun.Radius intentionally —
+            // it's a small near-sun overbright, not a system-wide light.
+            const float SystemLightRadius = 215_000f;
+            var light1 = AddLight("Key",               system, intensity,         SystemLightRadius, color, -50000);
+            var light2 = AddLight("OverSaturationKey", system, intensity * 5.00f, radius * 0.05f,    color, -1500);
+            var light3 = AddLight("LocalFill",         system, intensity * 0.55f, SystemLightRadius, Color.White, 0);
             //AddLight("Back", system, intensity * 0.5f , radius, color, 2500, fallOff: 0, fillLight: true);
             system.Lights.Add(light1);
             system.Lights.Add(light2);

--- a/UnitTests/Graphics/FillRectangleRectFTests.cs
+++ b/UnitTests/Graphics/FillRectangleRectFTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using SDGraphics;
+using Ship_Game;
+using XnaColor = Microsoft.Xna.Framework.Color;
+
+namespace UnitTests.Graphics;
+
+/// <summary>
+/// Regression guard for the FillRectangle(RectF)/Draw(Texture2D, RectF, ...)
+/// path. A pre-fix bug had `static readonly XnaRect? NullRectangle = new();`
+/// resolve to HasValue=true with a (0,0,0,0) Rectangle (target-typed new on
+/// Nullable<Rectangle> constructs the underlying type), which fed a 0-sized
+/// srcRect to SpriteBatch.Draw and divided by zero in the scale math.
+/// Symptom: every batch.FillRectangle(RectF) call rendered nothing.
+///
+/// This test paints a known rect through both the FillRectangle(RectF) and
+/// Draw(Texture2D, RectF) overloads and asserts pixels actually got written.
+/// If a future change reintroduces a zero source rectangle (or otherwise
+/// breaks the RectF path), the assertions catch it before it ships.
+/// </summary>
+[TestClass]
+public class FillRectangleRectFTests : StarDriveTest
+{
+    [TestMethod]
+    public void FillRectangle_RectF_WritesPixels()
+    {
+        GraphicsDevice device = Game.GraphicsDevice;
+
+        const int W = 32, H = 32;
+        const int X = 8,  Y = 8;
+        const int RW = 16, RH = 16;
+
+        using var rt = new RenderTarget2D(device, W, H, mipMap: false,
+                                          SurfaceFormat.Color, DepthFormat.None);
+
+        RenderTargetBinding[] prev = device.GetRenderTargets();
+        try
+        {
+            device.SetRenderTarget(rt);
+            device.Clear(XnaColor.Black);
+
+            using var batch = new SpriteBatch(device);
+            batch.Begin(SpriteSortMode.Deferred, BlendState.Opaque);
+            batch.FillRectangle(new RectF(X, Y, RW, RH), XnaColor.Red);
+            batch.End();
+        }
+        finally
+        {
+            device.SetRenderTargets(prev);
+        }
+
+        var pixels = new XnaColor[W * H];
+        rt.GetData(pixels);
+
+        // Inside the rect: every pixel should be the fill color.
+        int redHits = 0;
+        for (int y = Y; y < Y + RH; y++)
+            for (int x = X; x < X + RW; x++)
+                if (pixels[y * W + x].R > 200 && pixels[y * W + x].G < 20 && pixels[y * W + x].B < 20)
+                    redHits++;
+        Assert.AreEqual(RW * RH, redHits,
+            $"FillRectangle(RectF) wrote {redHits}/{RW * RH} red pixels. " +
+            "The RectF overload likely went through a zero source rectangle path " +
+            "and rendered nothing (see project_rectf_fillrectangle_broken).");
+
+        // Outside the rect: pixels should remain black (no overflow).
+        for (int y = 0; y < H; y++)
+            for (int x = 0; x < W; x++)
+            {
+                bool inside = x >= X && x < X + RW && y >= Y && y < Y + RH;
+                if (inside) continue;
+                XnaColor c = pixels[y * W + x];
+                Assert.IsTrue(c.R == 0 && c.G == 0 && c.B == 0,
+                    $"Expected black outside rect at ({x},{y}), got {c}.");
+            }
+    }
+
+    [TestMethod]
+    public void DrawTexture2D_RectF_WritesPixels()
+    {
+        GraphicsDevice device = Game.GraphicsDevice;
+
+        const int W = 32, H = 32;
+        const int X = 4,  Y = 4;
+        const int RW = 8, RH = 8;
+
+        using var tex = new Texture2D(device, 1, 1);
+        tex.SetData(new[] { XnaColor.White });
+
+        using var rt = new RenderTarget2D(device, W, H, mipMap: false,
+                                          SurfaceFormat.Color, DepthFormat.None);
+
+        RenderTargetBinding[] prev = device.GetRenderTargets();
+        try
+        {
+            device.SetRenderTarget(rt);
+            device.Clear(XnaColor.Black);
+
+            using var batch = new SpriteBatch(device);
+            batch.Begin(SpriteSortMode.Deferred, BlendState.Opaque);
+            // Call SpriteExtensions.Draw explicitly: an in-RectF arg would
+            // otherwise resolve to MonoGame's batch.Draw(Texture2D, Rectangle,
+            // Color) via RectF's implicit conversion, bypassing the InternalDraw
+            // path we're trying to guard.
+            SpriteExtensions.Draw(batch, tex, new RectF(X, Y, RW, RH), XnaColor.Lime);
+            batch.End();
+        }
+        finally
+        {
+            device.SetRenderTargets(prev);
+        }
+
+        var pixels = new XnaColor[W * H];
+        rt.GetData(pixels);
+
+        int limeHits = 0;
+        for (int y = Y; y < Y + RH; y++)
+            for (int x = X; x < X + RW; x++)
+                if (pixels[y * W + x].G > 200 && pixels[y * W + x].R < 20 && pixels[y * W + x].B < 20)
+                    limeHits++;
+        Assert.AreEqual(RW * RH, limeHits,
+            $"Draw(Texture2D, RectF, Color) wrote {limeHits}/{RW * RH} lime pixels. " +
+            "InternalDraw's RectF path is broken — likely a zero source rectangle " +
+            "is being passed to SpriteBatch.Draw.");
+    }
+}

--- a/UnitTests/Graphics/LightingEffectBinderTests.cs
+++ b/UnitTests/Graphics/LightingEffectBinderTests.cs
@@ -34,7 +34,8 @@ public class LightingEffectBinderTests : StarDriveTest
 
         var env = new SceneEnvironment
         {
-            AmbientLightColor = new Vector3(0.2f, 0.2f, 0.25f),
+            // Above MinAmbient floor so passthrough isn't masked by the lift.
+            AmbientLightColor = new Vector3(0.4f, 0.4f, 0.45f),
         };
 
         using var fx = new LightingEffect(Game.GraphicsDevice);
@@ -67,12 +68,12 @@ public class LightingEffectBinderTests : StarDriveTest
         using var fx = new LightingEffect(Game.GraphicsDevice);
         LightingEffectBinder.Apply(fx, lightManager.ActiveLights, env, Vector3.Zero);
 
-        // §4.6 #12: MinAmbient floor (0.2) lifts zero ambient so hulls
+        // §4.6 #12: MinAmbient floor (0.3) lifts zero ambient so hulls
         // never go fully black. LightingEnabled stays true as a result.
         Assert.IsTrue(fx.LightingEnabled, "Ambient floor should keep lighting enabled.");
-        Assert.AreEqual(0.2f, fx.AmbientLightColor.X, 0.001f, "Ambient.X should be lifted to MinAmbient.");
-        Assert.AreEqual(0.2f, fx.AmbientLightColor.Y, 0.001f, "Ambient.Y should be lifted to MinAmbient.");
-        Assert.AreEqual(0.2f, fx.AmbientLightColor.Z, 0.001f, "Ambient.Z should be lifted to MinAmbient.");
+        Assert.AreEqual(0.3f, fx.AmbientLightColor.X, 0.001f, "Ambient.X should be lifted to MinAmbient.");
+        Assert.AreEqual(0.3f, fx.AmbientLightColor.Y, 0.001f, "Ambient.Y should be lifted to MinAmbient.");
+        Assert.AreEqual(0.3f, fx.AmbientLightColor.Z, 0.001f, "Ambient.Z should be lifted to MinAmbient.");
 
         Assert.IsFalse(fx.DirectionalLight0.Enabled);
         Assert.IsFalse(fx.DirectionalLight1.Enabled);

--- a/UnitTests/SDUnitTests.csproj
+++ b/UnitTests/SDUnitTests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Fleets\FleetTests.cs" />
     <Compile Include="Graphics\BloomFilterTests.cs" />
     <Compile Include="Graphics\DistortionComponentTests.cs" />
+    <Compile Include="Graphics\FillRectangleRectFTests.cs" />
     <Compile Include="Graphics\FogOfWarTests.cs" />
     <Compile Include="Graphics\FbxMaterialSurveyTests.cs" />
     <Compile Include="Graphics\ForwardRendererTests.cs" />


### PR DESCRIPTION
## Summary

- **Lighting** — raised ship ambient floor 0.2 → 0.3 so far-side ships in solar systems aren't pitch-dark; decoupled sun scene-light radius from sun-sprite size so the lighting reaches the system rim.
- **SpriteExtensions root-cause fix** — `batch.FillRectangle(RectF)` silently rendered nothing post-migration (~14 latent call sites). Cause: `static readonly XnaRect? NullRectangle = new();` compiles to `HasValue=true, W=H=0` (verified via standalone repro), not a null — so MonoGame sampled a 0×0 source region and the scale math divided by zero. Killed the field, pass `null` directly, defensive (0,0,0,0)→null normalization inside `InternalDraw`. Submenu/Tooltip frame gaps now render cleanly without per-site Rectangle casts.
- **FleetDesignScreen** — kept the WouldOverlap drop rejection from fixes_13; reverted the auto-squad-assign on design drop (turned out unnecessary, muddied the data model).

## Test plan
- [x] Universe screen: confirm ships on the far side of solar systems are no longer pitch-dark; sun lighting reaches the system rim.
- [x] Submenu (SELECT HULL panel etc.) renders cleanly to its frame; no transparent strips.
- [x] Tooltips render cleanly to their frame.
- [x] Research screen, sliders, colony screen, diplomacy screen — sanity-check any UI that uses `FillRectangle(RectF)` (per the memory note's latent-callers list).
- [x] FleetDesignScreen: drag a ship design onto the grid → it lands, overlap is rejected, no squad auto-created. Existing squads still work after AutoArrange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)