### PR TITLE
Add shared Claude Code review workflow skills

### DIFF
--- a/.claude/skills/full-pr-review/SKILL.md
+++ b/.claude/skills/full-pr-review/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: full-pr-review
+description: Before opening a PR, launch a review agent over the FULL PR diff (all commits on the branch vs the base), apply the deep-review checklist, address findings, and record a HEAD marker so the gh-pr-create gate passes.
+---
+
+# Full PR review (before opening a PR)
+
+Run this before `gh pr create`. It reviews the whole branch — every commit since the
+base — not just the last commit, and records a marker the PR-create hook checks.
+
+## Steps
+
+1. Determine the base and gather the full PR diff. In parallel:
+   - `git rev-parse --abbrev-ref HEAD` — current branch.
+   - Base branch is normally `main` (confirm if the branch description says otherwise).
+   - `git log --oneline <base>..HEAD` — every commit that will be in the PR.
+   - `git diff <base>...HEAD --stat` then `git diff <base>...HEAD` — the cumulative diff
+     (three-dot: diff vs the merge-base, i.e. exactly what the PR introduces).
+
+   If the diff is empty, stop and tell the user there is nothing to review.
+
+2. Launch a review agent (`Agent`, `subagent_type: general-purpose`). The agent has none
+   of this conversation's context — hand it a self-contained prompt containing:
+   - The base branch, the list of commits, and the changed files with paths.
+   - 1–3 sentences (synthesized by you, not delegated) on what the PR is trying to achieve.
+   - Instruction to run `git diff <base>...HEAD -- <paths>` itself for the exact diff.
+   - **The deep-review checklist (required — this is the point of the skill):**
+     1. **Correctness / security / concurrency** — the usual.
+     2. **Caller-impact pass** — for every method whose signature OR behavior changed,
+        enumerate ALL callers (`grep`/`Grep` the repo) and verify the new behavior against
+        each caller's intent. Diff-local reading misses regressions that only surface at a
+        call site outside the diff (this is the class of bug that has slipped through before).
+     3. **Project-convention pass** — check conventions that live OUTSIDE CLAUDE.md too:
+        `.csproj` global usings / type aliases (e.g. `Range` aliased to `SDGraphics.Range`,
+        so `System.Range` slice syntax `x[..n]` is off-convention), analyzer rules, and the
+        defer-remove / for-loops-over-LINQ patterns this codebase prefers in sim hot paths.
+     4. **Exception-path pass** — for new IO / external-API / callback code, ask what can
+        throw and whether failure is swallowed where it must be (e.g. attachments and
+        telemetry callbacks must be best-effort and never derail the primary operation).
+     5. **Sensitive-subsystem mode** — if the diff touches telemetry/logging, save/load,
+        threading, or serialization, do a DEEPER pass and do not cap brevity. For these the
+        bar is "would an external reviewer (Copilot) find zero valid issues?"
+   - Ask for findings flagged by severity (blocker / nit), skip praise. Allow more than
+     300 words when sensitive-subsystem mode applies; otherwise keep it tight.
+
+3. Triage the report: **blockers** (fix before PR), **nits** (surface to the user), **false
+   positives** (note why dismissed). Fix blockers; commit the fixes.
+
+4. Present a short summary to the user. If blockers were found, propose/apply fixes and get
+   confirmation. Only proceed once the branch is clean or findings are addressed.
+
+5. Push and `gh pr create` as usual.
+
+   OPTIONAL hard gate: if you've enabled the `gh pr create` PreToolUse hook in your own
+   `.claude/settings.local.json` (see Notes), record the review marker LAST — after every fix
+   is committed, so it captures the final HEAD:
+   `git rev-parse HEAD > .claude/pr-review-passed`
+   The hook blocks PR creation unless this marker equals the current HEAD, so any commit made
+   after the review re-arms the gate and forces a re-review. Without the hook, this file is
+   just a harmless local note.
+
+## Notes
+
+- The review agent runs in the foreground — you need its findings before opening the PR.
+- This complements [[self-review-before-commit]] (per-commit) — it does not replace it. The
+  per-commit skill should also apply the caller-impact / convention / exception-path passes.
+- If the user explicitly says "skip review" or "just open the PR," honor it: record the marker
+  (`git rev-parse HEAD > .claude/pr-review-passed`) so the gate doesn't block them, and note
+  that review was skipped at their request.
+- OPTIONAL: to make this review a hard gate on `gh pr create` (mirroring a test-suite gate),
+  add a `PreToolUse` / `Bash` hook to your own `.claude/settings.local.json` (gitignored,
+  per-developer) that blocks unless the marker matches HEAD:
+  `head=$(git rev-parse HEAD 2>/dev/null); marker=$(cat .claude/pr-review-passed 2>/dev/null); if [ -z "$marker" ] || [ "$head" != "$marker" ]; then echo "Blocking: run the full-pr-review skill first." >&2; exit 2; fi`
+  guarded by `printf '%s' "$(cat)" | grep -qE 'gh(\.exe)?[^"]* pr create' || exit 0`.

--- a/.claude/skills/self-review-before-commit/SKILL.md
+++ b/.claude/skills/self-review-before-commit/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: self-review-before-commit
+description: Before committing, launch a code-review agent over the staged + unstaged diff and report findings; only proceed to commit after the review (and any fixes it surfaces).
+---
+
+# Self-review before commit
+
+When this skill is invoked, do NOT commit yet. Run a self-review first.
+
+## Steps
+
+1. Gather the diff to review. In parallel:
+   - `git status` — full list of changed files (including untracked).
+   - `git diff HEAD` — combined staged + unstaged changes since the last commit.
+   - `git log -1 --format="%H %s"` — base commit for context.
+
+   If the diff is empty, stop and tell the user there is nothing to review.
+
+2. Launch a review agent. Use the `Agent` tool with `subagent_type: general-purpose`
+   (or `code-reviewer` if available in this environment). Hand it a self-contained
+   prompt — the agent has none of this conversation's context. Include:
+   - The exact files changed and their paths.
+   - What the user is trying to accomplish in this set of changes (1-2 sentences,
+     synthesized from the conversation — do not delegate this understanding).
+   - The diff itself, or instruction to `git diff HEAD -- <paths>` themselves.
+   - Ask for: correctness bugs, security issues, concurrency/race risks,
+     obvious style violations per project conventions in CLAUDE.md, and any
+     dead/unused code introduced. Explicitly ask the agent to flag findings
+     by severity (blocker / nit) and to skip praise.
+   - Also require these three passes (they catch the bugs diff-local reading misses):
+     - **Caller-impact** — for any method whose signature OR behavior changed,
+       enumerate ALL callers and check the new behavior against each caller's intent.
+       A regression often only manifests at a call site outside the diff.
+     - **Project conventions beyond CLAUDE.md** — `.csproj` global usings / type
+       aliases (e.g. `Range` → `SDGraphics.Range`, so `System.Range` slice syntax is
+       off-convention), analyzer rules, and the codebase's preferred patterns.
+     - **Exception paths** — for new IO / external-API / callback code, what can throw,
+       and is failure swallowed where it must be (telemetry/attachments are best-effort)?
+   - For sensitive subsystems (telemetry/logging, save/load, threading, serialization),
+     run a deeper pass and lift the word cap. Otherwise cap: "Report under 300 words,
+     bullet form."
+
+3. Read the agent's report. Categorize findings:
+   - **Blockers** — correctness/security/concurrency issues. Fix before committing.
+   - **Nits** — style/clarity. Surface to the user; let them decide.
+   - **False positives** — note briefly why dismissed.
+
+4. Present the review to the user in a short summary. If there are blockers,
+   propose fixes and ask the user before applying. If there are only nits,
+   list them and ask whether to address or commit as-is. If the review is
+   clean, say so and proceed to the normal commit flow.
+
+5. After the user confirms (and any fixes are applied), perform the commit
+   exactly as the standard "create a git commit" flow does — drafted commit
+   message via HEREDOC, `Co-Authored-By` trailer, etc.
+
+## Notes
+
+- The review agent should run in the foreground — you need its findings before
+  you can decide whether to commit.
+- Do not skip step 2 when the diff is "obviously small." A trivial-looking
+  diff is exactly where a fresh pair of eyes catches the missed null guard
+  or the accidentally-removed branch.
+- If the user explicitly says "skip review" or "just commit," honor that and
+  skip directly to the commit flow.

--- a/.gitignore
+++ b/.gitignore
@@ -113,7 +113,9 @@ x64Migration/Tools/*/obj/
 # Per-user Claude Code state: permission caches, scheduled-task locks,
 # session metadata. All entries are user-machine-specific (absolute
 # paths, NuGet caches, Downloads folders); nothing here is portable.
-.claude/
+# Exception: .claude/skills/ holds shared, portable team workflow skills.
+.claude/*
+!.claude/skills/
 game/SDGraphics.pdb
 game/SDGraphics.dll
 game/SDUtils.dll


### PR DESCRIPTION
Ships two Claude Code workflow skills into the repo so any teammate using Claude Code gets the same review discipline. **Skills only — no team-wide blocking hook**; enforcement stays opt-in per developer.

## What's added
- **`.claude/skills/full-pr-review/`** — reviews the *whole* PR diff (all commits vs base), with a deep checklist: caller-impact (enumerate callers of changed methods), project conventions incl. `.csproj` global usings/aliases (e.g. `Range` → `SDGraphics.Range`, so `System.Range` slice syntax is off-convention), exception paths, and a sensitive-subsystem deep mode.
- **`.claude/skills/self-review-before-commit/`** — per-commit review carrying the same depth passes.

## Why
Two rounds of external (Copilot) review on a recent PR surfaced valid issues our internal review missed — all because reviews were diff-local, blind to conventions living in build files, and didn't reason about exception paths. These skills close those gaps.

## gitignore
`.claude/` is gitignored (per-user state). This adds a narrow exception tracking only `.claude/skills/`; `settings.local.json`, marker files, and scheduled-task locks stay ignored.

## Opt-in hard gate (not committed)
Developers who want `gh pr create` to *block* until a review is recorded can add the documented `PreToolUse` hook to their own `.claude/settings.local.json` (see the full-pr-review skill notes). Nothing is forced on the team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)