### PR TITLE
Jupiter 1.60 fixes_16: render, navigation, crash, and AI fixes

### DIFF
--- a/Ship_Game/AI/Research/ChooseTech.cs
+++ b/Ship_Game/AI/Research/ChooseTech.cs
@@ -363,16 +363,11 @@ namespace Ship_Game.AI.Research
 
         public static TechnologyType ConvertTechStringTechType(string typeName)
         {
-            TechnologyType techType = TechnologyType.General;
-            try
-            {
-                techType = (TechnologyType)Enum.Parse(typeof(TechnologyType), typeName);
-            }
-            catch
-            {
-                Log.Error("techType not found : ");
-            }
-            return techType;
+            if (Enum.TryParse(typeName, out TechnologyType techType))
+                return techType;
+
+            Log.Error($"ConvertTechStringTechType: unknown TechnologyType '{typeName}', defaulting to General");
+            return TechnologyType.General;
         }
 
         private TechEntry GetScriptedTech(string command1, TechnologyType techType, Array<TechEntry> availableTechs)

--- a/Ship_Game/AI/Research/ResearchOptions.cs
+++ b/Ship_Game/AI/Research/ResearchOptions.cs
@@ -178,9 +178,8 @@ namespace Ship_Game.AI.Research
 
         public void LoadResearchOptions(Empire empire)
         {
-            Array<ResearchSettings> researchMods = ResearchSettings.LoadYaml();
-
-            foreach (var mods in researchMods)
+            // Research.yaml is parsed once at content load and cached in ResourceManager.
+            foreach (var mods in ResourceManager.GetResearchOptionSettings())
             {
                 mods.ApplyMatchingModifiers(TechTypeMods,     mods.TechnologyTypeModifiers, empire);
                 mods.ApplyMatchingModifiers(ShipMods,         mods.ShipCostModifiers,       empire);

--- a/Ship_Game/AI/Research/ResearchPriorities.cs
+++ b/Ship_Game/AI/Research/ResearchPriorities.cs
@@ -152,7 +152,7 @@ namespace Ship_Game.AI.Research
 
         float CalcPlanetFoodNeeds(Planet p)
         {
-            float ratio = p.NonCybernetic ? p.Storage.FoodRatio : p.Storage.Prod;
+            float ratio = p.NonCybernetic ? p.Storage.FoodRatio : p.Storage.ProdRatio;
             float needs = 1 - ratio;
             needs       = (needs * p.Level).LowerBound(0);
             if (p.IsStarving)

--- a/Ship_Game/AI/Research/ShipPicker.cs
+++ b/Ship_Game/AI/Research/ShipPicker.cs
@@ -41,6 +41,9 @@ namespace Ship_Game.AI.Research
 
         public IShipDesign FindCheapestShipInList(Empire empire, Array<IShipDesign> ships, HashSet<string> techs)
         {
+            // Rebuild from scratch each pick; these accumulate otherwise and drift the line-focus ratio.
+            MostTechs.Clear();
+            KnownTechs.Clear();
             PopulateKnownTechs(empire);
             var buildableShips = empire.ShipsWeCanBuildSnapshot;
             PopulateMostTechs(buildableShips, KnownTechs);
@@ -137,7 +140,7 @@ namespace Ship_Game.AI.Research
                         MostTechs[ship.Role] = knownNumber;
                 }
                 else
-                    MostTechs[ship.Role] = 1;
+                    MostTechs[ship.Role] = knownNumber; // CountTechsAlreadyResearched already floors at 1
             }
         }
 

--- a/Ship_Game/AI/Research/ShipTechLineFocusing.cs
+++ b/Ship_Game/AI/Research/ShipTechLineFocusing.cs
@@ -72,7 +72,10 @@ namespace Ship_Game.AI.Research
                 case RoleName.capital: break;
 
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    // An unhandled role (e.g. a newly added or modded RoleName) must not crash the
+                    // research planner, which evaluates every ship design. Treat it as not researchable.
+                    Log.Warning($"IsRoleValid: unhandled RoleName {role}; excluding ship from research focusing");
+                    return false;
             }
             return true;
         }
@@ -255,7 +258,7 @@ namespace Ship_Game.AI.Research
             var shipTechs = ConvertStringToTech(bestShip.TechsNeeded);
             foreach (TechEntry tech in shipTechs)
             {
-                if (tech.GetUnlockableHulls(OwnerEmpire).Count > 0)
+                if (tech.UnlocksHullsFor(OwnerEmpire))
                     return tech;
             }
             return null;

--- a/Ship_Game/AI/Research/ShipTechProgresion.cs
+++ b/Ship_Game/AI/Research/ShipTechProgresion.cs
@@ -51,7 +51,7 @@ namespace Ship_Game.AI.Research
             foreach (string techName in techsNames)
             {
                 if (OwnerEmpire.TryGetTechEntry(techName, out TechEntry tech)
-                    && tech.GetUnLockableHulls(OwnerEmpire).Count > 0
+                    && tech.UnlocksHullsFor(OwnerEmpire)
                     && CanResearchHullInTimelyManner(tech))
                 {
                     return true;
@@ -111,7 +111,7 @@ namespace Ship_Game.AI.Research
                 TechEntry tech = shipTechs[i];
                 if (tech.Locked)
                 {
-                    if (tech.GetUnlockableHulls(OwnerEmpire).Count > 0)
+                    if (tech.UnlocksHullsFor(OwnerEmpire))
                     {
                         if (hullTech.IsEmpty())
                             hullTech = tech.UID;

--- a/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
@@ -411,9 +411,14 @@ namespace Ship_Game.AI
             if (tgt.IsInWarp || tgt.TroopsAreBoardingShip)
                 return 0;
 
-            float value = tgt.TotalDps / tgt.SurfaceArea + 100;
-            value *= 1f + tgt.Carrier.AllFighterHangars.Length*0.75f;
-            value *= 1 + tgt.TroopCapacity*0.5f;
+            // Base = firepower density (+20 keeps a lone unarmed ship pickable).
+            // Invasion threat (troops) and carrier-denial value are ADDED, not
+            // multiplied, so they read as high-value kills without exploding the
+            // priority; both capped, and distance-attenuated below. Keys on loaded
+            // troops, not capacity.
+            float value = (20 + tgt.TotalDps) / tgt.SurfaceArea
+                        + (tgt.TroopCount * 0.5f).UpperBound(5f)
+                        + (tgt.Carrier.AllFighterHangars.Length * 0.3f).UpperBound(5f);
             value *= 1 + (tgt.HasBombs ? tgt.BombBays.Count : tgt.BombBays.Count*0.25f);
 
             bool debug = EnableTargetPriorityDebug && (Owner.Loyalty.isPlayer);
@@ -442,46 +447,33 @@ namespace Ship_Game.AI
             if (tgt.Resupplying) // lower priority to enemies that are retreating
                 value *= 0.5f;
 
-            float distanceDivisor = distance*0.001f;
-            value /= distanceDivisor * distanceDivisor; // prefer targets that are closer
-            if (debug) Debug($"dv={distanceDivisor.String(2),-4}");
+            // Prefer closer targets: gently (linear) inside weapon range so the
+            // ship commits to the single nearest in-range target, steeply (cubed)
+            // outside it so it doesn't reach past in-range enemies for a far one.
+            float distanceNorm = distance / Owner.DesiredCombatRange;
+            value /= distanceNorm <= 1f ? distanceNorm : distanceNorm * distanceNorm * distanceNorm;
+            if (debug) Debug($"dn={distanceNorm.String(2),-4}");
 
-            // make ships prefer targets which are closer to their own size
-            // this ensures fighters prefer fighters and frigates prefer frigates
+            // prefer targets near our own size; the size multiplier is floored at
+            // 0.05 so nothing is ever fully ignored on size alone.
             float relSize = (float)tgt.SurfaceArea / Owner.SurfaceArea;
             if (relSize < 1f)
             {
-                // if we are interceptors - we want to get these smaller ships.
-                // value = 100 * (1/0.25) = 400
+                // interceptors chase the smallest; everyone else de-prioritizes smaller ships
                 if (Owner.ShipData.HangarDesignation == HangarOptions.Interceptor)
-                {
                     value *= (1 / relSize);
-                }
-                // if target is smaller then 0.5^2 = 0.25, smaller ships are
-                // almost always weaker than us so they're not a huge priority.
-                // other ships of same size are more important
-                // value = 100 * 0.25 = 25
                 else
-                {
-                    value *= (relSize * relSize);
-                }
+                    value *= (relSize * relSize).LowerBound(0.05f);
             }
             else if (relSize > 1f)
             {
-                // if we are anti-ship, always prefer to target big ships:
-                // value = 100 * (1.25*1.25) = 156.25 (stronger? prefer it)
+                // anti-ship prefers bigger; everyone else treats bigger as a juicy
+                // target, ramping from 1x at equal size up to a peak at ~2x then
+                // tapering (continuous at 1x, unlike the old 4/relSize jump to 4x)
                 if (Owner.ShipData.HangarDesignation == HangarOptions.AntiShip)
-                {
                     value *= (relSize * relSize);
-                }
-                // if target is bigger than us, use division to make us less afraid of it
-                // value = 100 / (2.0 * 0.25) = 200 (2x stronger? good target)
-                // value = 100 / (4.0 * 0.25) = 100 (4x stronger? not afraid at all)
-                // value = 100 / (4.47 * 0.25) = 89.4 (a bit afraid)
                 else
-                {
-                    value /= (relSize * 0.25f);
-                }
+                    value *= (relSize <= 2f ? relSize : 4f / relSize).LowerBound(0.05f);
             }
 
             // keep reserach and mining stations as very low priority targets

--- a/Ship_Game/Beam.cs
+++ b/Ship_Game/Beam.cs
@@ -63,6 +63,17 @@ namespace Ship_Game
         public int Thickness { get; private set; }
         public float PowerCost;
         public static Effect BeamEffect;
+
+        // Beam render mode. The pre-Phase-3.7 two-pass alpha-test technique
+        // can't work under MonoGame (alpha-test is fixed-function and
+        // RenderStates.EnableAlphaTest is a no-op stub), so both passes drew
+        // the entire quad and the second pass corrupted the result with
+        // non-premul SrcAlpha/InvSrcAlpha math on premultiplied DDS source —
+        // the visible "edges" / halos around beams. Single-pass additive gives
+        // a clean emissive look that brightens over background without halos.
+        // Flip via debugger immediate window (`Beam.UseAdditiveBlend = false`)
+        // to compare against the faithful premul (One/InvSrcAlpha) variant.
+        public static bool UseAdditiveBlend = true;
         public VertexPositionNormalTexture[] Vertices = new VertexPositionNormalTexture[4];
         public int[] Indexes = new int[6];
         float BeamZ;
@@ -205,25 +216,24 @@ namespace Ship_Game
                 Displacement = 1f;
 
             BeamEffect.Parameters["displacement"].SetValue(new Vector2(0f, Displacement));
-            RenderStates.EnableAlphaTest(device, CompareFunction.GreaterEqual, 200);
 
-            foreach (EffectPass pass in BeamEffect.CurrentTechnique.Passes)
-            {
-                pass.Apply();
-                device.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, Vertices, 0, 4, Indexes, 0, 2);
-            }
-
+            // Single-pass draw. The original two-pass alpha-test technique relied
+            // on fixed-function alpha-test that MonoGame removed; both passes
+            // drew the full quad and the second pass corrupted the result with
+            // non-premul blend math on premultiplied DDS source. See
+            // UseAdditiveBlend comment above.
             RenderStates.DisableDepthWrite(device);
-            RenderStates.EnableAlphaBlend(device, Blend.SourceAlpha, Blend.InverseSourceAlpha);
-            RenderStates.EnableAlphaTest(device, CompareFunction.Less, 200);
+            if (UseAdditiveBlend)
+                RenderStates.EnableAdditiveAlphaBlend(device);
+            else
+                RenderStates.EnableAlphaBlend(device, Blend.One, Blend.InverseSourceAlpha);
 
             foreach (EffectPass pass in BeamEffect.CurrentTechnique.Passes)
             {
                 pass.Apply();
                 device.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, Vertices, 0, 4, Indexes, 0, 2);
             }
-            
-            RenderStates.DisableAlphaTest(device);
+
             RenderStates.EnableClassicAlphaBlend(device); // restore default
             RenderStates.EnableDepthWrite(device);
         }

--- a/Ship_Game/Data/ResourceManager.cs
+++ b/Ship_Game/Data/ResourceManager.cs
@@ -21,6 +21,7 @@ using Ship_Game.Data.Mesh;
 using Ship_Game.Ships.Legacy;
 using Ship_Game.Universe;
 using Ship_Game.Utils;
+using Ship_Game.AI.Research;
 
 #pragma warning disable CA2237, RCS1194 // Mark ISerializable types with serializable
 
@@ -276,6 +277,7 @@ namespace Ship_Game
             Profiled(LoadSunZoneData);
             Profiled(LoadBuildRatios);
             Profiled(LoadEcoResearchStrats);
+            Profiled(LoadResearchOptionSettings);
             Profiled(LoadBlackboxSpecific);
             Profiled(LoadBlueprintsTemplates);
         }
@@ -390,6 +392,7 @@ namespace Ship_Game
             ShipNames.Clear();
 
             EconStrategies.Clear();
+            ResearchOptionSettings = Empty<ResearchOptions.ResearchSettings>.Array;
             ZoneDistribution.Clear();
             BuildRatios.Clear();
 
@@ -2089,6 +2092,17 @@ namespace Ship_Game
             EconStrategies.Clear();
             foreach (var s in YamlParser.DeserializeArray<EconomicResearchStrategy>("EconomicResearchStrategies.yaml"))
                 EconStrategies[s.Name] = s;
+        }
+
+        // Parsed Research.yaml (ResearchOptions modifiers). Loaded once per content load so
+        // ResearchOptions doesn't re-read+parse the file for every empire.
+        static IReadOnlyList<ResearchOptions.ResearchSettings> ResearchOptionSettings = Empty<ResearchOptions.ResearchSettings>.Array;
+
+        public static IReadOnlyList<ResearchOptions.ResearchSettings> GetResearchOptionSettings() => ResearchOptionSettings;
+
+        static void LoadResearchOptionSettings()
+        {
+            ResearchOptionSettings = ResearchOptions.ResearchSettings.LoadYaml();
         }
 
         static readonly Map<SunZone, Array<PlanetCategory>> ZoneDistribution = new();

--- a/Ship_Game/EconomicResearchStrategy.cs
+++ b/Ship_Game/EconomicResearchStrategy.cs
@@ -15,8 +15,8 @@ namespace Ship_Game
         [StarData] public readonly byte ResearchPriority = 5;
         [StarData] public readonly byte IndustryPriority = 5;
 
-        float PriorityRatio(float priority) 
-            => Math.Max(priority / (MilitaryPriority + ExpansionPriority + ResearchPriority + IndustryPriority), 0.1f);
+        float PriorityRatio(float priority)
+            => Math.Max(priority / Math.Max(MilitaryPriority + ExpansionPriority + ResearchPriority + IndustryPriority, 1), 0.1f);
 
         public float MilitaryRatio => PriorityRatio(MilitaryPriority);
         public float ExpansionRatio => PriorityRatio(ExpansionPriority);

--- a/Ship_Game/ExtensionMethods/HelperFunctions.cs
+++ b/Ship_Game/ExtensionMethods/HelperFunctions.cs
@@ -63,9 +63,15 @@ namespace Ship_Game
 
                 if (s.IsDefaultTroopShip)
                 {
-                    Troop troop = ResourceManager.GetTroopTemplatesFor(owner).First();
-                    if (ResourceManager.TryCreateTroop(troop.Name, owner, out Troop newTroop))
+                    // Owner may have no unlocked troop templates (no tech, or a
+                    // race whose troops are all locked) — leave the troop ship
+                    // empty instead of throwing inside fleet spawn.
+                    Troop[] templates = ResourceManager.GetTroopTemplatesFor(owner);
+                    if (templates.Length > 0
+                        && ResourceManager.TryCreateTroop(templates[0].Name, owner, out Troop newTroop))
+                    {
                         newTroop.LandOnShip(s);
+                    }
                 }
 
                 s.AI.CombatState = node.CombatState;

--- a/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_HandleInput.cs
+++ b/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_HandleInput.cs
@@ -114,9 +114,8 @@ namespace Ship_Game
             // assign it to the fleet on Left click
             if (input.LeftMouseClick && !ShipSL.HitTest(input.CursorPosition))
             {
-                Vector2 pickedPosition = SnapToGrid(CursorWorldPosition2D);
-                if (WouldOverlap(pickedPosition, ActiveShipDesign.Radius))
-                    return false;
+                if (!TryFindNearestFreeOffset(CursorWorldPosition2D, ActiveShipDesign.Radius, out Vector2 pickedPosition))
+                    return false; // fleet is packed solid around the cursor, nowhere to put it
                 AddDesignToFleet(ActiveShipDesign, pickedPosition);
 
                 // if we're holding shift key down, allow placing multiple designs
@@ -458,6 +457,53 @@ namespace Ship_Game
                     return true;
             }
             return false;
+        }
+
+        // Snap `desired` to the grid; if that slot overlaps a node, search grid
+        // rings outward and return the nearest free slot instead of rejecting.
+        // Returns false only if everything within the search bound is occupied.
+        bool TryFindNearestFreeOffset(Vector2 desired, float radius, out Vector2 result)
+        {
+            result = SnapToGrid(desired);
+            if (!WouldOverlap(result, radius))
+                return true;
+
+            const int maxRings = 40; // GridSnap*40 = 2000 world units of search
+            float bestDist = float.MaxValue;
+            int foundAtRing = -1;
+
+            for (int r = 1; r <= maxRings; r++)
+            {
+                for (int dx = -r; dx <= r; dx++)
+                {
+                    for (int dy = -r; dy <= r; dy++)
+                    {
+                        // only the perimeter of ring r (Chebyshev distance == r)
+                        if (dx != -r && dx != r && dy != -r && dy != r)
+                            continue;
+
+                        Vector2 candidate = new(result.X + dx*GridSnap, result.Y + dy*GridSnap);
+                        if (WouldOverlap(candidate, radius))
+                            continue;
+
+                        float d = candidate.Distance(desired);
+                        if (d < bestDist)
+                        {
+                            bestDist = d;
+                            result = candidate;
+                            if (foundAtRing < 0)
+                                foundAtRing = r;
+                        }
+                    }
+                }
+
+                // a free slot on ring r can still be beaten by an axis slot on
+                // ring r+1, so scan one extra ring before settling on the nearest
+                if (foundAtRing >= 0 && r >= foundAtRing + 1)
+                    return true;
+            }
+
+            return foundAtRing >= 0;
         }
 
         void UpdateHoveredNodesList(InputState input)

--- a/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_HandleInput.cs
+++ b/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_HandleInput.cs
@@ -468,6 +468,13 @@ namespace Ship_Game
             if (!WouldOverlap(result, radius))
                 return true;
 
+            // Capture the snap origin so the Chebyshev ring stays centered on
+            // the originally-snapped cursor. Reusing `result` as the origin
+            // shifts the ring every time we accept a better candidate, which
+            // breaks the "nearest free slot" guarantee (the search drifts
+            // cumulatively away from `desired`).
+            Vector2 snapOrigin = result;
+
             const int maxRings = 40; // GridSnap*40 = 2000 world units of search
             float bestDist = float.MaxValue;
             int foundAtRing = -1;
@@ -482,7 +489,7 @@ namespace Ship_Game
                         if (dx != -r && dx != r && dy != -r && dy != r)
                             continue;
 
-                        Vector2 candidate = new(result.X + dx*GridSnap, result.Y + dy*GridSnap);
+                        Vector2 candidate = new(snapOrigin.X + dx*GridSnap, snapOrigin.Y + dy*GridSnap);
                         if (WouldOverlap(candidate, radius))
                             continue;
 

--- a/Ship_Game/GameScreens/Universe/GamePlayMenuScreen.cs
+++ b/Ship_Game/GameScreens/Universe/GamePlayMenuScreen.cs
@@ -135,8 +135,15 @@ public sealed class GamePlayMenuScreen : GameScreen
     {
         if (DisallowActions()) return;
 
-        // safely go to MainMenu, clear all 3D stuff if there's anything left
-        ScreenManager.GoToScreen(new MainMenuScreen(), clear3DObjects:true);
+        // Route through GameLoadingScreen with resetResources:true. This is the
+        // same path the mod-switch flow uses (ModManager.cs:169): it tears down
+        // the in-game graphics state via the safely-sequenced UnloadAllData →
+        // UnloadGraphicsResources, then re-runs the boot LoadContent sequence
+        // so MainMenu finds ResourceManager.Blank, Beam.BeamEffect, the Textures
+        // index, etc. populated. Direct GoToScreen(MainMenu, true) leaves the
+        // in-game content cache pinned and OOM'd on memory-tight machines when
+        // MainMenu's atlas DXT5 decompress allocated on top of it.
+        ScreenManager.GoToScreen(new GameLoadingScreen(showSplash:false, resetResources:true), clear3DObjects:true);
     }
 
     void Exit_OnClick(UIButton button)

--- a/Ship_Game/Graphics/RenderStates.cs
+++ b/Ship_Game/Graphics/RenderStates.cs
@@ -116,7 +116,33 @@ namespace Ship_Game.Graphics
             else            DisableDepthWrite(device);
         }
 
-        public static void EnableSeparateAlphaBlend(GraphicsDevice device, Blend srcBlend, Blend dstBlend) { }
-        public static void DisableSeparateAlphaChannelBlend(GraphicsDevice device) { }
+        // Cache for BlendStates that keep the RGB channel on premul AlphaBlend
+        // (One/InverseSourceAlpha) but override the alpha channel's src/dst blend.
+        // Used by influence-border rendering to merge same-empire overlapping
+        // node-gradient textures into smooth blobs: SourceAlphaSaturation/One
+        // makes the alpha channel grow additively until it saturates at 1.0,
+        // while RGB continues to blend normally so colors don't oversaturate.
+        // SolarDebug.cs scrubs BorderBlendSrc/BorderBlendDest live via this path.
+        static readonly ConcurrentDictionary<(Blend, Blend), BlendState> SeparateAlphaCache = new();
+
+        public static void EnableSeparateAlphaBlend(GraphicsDevice device, Blend srcAlphaBlend, Blend dstAlphaBlend)
+        {
+            BlendState bs = SeparateAlphaCache.GetOrAdd((srcAlphaBlend, dstAlphaBlend), key => new BlendState
+            {
+                Name = $"SeparateAlpha-{key.Item1}-{key.Item2}",
+                ColorSourceBlend      = Blend.One,
+                ColorDestinationBlend = Blend.InverseSourceAlpha,
+                ColorBlendFunction    = BlendFunction.Add,
+                AlphaSourceBlend      = key.Item1,
+                AlphaDestinationBlend = key.Item2,
+                AlphaBlendFunction    = BlendFunction.Add,
+            });
+            device.BlendState = bs;
+        }
+
+        public static void DisableSeparateAlphaChannelBlend(GraphicsDevice device)
+        {
+            device.BlendState = BlendState.AlphaBlend;
+        }
     }
 }

--- a/Ship_Game/TechEntry.cs
+++ b/Ship_Game/TechEntry.cs
@@ -342,17 +342,15 @@ namespace Ship_Game
             return modulesUnlocked;
         }
 
-        public Array<Technology.UnlockedHull> GetUnlockableHulls(Empire empire)
+        // True if this tech unlocks at least one hull this empire is eligible for (CheckSource).
+        public bool UnlocksHullsFor(Empire empire)
         {
-            var modulesUnlocked = new Array<Technology.UnlockedHull>();
-            //Added by McShooterz: Race Specific modules
             foreach (Technology.UnlockedHull unlockedHull in Tech.HullsUnlocked)
             {
-                if (!CheckSource(unlockedHull.ShipType, empire))
-                    continue;
-                modulesUnlocked.Add(unlockedHull);
+                if (CheckSource(unlockedHull.ShipType, empire))
+                    return true;
             }
-            return modulesUnlocked;
+            return false;
         }
 
         public void UnlockModules(Empire us, Empire them)

--- a/Ship_Game/Universe/EmpireUIOverlay.cs
+++ b/Ship_Game/Universe/EmpireUIOverlay.cs
@@ -545,14 +545,6 @@ namespace Ship_Game
                         }
                         else if (caller is ShipDesignScreen shipDesigner && b.launches != "Shipyard")
                         {
-                            // Symmetric with the FleetDesign → non-Fleets branch above.
-                            // Without this, the top-bar Fleets button from inside
-                            // ShipDesign left ShipDesignScreen alive underneath the
-                            // newly-added FleetDesignScreen, and its DesignedShip's
-                            // SceneObject kept rendering as a center-screen orphan in
-                            // the FleetDesign view. Using ExitScreen routes through
-                            // the existing save-WIP / save-dirty dialog flow so the
-                            // hull selection survives the round-trip.
                             shipDesigner.ExitScreen();
                         }
 

--- a/Ship_Game/Universe/EmpireUIOverlay.cs
+++ b/Ship_Game/Universe/EmpireUIOverlay.cs
@@ -543,6 +543,18 @@ namespace Ship_Game
                         {
                             fleetDesigner.ExitScreen();
                         }
+                        else if (caller is ShipDesignScreen shipDesigner && b.launches != "Shipyard")
+                        {
+                            // Symmetric with the FleetDesign → non-Fleets branch above.
+                            // Without this, the top-bar Fleets button from inside
+                            // ShipDesign left ShipDesignScreen alive underneath the
+                            // newly-added FleetDesignScreen, and its DesignedShip's
+                            // SceneObject kept rendering as a center-screen orphan in
+                            // the FleetDesign view. Using ExitScreen routes through
+                            // the existing save-WIP / save-dirty dialog flow so the
+                            // hull selection survives the round-trip.
+                            shipDesigner.ExitScreen();
+                        }
 
                         if (b.launches == null)
                         {

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
@@ -407,8 +407,14 @@ namespace Ship_Game
             if (TroopsInTheWorks)
                 return;  // Build one militia at a time
 
-            Troop cheapestTroop = ResourceManager.GetTroopTemplatesFor(Owner).First();
-            Construction.Enqueue(cheapestTroop, QueueItemType.Troop);
+            // CanBuildInfantry only checks the building flag; the empire may
+            // still have zero unlocked troop templates (no troop tech, or a
+            // race whose troops are all locked in the active mod). Skip the
+            // build instead of throwing inside the sim thread.
+            Troop[] templates = ResourceManager.GetTroopTemplatesFor(Owner);
+            if (templates.Length == 0)
+                return;
+            Construction.Enqueue(templates[0], QueueItemType.Troop);
         }
 
         void BuildAndScrapMilitaryBuildings(float budget, float tolerance)

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
@@ -110,11 +110,22 @@ public partial class Planet
         for (int i = 0; i < modifiedQueue.Count; i++)
         {
             QueueItem qi = modifiedQueue[i];
-            // How much production will be created for this item (since some will be diverted to research)
-            float productionOutputForItem = Prod.FlatBonus + workPercentage * EvaluateProductionQueue(qi) * PopulationBillion;
-            // How much net production will be applied to the queue item after checking planet's trade state
-            float netProdPerTurn = LimitedProductionExpenditure(turnsWithInfra <= 0 ? productionOutputForItem 
-                : productionOutputForItem + InfraStructure);
+            // Manual (no-governor) colonies apply their full production income to the queue each turn, with the
+            // stockpile refilling every turn. The governor worker-model and LimitedProductionExpenditure's import
+            // branch (which caps to the current stockpile snapshot) badly underestimate a multi-turn build, so use
+            // the real per-turn throughput directly.
+            float netProdPerTurn;
+            if (GovernorOff)
+            {
+                netProdPerTurn = CurrentProductionToQueue;
+            }
+            else
+            {
+                // some production will be diverted to research via the governor's worker-allocation model
+                float productionOutputForItem = Prod.FlatBonus + workPercentage * EvaluateProductionQueue(qi) * PopulationBillion;
+                netProdPerTurn = LimitedProductionExpenditure(turnsWithInfra <= 0 ? productionOutputForItem
+                    : productionOutputForItem + InfraStructure);
+            }
 
             float turnsToCompleteItem = qi.ProductionNeeded / netProdPerTurn.LowerBound(0.01f);
             // Reduce the turns with infra by the turns needed to complete the item so it can be better evaluated next qi

--- a/Ship_Game/Utils/Log.cs
+++ b/Ship_Game/Utils/Log.cs
@@ -799,6 +799,21 @@ namespace Ship_Game
 
                 evt["Memory"] = (GC.GetTotalMemory(false) / 1024).ToString();
                 evt["XnaMemory"] = StarDriveGame.Instance != null ? (StarDriveGame.Instance.Content.GetLoadedAssetBytes() / 1024).ToString() : "0";
+
+                // System-memory pressure context (KB). When MemoryLoad reaches
+                // HighMemoryLoadThreshold the GC stops growing the heap and
+                // throws OOM on large allocations even if the managed heap is
+                // healthy — this fingerprint is invisible without GCMemoryInfo.
+                try
+                {
+                    GCMemoryInfo gcInfo = GC.GetGCMemoryInfo();
+                    evt["GCHeap"] = (gcInfo.HeapSizeBytes / 1024).ToString();
+                    evt["GCFragmented"] = (gcInfo.FragmentedBytes / 1024).ToString();
+                    evt["MemoryLoad"] = (gcInfo.MemoryLoadBytes / 1024).ToString();
+                    evt["MemoryLoadThreshold"] = (gcInfo.HighMemoryLoadThresholdBytes / 1024).ToString();
+                    evt["TotalAvailableMemory"] = (gcInfo.TotalAvailableMemoryBytes / 1024).ToString();
+                }
+                catch { /* GCMemoryInfo unsupported on this runtime — skip */ }
             }
 
             if (!evt.Contains("Thread"))

--- a/UnitTests/StarDriveTestContext.cs
+++ b/UnitTests/StarDriveTestContext.cs
@@ -49,6 +49,13 @@ namespace UnitTests
         static void CreateGameInstance()
         {
             GlobalStats.LoadConfig();
+            // Tests must always run against vanilla content. The net8 testhost
+            // ignores UnitTests/app.config (where ActiveMod=""), so LoadConfig can
+            // pick up the developer's active mod from the user config and load its
+            // roster instead of the base ships the tests expect. Clear the path so
+            // content loads vanilla. This only touches the in-memory field (no
+            // SaveActiveMod), so the developer's real mod selection is untouched.
+            GlobalStats.ModPath = "";
             Log.Initialize(enableSentry: false, showHeader: false);
             Log.VerboseLogging = true;
 

--- a/UnitTests/StarDriveTestContext.cs
+++ b/UnitTests/StarDriveTestContext.cs
@@ -52,10 +52,11 @@ namespace UnitTests
             // Tests must always run against vanilla content. The net8 testhost
             // ignores UnitTests/app.config (where ActiveMod=""), so LoadConfig can
             // pick up the developer's active mod from the user config and load its
-            // roster instead of the base ships the tests expect. Clear the path so
-            // content loads vanilla. This only touches the in-memory field (no
-            // SaveActiveMod), so the developer's real mod selection is untouched.
-            GlobalStats.ModPath = "";
+            // roster instead of the base ships the tests expect. Fully reset to
+            // vanilla: this clears ActiveMod (so HasMod is false and InitContentDir
+            // won't reject the empty ModPath), ModPath, and Defaults. It does NOT
+            // SaveActiveMod, so the developer's real mod selection is untouched.
+            GlobalStats.SetActiveModNoSave(null);
             Log.Initialize(enableSentry: false, showHeader: false);
             Log.VerboseLogging = true;
 


### PR DESCRIPTION
## Summary

Batch of Jupiter 1.60 fixes across rendering, navigation, sim-thread stability, and AI behavior.

**Rendering (Phase 3.7 stub fallout)**
- `Beam.cs`: collapse the dead two-pass alpha-test technique to single-pass additive blend. `RenderStates.EnableAlphaTest` was stubbed as a no-op in the MonoGame migration, so both passes were silently drawing the full quad with the second pass corrupting the result via non-premul `SrcAlpha/InvSrcAlpha` math on premultiplied DDS source. Fixes visible halos around beam weapons.
- `RenderStates.EnableSeparateAlphaBlend`: implement the previously-stubbed separate-channel BlendState. Influence-border node textures (`UniverseScreen.Draw.cs:124`) now use additive alpha + premul RGB as originally intended, so overlapping same-empire nodes merge into smooth blobs instead of stacked discrete discs. `SolarDebug` blend-mode scrub is live again as a side benefit.

**Sim-thread crashes**
- `GetTroopTemplatesFor(...).First()` in `Planet.BuildSingleMilitiaTroop` and `HelperFunctions` fleet-spawn now skip when the empire's roster is empty. Faction empires (pirates/remnants/rebels) explicitly skip the default-troop unlock invariant in `InitEmpireUnlocks` (`!IsFaction` gate), so a faction-owned planet with planetary events could trip `Sequence contains no elements`.
- `ExitToMain` from the pause menu now routes through `GameLoadingScreen(showSplash:false, resetResources:true)` so the in-game graphics cache is freed before MainMenu loads its atlases. Fixes OOM on Combined Arms + memory-tight machines hit during MainMenu atlas DXT5 decompress.
- Crash dumps now emit `GCHeap` / `GCFragmented` / `MemoryLoad` / `MemoryLoadThreshold` / `TotalAvailableMemory` so future OOM reports distinguish heap fragmentation from system-pressure throttling without a second round trip.

**Navigation / UX**
- `EmpireUIOverlay` top-bar nav: ShipDesign → Fleets now exits ShipDesignScreen first (mirrors the existing FleetDesign → non-Fleets branch). Fixes the orphan ship preview rendering in the middle of FleetDesignScreen, and lets the existing save-WIP flow restore the hull selection on the round-trip.
- `FleetDesignScreen`: place new ship at nearest free grid slot instead of rejecting placement.

**AI / sim**
- Research planner: cache `Research.yaml` at content load instead of re-parsing per empire; reset `ShipPicker.MostTechs/KnownTechs` per pick so picks don't drift across roles; guard `EconomicResearchStrategy.PriorityRatio` against zero-sum priorities; fix cybernetic food signal to use `ProdRatio`; harden role/tech-type parsing against modded inputs; dedupe hull query.
- `TurnsUntilQueueComplete`: use real throughput for no-governor colonies.
- `ShipAI.Combat`: rework combat target priority scoring.

**Test harness**
- Force vanilla content via `SetActiveModNoSave(null)` so an active developer mod can't bleed into the suite.

## Test plan
- [x] In-game pause menu → Exit to Main: brief loading screen, no OOM on Combined Arms, MainMenu renders normally afterward
- [x] Click Fleets button from ShipDesign top bar: no orphan ship in FleetDesign view; re-open Shipyard restores the picked hull from WIP
- [x] Mid-game with pirates/remnants holding planets + planetary events firing: sim thread does not crash on `Sequence contains no elements`
- [x] Beam-weapon ships visibly fire without halos around the beam (any mod, any beam color)
- [x] Zoom to SectorView+ with overlapping empire influence: same-empire node circles merge into one smooth blob; multi-empire overlays still composite cleanly
- [x] FleetDesign: add a new ship to a fleet that has a clustered formation — placement falls to nearest free slot instead of being rejected
- [x] `dotnet test UnitTests/SDUnitTests.csproj` passes with no active developer mod required

🤖 Generated with [Claude Code](https://claude.com/claude-code)