### PR TITLE
jupiter-1.60/fixes_20: refit queue priority, PTB/POL languages, ExplosionManager load fix

### DIFF
--- a/Ship_Game/Data/Localizer.cs
+++ b/Ship_Game/Data/Localizer.cs
@@ -34,6 +34,7 @@ namespace Ship_Game
         [StarData] public string UKR;
         [StarData] public string GER;
         [StarData] public string PTB; // Brazilian Portuguese
+        [StarData] public string POL; // Polish
     }
 
     public static class Localizer
@@ -160,6 +161,7 @@ namespace Ship_Game
                     case Language.Ukrainian: text = t.UKR.NotEmpty() ? t.UKR : t.ENG; break;
                     case Language.German:    text = t.GER.NotEmpty() ? t.GER : t.ENG; break;
                     case Language.Portuguese: text = t.PTB.NotEmpty() ? t.PTB : t.ENG; break;
+                    case Language.Polish:     text = t.POL.NotEmpty() ? t.POL : t.ENG; break;
                 }
                 
                 // when replacing an existing token, reuse its Index

--- a/Ship_Game/Data/Localizer.cs
+++ b/Ship_Game/Data/Localizer.cs
@@ -33,6 +33,7 @@ namespace Ship_Game
         [StarData] public string SPA;
         [StarData] public string UKR;
         [StarData] public string GER;
+        [StarData] public string PTB; // Brazilian Portuguese
     }
 
     public static class Localizer
@@ -158,6 +159,7 @@ namespace Ship_Game
                     case Language.Spanish:   text = t.SPA.NotEmpty() ? t.SPA : t.ENG; break;
                     case Language.Ukrainian: text = t.UKR.NotEmpty() ? t.UKR : t.ENG; break;
                     case Language.German:    text = t.GER.NotEmpty() ? t.GER : t.ENG; break;
+                    case Language.Portuguese: text = t.PTB.NotEmpty() ? t.PTB : t.ENG; break;
                 }
                 
                 // when replacing an existing token, reuse its Index

--- a/Ship_Game/ExplosionManager.cs
+++ b/Ship_Game/ExplosionManager.cs
@@ -97,16 +97,6 @@ namespace Ship_Game
             }
         }
 
-        public static void UnloadContent()
-        {
-            using (Lock.AcquireWriteLock())
-            {
-                ActiveExplosions.Clear();
-                ExplosionPixel = null;
-                Types.Clear();
-            }
-        }
-
         static void AddLight(ExplosionState newExp, Vector3 position, float intensity)
         {
             newExp.Light = new PointLight

--- a/Ship_Game/ExplosionManager.cs
+++ b/Ship_Game/ExplosionManager.cs
@@ -69,6 +69,16 @@ namespace Ship_Game
         {
             GameLoadingScreen.SetStatus("LoadExplosions");
 
+            // Drop any explosions still in flight from a previous session. This
+            // reload disposes the old explosion atlases, and a surviving
+            // ExplosionState holds a now-dead atlas reference whose Sorted array
+            // is emptied — DrawExplosion would then index into it and throw
+            // IndexOutOfRange (seen after loading a save mid-battle). Clearing
+            // here is coupled to the exact moment the atlases are rebuilt, so no
+            // stale state can outlive the load.
+            using (Lock.AcquireWriteLock())
+                ActiveExplosions.Clear();
+
             foreach (KeyValuePair<ExplosionType, Array<Explosion>> kv in Types)
                 kv.Value.Clear();
 

--- a/Ship_Game/GlobalStats.cs
+++ b/Ship_Game/GlobalStats.cs
@@ -16,6 +16,7 @@ public enum Language
     Spanish,
     Ukrainian,
     German,
+    Portuguese, // Brazilian Portuguese (PTB column in GameText.yaml)
 }
 
 public enum WindowMode

--- a/Ship_Game/GlobalStats.cs
+++ b/Ship_Game/GlobalStats.cs
@@ -17,6 +17,7 @@ public enum Language
     Ukrainian,
     German,
     Portuguese, // Brazilian Portuguese (PTB column in GameText.yaml)
+    Polish,     // POL column in GameText.yaml
 }
 
 public enum WindowMode

--- a/Ship_Game/Tools/Localization/LocText.cs
+++ b/Ship_Game/Tools/Localization/LocText.cs
@@ -7,7 +7,7 @@ namespace Ship_Game.Tools.Localization
 {
     public class LocText
     {
-        public static string[] SupportedLangs = new[]{ "ENG", "RUS", "SPA", "UKR", "GER", "PTB" };
+        public static string[] SupportedLangs = new[]{ "ENG", "RUS", "SPA", "UKR", "GER", "PTB", "POL" };
         public int Id;
         public string NameId;
         public string Comment;

--- a/Ship_Game/Tools/Localization/LocText.cs
+++ b/Ship_Game/Tools/Localization/LocText.cs
@@ -7,7 +7,7 @@ namespace Ship_Game.Tools.Localization
 {
     public class LocText
     {
-        public static string[] SupportedLangs = new[]{ "ENG", "RUS", "SPA" };
+        public static string[] SupportedLangs = new[]{ "ENG", "RUS", "SPA", "UKR", "GER", "PTB" };
         public int Id;
         public string NameId;
         public string Comment;

--- a/Ship_Game/Tools/Localization/LocalizationTool.cs
+++ b/Ship_Game/Tools/Localization/LocalizationTool.cs
@@ -37,6 +37,7 @@ namespace Ship_Game.Tools.Localization
                     db.AddFromYaml($"{gameContent}\\GameText.Missing.SPA.yaml", logMerge:true);
                     db.AddFromYaml($"{gameContent}\\GameText.Missing.UKR.yaml", logMerge:true);
                     db.AddFromYaml($"{gameContent}\\GameText.Missing.GER.yaml", logMerge:true);
+                    db.AddFromYaml($"{gameContent}\\GameText.Missing.PTB.yaml", logMerge:true);
                 }
             }
             if (db.NumLocalizations == 0)
@@ -60,6 +61,7 @@ namespace Ship_Game.Tools.Localization
             db.ExportMissingTranslationsYaml("SPA", $"{gameContent}\\GameText.Missing.SPA.yaml");
             db.ExportMissingTranslationsYaml("UKR", $"{gameContent}\\GameText.Missing.UKR.yaml");
             db.ExportMissingTranslationsYaml("GER", $"{gameContent}\\GameText.Missing.GER.yaml");
+            db.ExportMissingTranslationsYaml("PTB", $"{gameContent}\\GameText.Missing.PTB.yaml");
 
             if (Directory.Exists(modContent))
             {
@@ -71,6 +73,7 @@ namespace Ship_Game.Tools.Localization
                         db.AddFromModYaml($"{modContent}\\GameText.Missing.SPA.yaml", logMerge:true);
                         db.AddFromModYaml($"{modContent}\\GameText.Missing.UKR.yaml", logMerge:true);
                         db.AddFromModYaml($"{modContent}\\GameText.Missing.GER.yaml", logMerge:true);
+                        db.AddFromModYaml($"{modContent}\\GameText.Missing.PTB.yaml", logMerge:true);
                     }
                 }
                 if (db.NumModLocalizations == 0)
@@ -86,6 +89,7 @@ namespace Ship_Game.Tools.Localization
                 db.ExportMissingModYaml("SPA", $"{modContent}\\GameText.Missing.SPA.yaml");
                 db.ExportMissingModYaml("UKR", $"{modContent}\\GameText.Missing.UKR.yaml");
                 db.ExportMissingModYaml("GER", $"{modContent}\\GameText.Missing.GER.yaml");
+                db.ExportMissingModYaml("PTB", $"{modContent}\\GameText.Missing.PTB.yaml");
             }
             return db;
         }

--- a/Ship_Game/Tools/Localization/LocalizationTool.cs
+++ b/Ship_Game/Tools/Localization/LocalizationTool.cs
@@ -38,6 +38,7 @@ namespace Ship_Game.Tools.Localization
                     db.AddFromYaml($"{gameContent}\\GameText.Missing.UKR.yaml", logMerge:true);
                     db.AddFromYaml($"{gameContent}\\GameText.Missing.GER.yaml", logMerge:true);
                     db.AddFromYaml($"{gameContent}\\GameText.Missing.PTB.yaml", logMerge:true);
+                    db.AddFromYaml($"{gameContent}\\GameText.Missing.POL.yaml", logMerge:true);
                 }
             }
             if (db.NumLocalizations == 0)
@@ -62,6 +63,7 @@ namespace Ship_Game.Tools.Localization
             db.ExportMissingTranslationsYaml("UKR", $"{gameContent}\\GameText.Missing.UKR.yaml");
             db.ExportMissingTranslationsYaml("GER", $"{gameContent}\\GameText.Missing.GER.yaml");
             db.ExportMissingTranslationsYaml("PTB", $"{gameContent}\\GameText.Missing.PTB.yaml");
+            db.ExportMissingTranslationsYaml("POL", $"{gameContent}\\GameText.Missing.POL.yaml");
 
             if (Directory.Exists(modContent))
             {
@@ -74,6 +76,7 @@ namespace Ship_Game.Tools.Localization
                         db.AddFromModYaml($"{modContent}\\GameText.Missing.UKR.yaml", logMerge:true);
                         db.AddFromModYaml($"{modContent}\\GameText.Missing.GER.yaml", logMerge:true);
                         db.AddFromModYaml($"{modContent}\\GameText.Missing.PTB.yaml", logMerge:true);
+                        db.AddFromModYaml($"{modContent}\\GameText.Missing.POL.yaml", logMerge:true);
                     }
                 }
                 if (db.NumModLocalizations == 0)
@@ -90,6 +93,7 @@ namespace Ship_Game.Tools.Localization
                 db.ExportMissingModYaml("UKR", $"{modContent}\\GameText.Missing.UKR.yaml");
                 db.ExportMissingModYaml("GER", $"{modContent}\\GameText.Missing.GER.yaml");
                 db.ExportMissingModYaml("PTB", $"{modContent}\\GameText.Missing.PTB.yaml");
+                db.ExportMissingModYaml("POL", $"{modContent}\\GameText.Missing.POL.yaml");
             }
             return db;
         }

--- a/Ship_Game/Tools/Localization/TextToken.cs
+++ b/Ship_Game/Tools/Localization/TextToken.cs
@@ -48,6 +48,7 @@ namespace Ship_Game.Tools.Localization
                     if (t.UKR != null) tokens.Add(new TextToken("UKR", t.Id, nameId, t.UKR));
                     if (t.GER != null) tokens.Add(new TextToken("GER", t.Id, nameId, t.GER));
                     if (t.PTB != null) tokens.Add(new TextToken("PTB", t.Id, nameId, t.PTB));
+                    if (t.POL != null) tokens.Add(new TextToken("POL", t.Id, nameId, t.POL));
                 }
             }
             return tokens;

--- a/Ship_Game/Tools/Localization/TextToken.cs
+++ b/Ship_Game/Tools/Localization/TextToken.cs
@@ -45,6 +45,9 @@ namespace Ship_Game.Tools.Localization
                     if (t.ENG != null) tokens.Add(new TextToken("ENG", t.Id, nameId, t.ENG));
                     if (t.RUS != null) tokens.Add(new TextToken("RUS", t.Id, nameId, t.RUS));
                     if (t.SPA != null) tokens.Add(new TextToken("SPA", t.Id, nameId, t.SPA));
+                    if (t.UKR != null) tokens.Add(new TextToken("UKR", t.Id, nameId, t.UKR));
+                    if (t.GER != null) tokens.Add(new TextToken("GER", t.Id, nameId, t.GER));
+                    if (t.PTB != null) tokens.Add(new TextToken("PTB", t.Id, nameId, t.PTB));
                 }
             }
             return tokens;

--- a/Ship_Game/Universe/SolarBodies/SBProduction.cs
+++ b/Ship_Game/Universe/SolarBodies/SBProduction.cs
@@ -421,6 +421,38 @@ namespace Ship_Game.Universe.SolarBodies
             AddToQueueAndPrioritize(item);
         }
 
+        // Bumps a refit job to the front of the queue (for both player and AI) so the ship
+        // gets back into service fast - unless the current front item is about to finish, in
+        // which case the refit slots second so a nearly-complete build isn't bumped.
+        // Caller must hold the ConstructionQueue lock.
+        void PromoteRefitToFront(QueueItem item)
+        {
+            if (Count <= 1)
+                return; // the refit is already the only/first item
+
+            int refitIndex = ConstructionQueue.IndexOf(item);
+            if (refitIndex < 0)
+                return;
+
+            // The "about to finish" window scales with ProductionPace, same as build costs do.
+            float turnsThreshold = 5 * P.Universe.ProductionPace;
+            int insertAt = TurnsToCompleteFirstItem() <= turnsThreshold ? 1 : 0;
+            if (refitIndex != insertAt)
+                MoveTo(insertAt, refitIndex);
+        }
+
+        // Turns the planet needs to finish the item currently at the front of the queue.
+        // Stored production is dumped into it first, then per-turn income covers the rest.
+        int TurnsToCompleteFirstItem()
+        {
+            float remaining = (ConstructionQueue[0].ProductionNeeded - P.ProdHere).LowerBound(0);
+            if (remaining <= 0)
+                return 0; // the stockpile alone finishes it next turn
+
+            float perTurn = P.CurrentProductionToQueue.LowerBound(0.01f);
+            return (int)Math.Ceiling(remaining / perTurn);
+        }
+
         void AddToQueueAndPrioritize(QueueItem item)
         {
             lock (ConstructionQueue)
@@ -443,6 +475,10 @@ namespace Ship_Game.Universe.SolarBodies
                         MoveTo(0, Count - 1);
                     }
                 }
+
+                // Ship and orbital refits jump the queue so the ship returns to service fast.
+                if (item.Goal is RefitShip or RefitOrbital)
+                    PromoteRefitToFront(item);
             }
         }
 

--- a/UnitTests/Planets/TestRefitQueuePlacement.cs
+++ b/UnitTests/Planets/TestRefitQueuePlacement.cs
@@ -1,0 +1,112 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ship_Game;
+using Ship_Game.Commands.Goals;
+using Ship_Game.Ships;
+using Vector2 = SDGraphics.Vector2;
+#pragma warning disable CA2213
+
+namespace UnitTests.Planets;
+
+// Verifies SBProduction.AddToQueueAndPrioritize / PromoteRefitToFront: a refit job
+// (RefitShip / RefitOrbital goal) jumps to the front of the construction queue so the
+// ship gets back into service fast - unless the current front item is within
+// 5 * ProductionPace turns of completion, in which case the refit slots in second so a
+// nearly-finished build isn't bumped.
+[TestClass]
+public class TestRefitQueuePlacement : StarDriveTest
+{
+    Planet Homeworld;
+    Building NanoMine;
+    IShipDesign ScoutDesign;
+
+    public TestRefitQueuePlacement()
+    {
+        CreateUniverseAndPlayerEmpire();
+        Homeworld = AddHomeWorldToEmpire(new Vector2(2000), Player);
+        NanoMine = ResourceManager.GetBuildingTemplate("Nano Mine");
+        Assert.IsNotNull(NanoMine, "Nano Mine template missing from ResourceManager");
+        ScoutDesign = ResourceManager.GetShipTemplate("Rocket Scout").ShipData;
+        Assert.IsNotNull(ScoutDesign, "Rocket Scout design missing (did ReloadStarterShips run?)");
+    }
+
+    // Enqueues a plain building as the front item and overrides its cost/progress so the
+    // test controls how many turns it is from completion. Returns the live QueueItem.
+    QueueItem EnqueueFrontItem(float cost, float productionSpent)
+    {
+        Assert.IsTrue(Homeworld.Construction.Enqueue(NanoMine), "Failed to enqueue front item");
+        var queue = Homeworld.Construction.GetConstructionQueue();
+        QueueItem front = queue[queue.Count - 1];
+        front.Cost = cost;
+        front.ProductionSpent = productionSpent;
+        return front;
+    }
+
+    QueueItem MakeRefit(float cost = 50f)
+    {
+        return new QueueItem(Homeworld)
+        {
+            isShip   = true,
+            ShipData = ScoutDesign,
+            Cost     = cost,
+            QType    = QueueItemType.CombatShip,
+            Goal     = new RefitShip(Player),
+        };
+    }
+
+    [TestMethod]
+    public void RefitJumpsToFront_WhenFrontItemIsFarFromCompletion()
+    {
+        Homeworld.ProdHere = 0; // no stockpile to dump into the front item
+        QueueItem front = EnqueueFrontItem(cost: 1_000_000, productionSpent: 0); // many turns away
+
+        QueueItem refit = MakeRefit();
+        Homeworld.Construction.EnqueueRefitShip(refit);
+
+        var queue = Homeworld.Construction.GetConstructionQueue();
+        Assert.AreEqual(2, queue.Count);
+        Assert.AreSame(refit, queue[0], "Refit should jump ahead of a front item that is many turns from completion");
+        Assert.AreSame(front, queue[1]);
+    }
+
+    [TestMethod]
+    public void RefitSlotsSecond_WhenFrontItemIsNearlyComplete()
+    {
+        Homeworld.ProdHere = 0;
+        // ProductionNeeded == 0 -> 0 turns to finish, inside the 5 * ProductionPace window
+        QueueItem front = EnqueueFrontItem(cost: 100, productionSpent: 100);
+
+        QueueItem refit = MakeRefit();
+        Homeworld.Construction.EnqueueRefitShip(refit);
+
+        var queue = Homeworld.Construction.GetConstructionQueue();
+        Assert.AreEqual(2, queue.Count);
+        Assert.AreSame(front, queue[0], "A nearly-complete front item should not be bumped");
+        Assert.AreSame(refit, queue[1], "Refit should slot in second behind the nearly-complete item");
+    }
+
+    [TestMethod]
+    public void RefitOnEmptyQueue_StaysAtFront()
+    {
+        QueueItem refit = MakeRefit();
+        Homeworld.Construction.EnqueueRefitShip(refit);
+
+        var queue = Homeworld.Construction.GetConstructionQueue();
+        Assert.AreEqual(1, queue.Count);
+        Assert.AreSame(refit, queue[0]);
+    }
+
+    [TestMethod]
+    public void NonRefitBuild_IsNotPromoted()
+    {
+        Homeworld.ProdHere = 0;
+        QueueItem front = EnqueueFrontItem(cost: 1_000_000, productionSpent: 0);
+
+        // A normal (non-refit) ship build runs through the same prioritize path but
+        // must NOT jump the queue - only RefitShip / RefitOrbital goals do.
+        Homeworld.Construction.Enqueue(ScoutDesign, QueueItemType.CombatShip);
+
+        var queue = Homeworld.Construction.GetConstructionQueue();
+        Assert.AreEqual(2, queue.Count);
+        Assert.AreSame(front, queue[0], "Non-refit builds must not jump the queue");
+    }
+}

--- a/UnitTests/SDUnitTests.csproj
+++ b/UnitTests/SDUnitTests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Planets\CapitalTransfer.cs" />
     <Compile Include="Planets\LandOnTiles.cs" />
     <Compile Include="Planets\TestOrbitalBomb.cs" />
+    <Compile Include="Planets\TestRefitQueuePlacement.cs" />
     <Compile Include="Planets\TestSabotageWorkDistribution.cs" />
     <Compile Include="Serialization\BinaryReadWriteTests.cs" />
     <Compile Include="Serialization\ObjectScannerTests.cs" />


### PR DESCRIPTION
Rolling fixes batch off `main`. Three independent themes.

## Refit construction-queue priority
Ship and orbital refit jobs were appended to the **end** of a planet's
construction queue, so a refitted ship could sit behind a long backlog before
rebuilding. `AddToQueueAndPrioritize` now detects refit goals (`RefitShip` /
`RefitOrbital`) and promotes the job to the **front** of the queue for player
and AI alike, via `PromoteRefitToFront`.

To avoid wasting a nearly-finished build, the refit slots in **second** instead
of first when the current front item is within `5 * ProductionPace` turns of
completion. `TurnsToCompleteFirstItem` estimates that from the item's remaining
production, the planet's stockpile, and its per-turn throughput
(`CurrentProductionToQueue`). The refit is located by `IndexOf` rather than the
tail index because the preceding `DePrioritizeTerraformer` housekeeping can land
an item behind it.

Covered by 4 new unit tests (`TestRefitQueuePlacement`): front-jump when the
front item is far out, second-slot when it's nearly done, empty-queue stays at
front, and a non-refit build is **not** promoted.

Known limitation: AI planets re-sort their queue on each subsequent enqueue, so
a promoted refit can be re-demoted before it completes (inherent to the AI
priority model — pinning would be a follow-up).

## Localization: add Brazilian Portuguese (PTB) and Polish (POL)
- New `Language` enum values (appended — `Language` is persisted by **name**, so
  this is ordinal-safe), `LangToken.PTB`/`POL` YAML columns, `LoadFromYaml` cases
  with English fallback, and the offline dev tooling
  (`TextToken.FromYaml`, `LocText.SupportedLangs`, `LocalizationTool`
  merge/export).
- Also fixes a pre-existing round-trip gap where UKR/GER were present in some
  tool sites but missing from `TextToken.FromYaml` / `LocText.SupportedLangs`.
- No translation strings ship in this PR — both languages fall back to English
  until their columns are populated (on the dedicated translations branch).
- PTB renders today (diacritics are in the baked Latin-1 region). **Polish is
  not announced yet** — its special letters need a SpriteFont rebake (Latin
  Extended-A), tracked separately.

## ExplosionManager: drop stale explosions on content reload
The static `ActiveExplosions` list survived save/load, so loading a save
mid-battle left stale explosions on screen. Now cleared (under the write lock)
in `LoadExplosions`, which runs on every content reload. Also removes a dead
`UnloadContent()` method (no callers; everything it did is re-established by
`LoadExplosions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)