### PR TITLE
Jupiter 1.60 fixes_18: pathfinder warp fixes, gravity-well overlay, build & AI cleanup

### DIFF
--- a/Ship_Game/AI/ExpansionAI/ExpansionPlanner.cs
+++ b/Ship_Game/AI/ExpansionAI/ExpansionPlanner.cs
@@ -121,6 +121,15 @@ namespace Ship_Game.AI.ExpansionAI
             if (Owner.isPlayer && !Owner.AutoColonize)
                 return;
 
+            if (ExpandSearchTimer > 0)
+                --ExpandSearchTimer;
+
+            if (ExpandSearchTimer <= 0 && MaxSystemsToCheckedDiv > 1)
+            {
+                ResetExpandSearchTimer();
+                MaxSystemsToCheckedDiv = (MaxSystemsToCheckedDiv - 1).LowerBound(1);
+            }
+
             int ourPlanetsNum = Owner.GetPlanets().Count;
             if (!Owner.isPlayer)
             {
@@ -164,12 +173,8 @@ namespace Ship_Game.AI.ExpansionAI
             // Rank all known planets near the empire
             if (!GatherAllPlanetRanks(potentialPlanets, currentColonizationGoals, empireCenter, out Array<PlanetRanker> allPlanetsRanker))
             {
-                // Nothing found in current search area
-                if (--ExpandSearchTimer <= 0 && MaxSystemsToCheckedDiv > 1) // increase search area if timer is done
-                {
-                    ResetExpandSearchTimer();
-                    MaxSystemsToCheckedDiv = (MaxSystemsToCheckedDiv - 1).LowerBound(1);
-                }
+                // Nothing found this tick. Widening is handled at the top of the function
+                // based solely on ExpandSearchTimer, so there's nothing else to do here.
                 return;
             }
 
@@ -177,7 +182,7 @@ namespace Ship_Game.AI.ExpansionAI
             if (allPlanetsRanker.Count > 0)
             {
                 PlanetRanker bestValuePlanet = allPlanetsRanker.FindMax(pr => pr.Value);
-                    CreateColonyGoals(bestValuePlanet.Planet, currentColonizationGoals.Length);
+                CreateColonyGoals(bestValuePlanet.Planet, currentColonizationGoals.Length);
             }
         }
 
@@ -251,17 +256,17 @@ namespace Ship_Game.AI.ExpansionAI
                 return false;
 
             float longestDistance  = planetList.Last().Position.Distance(empireCenter);
-        
+
             for (int i = 0; i < planetList.Count; i++)
             {
                 Planet p = planetList[i];
                 // The planet ranker does the ranking
-                if (!markedPlanets.Contains(p)) // Don't include planets we are already trying to colonize
-                {
-                    var pr = new PlanetRanker(Owner, p, longestDistance, empireCenter);
-                    if (pr.CanColonize)
-                        planetRanker.Add(pr);
-                }
+                if (markedPlanets.Contains(p)) // Don't include planets we are already trying to colonize
+                    continue;
+
+                var pr = new PlanetRanker(Owner, p, longestDistance, empireCenter);
+                if (pr.CanColonize)
+                    planetRanker.Add(pr);
             }
 
             return planetRanker.Count > 0;

--- a/Ship_Game/AI/ExpansionAI/PlanetRanker.cs
+++ b/Ship_Game/AI/ExpansionAI/PlanetRanker.cs
@@ -39,14 +39,19 @@ namespace Ship_Game.AI.ExpansionAI
             float rawValue        = planet.ColonyPotentialValue(empire);
 
             bool moralityBlock = IsColonizeBlockedByMorals(Planet.System, empire);
+            bool inOwnedSystem = Planet.System.HasPlanetsOwnedBy(empire);
+
             CanColonize = !moralityBlock;
             Value = rawValue;
-            if (!Planet.System.HasPlanetsOwnedBy(empire))
+            if (!inOwnedSystem)
             {
-                DistanceMod = (planet.Position.Distance(empireCenter) / longestDistance * 10).Clamped(1, 10);
-                EnemyStrMod = ((empire.KnownEnemyStrengthIn(planet.System) / (empire.OffensiveStrength+10)) * 10).Clamped(1, 10);
-                CanColonize = !moralityBlock && (rawValue > 20 || empire.IsCybernetic && planet.MineralRichness > 1.5f);
-                Value = rawValue / DistanceMod / EnemyStrMod;
+                float distanceRaw = planet.Position.Distance(empireCenter);
+                float enemyStrRaw = empire.KnownEnemyStrengthIn(planet.System);
+                bool valueOk      = rawValue > 20 || empire.IsCybernetic && planet.MineralRichness > 1.5f;
+                DistanceMod = (distanceRaw / longestDistance * 10).Clamped(1, 10);
+                EnemyStrMod = ((enemyStrRaw / (empire.OffensiveStrength+10)) * 10).Clamped(1, 10);
+                CanColonize = !moralityBlock && valueOk;
+                Value       = rawValue / DistanceMod / EnemyStrMod;
             }
         }
 

--- a/Ship_Game/AI/GravityWellRouter.cs
+++ b/Ship_Game/AI/GravityWellRouter.cs
@@ -10,13 +10,15 @@ namespace Ship_Game.AI;
 // hostile/unknown space. Replaces the dead A* graph (PathFinder/Astar.cs).
 //
 // Two-tier obstacle model:
-//   - FAR systems (origin >= 1.1 system diameters from system center) that aren't
-//     covered by friendly projector influence are treated as a SINGLE blob — the
-//     whole system disc becomes the obstacle. Skips:
+//   - FAR systems (both origin AND destination >= 1.1 system diameters from system
+//     center) that aren't covered by friendly projector influence are treated as a
+//     SINGLE blob — the whole system disc becomes the obstacle. Skips:
 //       · friendly influence covers the system center (in our territory)
 //       · system is KNOWN to be empty (no planets → no wells, safe transit)
-//   - NEAR systems (origin within 1.1 diameters of the system center) fall back
-//     to per-planet gravity-well detection. Skips:
+//   - NEAR systems (origin OR destination within 1.1 diameters of the system center)
+//     fall back to per-planet gravity-well detection — too close to swing around the
+//     whole disc, and near the destination the disc contains the endpoint so it would
+//     otherwise be skipped entirely (and its wells clipped on approach). Skips:
 //       · system is NOT known to our empire (can't see wells; reactive warp-drop
 //         logic handles whatever the ship hits — we can't strategically route
 //         around obstacles we don't know exist).
@@ -42,9 +44,9 @@ public static class GravityWellRouter
     // and isn't mis-detected as tangent-touching the same obstacle on the next pass.
     const float BracketPlacementMul = 1.02f;
 
-    // Per-system "near" threshold: if origin is within (system diameter * 1.1) of
-    // the system center, fall back to per-planet checks (too close to swing around).
-    // Bigger systems get a wider near-band naturally.
+    // Per-system "near" threshold: if origin OR destination is within (system diameter
+    // * 1.1) of the system center, fall back to per-planet checks (too close to swing
+    // around). Bigger systems get a wider near-band naturally.
     const float NearSystemDiameterScale = 1.1f;
 
     // Recursion cap. Each detour inserts 2 waypoints (bracketing the disc), so cap
@@ -65,7 +67,7 @@ public static class GravityWellRouter
     static readonly Vector2[] Empty = Array.Empty<Vector2>();
 
     // Diagnostic; flip to true to trace router decisions in the log. Off in release.
-    public static bool LogVerbose = false;
+    public static bool LogVerbose = true;
 
     // Walks the detour chain — returns the next point the ship should thrust toward,
     // advancing past any detours already reached or that lie farther from the ship
@@ -308,10 +310,16 @@ public static class GravityWellRouter
             sysCandidates++;
 
             float nearThreshold = sys.Radius * 2f * NearSystemDiameterScale;
-            bool isNearOrigin = sys.Position.SqDist(origin) < nearThreshold * nearThreshold;
+            // Per-planet routing kicks in when the ship can't swing around the whole system
+            // disc — true near BOTH the origin and the destination. Near the destination this
+            // lets us avoid individual wells on approach: the arrival system's disc contains
+            // finalDest, so the coarse system-disc path skips the whole system and clips its
+            // wells. Per-planet still skips the destination planet's own well (we're going there).
+            float nt2 = nearThreshold * nearThreshold;
+            bool isNear = sys.Position.SqDist(origin) < nt2 || sys.Position.SqDist(finalDest) < nt2;
             bool isKnown = sys.IsExploredBy(ship.Loyalty);
 
-            if (!isNearOrigin)
+            if (!isNear)
             {
                 if (ship.Universe.Influence.IsInInfluenceOf(ship.Loyalty, sys.Position))
                 {
@@ -410,8 +418,16 @@ public static class GravityWellRouter
         // not the sub-segment's a/b — those are internally-computed waypoints,
         // and if they land inside a well that's a routing bug we WANT to flag
         // so the safety-merge can pull that well into the cluster.
-        if (origin.SqDist(center) <= r2) return false;
-        if (finalDest.SqDist(center) <= r2) return false;
+        if (origin.SqDist(center) <= r2)
+        {
+            if (LogVerbose) Log.Info($"[GWRouter]   skip {name}: origin inside disc (r={r:0})");
+            return false;
+        }
+        if (finalDest.SqDist(center) <= r2)
+        {
+            if (LogVerbose) Log.Info($"[GWRouter]   skip {name}: finalDest inside disc (r={r:0}) — destination system, not routed around");
+            return false;
+        }
 
         // Closest-point t can be outside (0, 1) — clamp to capture wells that contain
         // an endpoint of the segment too. Otherwise wells right at a/b silently slip

--- a/Ship_Game/AI/GravityWellRouter.cs
+++ b/Ship_Game/AI/GravityWellRouter.cs
@@ -66,8 +66,8 @@ public static class GravityWellRouter
 
     static readonly Vector2[] Empty = Array.Empty<Vector2>();
 
-    // Diagnostic; flip to true to trace router decisions in the log. Off in release.
-    public static bool LogVerbose = true;
+    // Diagnostic; flip to true to trace router decisions in the log. Off by default.
+    public static bool LogVerbose = false;
 
     // Walks the detour chain — returns the next point the ship should thrust toward,
     // advancing past any detours already reached or that lie farther from the ship

--- a/Ship_Game/AI/Research/ChooseTech.cs
+++ b/Ship_Game/AI/Research/ChooseTech.cs
@@ -1,5 +1,6 @@
 ﻿using Ship_Game.Ships;
 using System;
+using System.Collections.Generic;
 using SDGraphics;
 using SDUtils;
 
@@ -275,19 +276,34 @@ namespace Ship_Game.AI.Research
                 case "TECH":
                     {
                         string[] script = modifier.Split(':');
+                        bool isCheaper = command1 == "CHEAPEST";
+                        HashSet<string> seenCandidates = new();
                         for (int i = 1; i < script.Length; i++)
                         {
                             var techTypeName    = script[i];
                             var techType             = ConvertTechStringTechType(techTypeName);
                             TechEntry researchTech   = GetScriptedTech(command1, techType, availableTechs);
-                            bool isCheaper           = command1 == "CHEAPEST";
-                            string testResearchTopic = DoesCostCompare(ref previousCost, researchTech, techType, isCheaper);
 
-                            if (testResearchTopic.NotEmpty())
-                                researchTopic = testResearchTopic;
-                            float priority = 0;
-                            // bump priority but consider ship tech categories as more of a unit.
-                            if (techTypeName.Contains("ship"))
+                            // Progression frequently collapses many ship designs to a single ship tech, and
+                            // ship techs can pass several sub-category filters at once (especially with mods
+                            // that multi-type techs via building/bonus unlocks -- e.g. Combined Arms tagging
+                            // weapon techs as GroundCombat through planetary weapon buildings). A repeat
+                            // candidate can never displace itself (later CostNormalizer is monotonically higher,
+                            // so the normalized cost is strictly worse), so skip the redundant compare + log.
+                            // CostNormalizer still advances to keep per-slot pacing intact.
+                            if (researchTech == null || seenCandidates.Add(researchTech.UID))
+                            {
+                                string testResearchTopic = DoesCostCompare(ref previousCost, researchTech, techType, isCheaper);
+                                if (testResearchTopic.NotEmpty())
+                                    researchTopic = testResearchTopic;
+                            }
+
+                            float priority;
+                            // Bump CostNormalizer but treat ship sub-categories (ShipHull/Weapons/Defense/General)
+                            // as one unit: their 4 slots should collectively add ~one non-ship slot's worth,
+                            // otherwise ship techs get penalized 4x for being split. Categories arrive PascalCase
+                            // from GetShipTechString, so the match must be case-insensitive.
+                            if (techTypeName.Contains("Ship", StringComparison.OrdinalIgnoreCase))
                                 priority = 0.0002f;
                             else
                                 priority = 0.005f;

--- a/Ship_Game/AI/ShipAI/ShipAI.Goals.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Goals.cs
@@ -205,7 +205,7 @@ namespace Ship_Game.AI
 
         void AddMoveOrder(Plan plan, WayPoint wayPoint, AIState state, float speedLimit, MoveOrder order, Goal goal = null)
         {
-            EnqueueOrPush(new ShipGoal(plan, wayPoint.Position, wayPoint.Direction, state, order, speedLimit, goal));
+            EnqueueOrPush(new ShipGoal(plan, wayPoint.Position, wayPoint.Direction, state, order, speedLimit, goal, wayPoint.IsDetour));
         }
 
         void EnqueueOrPush(ShipGoal goal, bool pushToFront = false)
@@ -378,6 +378,11 @@ namespace Ship_Game.AI
             [StarData] public TradePlan Trade;
             [StarData] public readonly MoveOrder MoveOrder = MoveOrder.Regular;
 
+            // True when this move goal targets a pathfinder detour waypoint (a pass-through
+            // swing-by). Fleets keep formation warp engaged through detours instead of
+            // dropping out of warp near them. See ShipAI.Movement.ThrustOrWarpToPos.
+            [StarData] public readonly bool IsDetourWaypoint;
+
             // Pathfinder detour chain pre-computed when this goal is queued (from the ship's
             // position at order time to the goal's target). Per-tick handlers route their
             // long-haul thrust through GetThrustTarget so warps skirt hostile/unknown wells.
@@ -448,8 +453,8 @@ namespace Ship_Game.AI
                 WantedState = wantedState;
             }
 
-            public ShipGoal(Plan plan, Vector2 waypoint, Vector2 direction, AIState state, 
-                            MoveOrder order, float speedLimit, Goal goal)
+            public ShipGoal(Plan plan, Vector2 waypoint, Vector2 direction, AIState state,
+                            MoveOrder order, float speedLimit, Goal goal, bool isDetourWaypoint = false)
             {
                 Plan         = plan;
                 MovePosition = waypoint;
@@ -458,6 +463,7 @@ namespace Ship_Game.AI
                 Goal         = goal;
                 MoveOrder    = order;
                 SpeedLimit   = speedLimit;
+                IsDetourWaypoint = isDetourWaypoint;
             }
 
             // restore from SaveGame

--- a/Ship_Game/AI/ShipAI/ShipAI.Movement.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Movement.cs
@@ -206,7 +206,7 @@ namespace Ship_Game.AI
             // FB - we are also setting speed limit for group formation movement
             float speedLimit = Owner.Carrier.RecallingShipsBeforeWarp ? Owner.STLSpeedLimit : 0;
             Vector2 movePos = goal.MovePosition; // dynamic move position
-            ThrustOrWarpToPos(movePos, timeStep, speedLimit);
+            ThrustOrWarpToPos(movePos, timeStep, speedLimit, isDetourLeg: goal.IsDetourWaypoint);
 
             float distance = Owner.Position.Distance(movePos);
 
@@ -404,7 +404,7 @@ namespace Ship_Game.AI
          * @param warpExitDistance [0] If set to nonzero, ships will exit warp at this distance
          *                   but only if this is the last WayPoint
          */
-        internal void ThrustOrWarpToPos(Vector2 pos, FixedSimTime timeStep, float speedLimit = 0f, float warpExitDistance = 0f)
+        internal void ThrustOrWarpToPos(Vector2 pos, FixedSimTime timeStep, float speedLimit = 0f, float warpExitDistance = 0f, bool isDetourLeg = false)
         {
             if (Owner.EnginesKnockedOut)
                 return;
@@ -466,7 +466,10 @@ namespace Ship_Game.AI
                 }
                 else
                 {
-                    if (distance > 7500f) // Not near destination
+                    // A pathfinder detour is a pass-through swing-by: keep formation warp
+                    // engaged so the fleet doesn't drop out of warp at every detour (matching
+                    // single-ship behavior). Only disengage near a real user/final waypoint.
+                    if (distance > 7500f || isDetourLeg) // Not near destination, or just a detour
                     {
                         EngageFormationWarp();
                     }

--- a/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
@@ -324,7 +324,13 @@ namespace Ship_Game.AI
             }
             else
             {
-                detours = GravityWellRouter.BuildDetours(Owner, Owner.Position, position, order);
+                // For a queued waypoint (shift-click), the leg the ship will actually fly
+                // starts at the previously queued waypoint, not the ship's current position.
+                // Route from there so the detours match the real segment.
+                Vector2 routeFrom = (queueNewWayPoint && WayPoints.Count > 0)
+                    ? WayPoints.ElementAt(WayPoints.Count - 1).Position
+                    : Owner.Position;
+                detours = GravityWellRouter.BuildDetours(Owner, routeFrom, position, order);
             }
 
             // WARNING: please don't 'FIX' anything here without caution and testing.

--- a/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.OrderAction.cs
@@ -361,7 +361,10 @@ namespace Ship_Game.AI
             for (int i = 0; i < wayPoints.Length - 1; ++i)
             {
                 wp = wayPoints[i];
-                if (assembleBetweenWayPoints)
+                // Pathfinder detour waypoints are pass-through swing-bys: even fleets keep
+                // warp engaged through them (no reform / MakeFinalApproach), matching single
+                // ship behavior. Reform only at real user waypoints.
+                if (assembleBetweenWayPoints && !wp.IsDetour)
                 {
                     AddMoveOrder(Plan.MoveToWithin1000, wp, wantedState, speedLimit, o|MoveOrder.DequeueWayPoint);
                     AddMoveOrder(Plan.MakeFinalApproach, wp, wantedState, speedLimit, o, goal);

--- a/Ship_Game/Debug/DebugInfoScreen.cs
+++ b/Ship_Game/Debug/DebugInfoScreen.cs
@@ -166,8 +166,15 @@ public sealed partial class DebugInfoScreen : GameScreen
 
     public void ResearchLog(string text, Empire empire)
     {
-        if (!DebugLogText(text, DebugModes.Tech))
+        // Always route to the log file (when VerboseLogging is on), tagged with the
+        // empire name so per-empire research decisions can be grepped after a session.
+        // The Tech debug overlay accumulates lines independently below.
+        if (GlobalStats.VerboseLogging)
+            Log.Info($"[Research:{empire.Name}] {text}");
+
+        if (!IsOpen || Mode != DebugModes.Tech)
             return;
+
         if (GetResearchLog(empire, out Array<string> empireTechs))
         {
             empireTechs.Add(text);

--- a/Ship_Game/ShipGroup.cs
+++ b/Ship_Game/ShipGroup.cs
@@ -456,6 +456,17 @@ namespace Ship_Game
                 return null;
             }
 
+            // Queued waypoints (shift-click) start at the previous fleet waypoint, not the
+            // current average position. A shared avg-anchored route would be wrong for the
+            // queued leg, so skip clustering and let each ship route its own leg in
+            // AddWayPoint (which anchors at that ship's previous queued waypoint).
+            if (order.IsSet(MoveOrder.AddWayPoint))
+            {
+                if (GravityWellRouter.LogVerbose)
+                    Log.Info($"[GWRouter] FLEET ({Ships.Count} ships) queued waypoint — per-ship routing");
+                return null;
+            }
+
             Vector2 avg = AveragePosition();
             float cohesion = GetRelativeSize().Length();
             float cohesionSq = cohesion * cohesion;

--- a/Ship_Game/Ships/AI/WayPoints.cs
+++ b/Ship_Game/Ships/AI/WayPoints.cs
@@ -10,10 +10,15 @@ public readonly struct WayPoint
 {
     [StarData] public readonly Vector2 Position;
     [StarData] public readonly Vector2 Direction; // direction we should be facing at the way point
-    public WayPoint(Vector2 pos, Vector2 dir)
+    // True for pathfinder detour waypoints (gravity-well swing-bys). Fleets reform and
+    // drop out of warp at user waypoints, but pass straight through detours to keep warp
+    // engaged — matching single-ship behavior. Defaults false (old saves => user waypoint).
+    [StarData] public readonly bool IsDetour;
+    public WayPoint(Vector2 pos, Vector2 dir, bool isDetour = false)
     {
         Position = pos;
         Direction = dir;
+        IsDetour = isDetour;
     }
 }
 
@@ -56,7 +61,7 @@ public sealed class WayPoints : IDisposable
                 {
                     Vector2 next = i + 1 < detourPositions.Length ? detourPositions[i + 1] : final.Position;
                     Vector2 dir = (next - detourPositions[i]).Normalized();
-                    ActiveWayPoints.Enqueue(new WayPoint(detourPositions[i], dir));
+                    ActiveWayPoints.Enqueue(new WayPoint(detourPositions[i], dir, isDetour: true));
                 }
             }
             ActiveWayPoints.Enqueue(final);

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
@@ -675,22 +675,26 @@ namespace Ship_Game
             {
                 var inhibit = ResourceManager.Texture("UI/node_inhibit");
 
-                Planet[] visiblePlanets = UState.GetVisiblePlanets();
-                foreach (Planet planet in visiblePlanets)
+                // Gravity wells are only legible up to sector view; skip them in galaxy view
+                if (viewState <= UnivScreenState.SectorView)
                 {
-                    if (planet.System.IsExploredBy(Player))
+                    Planet[] visiblePlanets = UState.GetVisiblePlanets();
+                    foreach (Planet planet in visiblePlanets)
                     {
-                        DrawCircleProjected(planet.Position, planet.GravityWellRadius,
-                                            new Color(255, 50, 0, 150).Premultiplied(), 1f, inhibit, new Color(200, 0, 0, 50).Premultiplied());
+                        if (planet.System.IsExploredBy(Player))
+                        {
+                            DrawCircleProjected(planet.Position, planet.GravityWellRadius,
+                                                new Color(255, 50, 0, 150).Premultiplied(), 1f, inhibit, new Color(200, 0, 0, 50).Premultiplied());
+                        }
                     }
-                }
 
-                foreach (Ship ship in UState.Objects.VisibleShips)
-                {
-                    if (ship is { InhibitionRadius: > 0f, IsVisibleToPlayer: true })
+                    foreach (Ship ship in UState.Objects.VisibleShips)
                     {
-                        DrawCircleProjected(ship.Position, ship.InhibitionRadius,
-                                            new Color(255, 50, 0, 150).Premultiplied(), 1f, inhibit, new Color(200, 0, 0, 40).Premultiplied());
+                        if (ship is { InhibitionRadius: > 0f, IsVisibleToPlayer: true })
+                        {
+                            DrawCircleProjected(ship.Position, ship.InhibitionRadius,
+                                                new Color(255, 50, 0, 150).Premultiplied(), 1f, inhibit, new Color(200, 0, 0, 40).Premultiplied());
+                        }
                     }
                 }
 

--- a/StarDrive.sln
+++ b/StarDrive.sln
@@ -129,12 +129,10 @@ Global
 		{DD03444F-B149-40DB-B1DF-CB31541008ED}.Release|x64.Build.0 = Release|x64
 		{991F9257-97A2-4CF0-8959-C8EC09F17796}.Debug - Auto Fast|x64.ActiveCfg = Debug|x86
 		{991F9257-97A2-4CF0-8959-C8EC09F17796}.Debug - Auto|x64.ActiveCfg = Debug|x86
-		{991F9257-97A2-4CF0-8959-C8EC09F17796}.Debug - Auto|x64.Build.0 = Debug|x86
 		{991F9257-97A2-4CF0-8959-C8EC09F17796}.Debug|x64.ActiveCfg = Debug|x86
 		{991F9257-97A2-4CF0-8959-C8EC09F17796}.Deploy|x64.ActiveCfg = Release|x86
 		{991F9257-97A2-4CF0-8959-C8EC09F17796}.Release - Auto Fast|x64.ActiveCfg = Release|x86
 		{991F9257-97A2-4CF0-8959-C8EC09F17796}.Release - Auto|x64.ActiveCfg = Release|x86
-		{991F9257-97A2-4CF0-8959-C8EC09F17796}.Release - Auto|x64.Build.0 = Release|x86
 		{991F9257-97A2-4CF0-8959-C8EC09F17796}.Release|x64.ActiveCfg = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution


### PR DESCRIPTION
## Summary

A batch of Jupiter 1.60 fixes accumulated on `fixes_18`.

### Pathfinding / warp
- **GravityWellRouter: route around destination-system wells + fix queued-waypoint origin** (`f5e664438`) — the router now treats a system as NEAR when either the origin *or* the final destination is inside it, so ships stop clipping a gravity well at the end of a route. Shift-clicked (queued) waypoints now build detours from the previous waypoint instead of the ship's current position.
- **ShipAI: fleets keep warp through pathfinder detours** (`ca33d05c6`) — fleets used to drop out of warp at every detour waypoint while single ships kept warp. Detour legs are now flagged (`WayPoint.IsDetour` → `ShipGoal.IsDetourWaypoint`) so formation warp stays engaged through pathfinder swing-bys; normal waypoints still exit warp for fleets as before.

### UI / overlay
- **Overlay: hide gravity-well rings in galaxy view; quiet the router log** (`0e0c18c05`) — the red gravity-well / inhibitor circles (F2 overlay) now render only at `viewState <= SectorView`, so they vanish in galaxy view. The green influence overlay is unchanged. `GravityWellRouter.LogVerbose` is back to `false`.

### Build
- **Solution: stop building the SDInstaller WiX project in the Auto configs** (`73ef2d6b4`) — the installer carried a stray `Build.0` only under `Debug - Auto` / `Release - Auto`, so rebuilding in those configs also ran the installer. Dropped both so the Auto configs match every other config.

### AI cleanup
- **AI research: ship sub-categories share CostNormalizer slot + dedup compares** (`1d97667a9`)
- **ExpansionAI: strip WIP debug logging, keep the logic** (`a4758879d`) — removed the magenta `[Expansion:...]` trace scaffolding while retaining the functional changes (search-timer widening relocation, `GatherAllPlanetRanks` early-continue, PlanetRanker local extraction). Kept `KnownEnemyStrengthIn` inside the `!inOwnedSystem` branch to avoid an extra ThreatMatrix scan per rank.

## Test plan
- Full unit-test suite (run automatically by the pre-PR hook).
- In-game: ordered ships/fleets across gravity wells incl. queued waypoints; verified fleets hold warp through detours (LALA fleet). F2 overlay checked at sector vs galaxy zoom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)