### PR TITLE
jupiter-1.60/fixes_22: combat, fleet, memory & crash-robustness fixes

### DIFF
--- a/Ship_Game/AI/CombatTactics/Artillery.cs
+++ b/Ship_Game/AI/CombatTactics/Artillery.cs
@@ -17,6 +17,11 @@ namespace Ship_Game.AI.CombatTactics
         {
         }
 
+        // Artillery holds a fixed facing to the target and reverse-thrusts to keep range; the
+        // anti-chase Disengage (turn-and-burn) would thrash against that face-the-target logic
+        // and drive the ship forward into the enemy. So Artillery never disengages.
+        protected override bool AllowDisengage => false;
+
         protected override void OverrideCombatValues(FixedSimTime timeStep)
         {
             Ship target = OwnerTarget;
@@ -49,14 +54,29 @@ namespace Ship_Game.AI.CombatTactics
                 // maybe (Owner.Velocity - Target.Velocity).Length * 2.0f; to make it adaptable to ship speeds.
                 const float interceptBuffer = 1500f;
 
-                if (DistanceToTarget > maxDistance + interceptBuffer) 
+                // Start decelerating EARLY so we coast to a stop AT the standoff range instead of
+                // carrying our full approach momentum straight through it to point-blank (the
+                // artillery "overshoot" that makes long-range ships fight up close). Once the
+                // standoff range is within our reverse-thrust stopping distance (plus a 1.2 margin),
+                // start reverse-thrusting now while staying faced on the target so we can keep firing.
+                // Driving the thrust directly avoids the late-braking we'd get from
+                // SubLightMoveTowardsPosition, which skips its speed cap on any frame it's rotating.
+                float distToStandoff = DistanceToTarget - maxDistance;
+                float brakingDistance = Owner.GetMinDecelerationDistance(Owner.CurrentVelocity) * 1.2f;
+
+                if (distToStandoff <= brakingDistance)
+                {
+                    AI.RotateTowardsPosition(Owner.PredictImpact(target), timeStep, 0.05f);
+                    Owner.SubLightAccelerate(stlSpeedLimit: 0f, Thrust.Reverse);
+                    return CombatMoveState.Approach;
+                }
+
+                if (DistanceToTarget > maxDistance + interceptBuffer)
                 {
                     // This move will keep the ship aligned with the intercept point (for fastest closing of distance).
-                    // You won't notice when charging head to head / chasing directly behind, but there are cases 
-                    // where this is quite bad for weapons alignment. That is the reason for the buffer.                    
                     AI.SubLightMoveTowardsPosition(target.Position, timeStep);
                 }
-                else 
+                else
                 {
                     // spend the last bit of the firing gap on a shot impact course, for optimal alignment.
                     AI.SubLightMoveTowardsPosition(Owner.PredictImpact(target), timeStep);

--- a/Ship_Game/AI/GravityWellRouter.cs
+++ b/Ship_Game/AI/GravityWellRouter.cs
@@ -464,12 +464,19 @@ public static class GravityWellRouter
     // coverage are handled correctly:
     //   - own planets:   never block (no self-inhibit)
     //   - enemy planets: ALWAYS block (inhibits even inside friendly projector range)
-    //   - neutral/ally:  blocks unless the well itself sits inside our projector coverage
+    //   - star (system center) NOT in our influence: the whole system is hostile transit
+    //     space. A ship crossing it won't be in friendly projector range, so EVERY well
+    //     inhibits — a single planet that merely clips the fringe of our influence must not
+    //     exempt itself (the Romandal case: one planet sat partly in our influence while the
+    //     system did not, so the router waved the scout straight through the well).
+    //   - star in our influence: friendly system — block only wells outside our coverage.
     static bool IsBlockingFor(Planet p, Ship ship)
     {
         Empire owner = p.Owner;
         if (owner == ship.Loyalty) return false;
         if (owner != null && owner.WillInhibit(ship.Loyalty)) return true;
+        if (!ship.Universe.Influence.IsInInfluenceOf(ship.Loyalty, p.ParentSystem.Position))
+            return true;
         return !ship.Universe.Influence.IsInInfluenceOf(ship.Loyalty, p.Position);
     }
 

--- a/Ship_Game/AI/ShipMovement/CombatManeuvers/CombatMovement.cs
+++ b/Ship_Game/AI/ShipMovement/CombatManeuvers/CombatMovement.cs
@@ -75,6 +75,15 @@ namespace Ship_Game.AI.ShipMovement.CombatManeuvers
 
         protected ChaseState ChaseStates;
 
+        /// <summary>
+        /// Whether this stance uses the anti-chase Disengage maneuver (turn-and-burn sideways).
+        /// Stances that hold a fixed facing to the target while reverse-thrusting (Artillery)
+        /// must NOT disengage: the per-frame attack/disengage thrash leaves the ship pointed at
+        /// the target while the disengage applies FORWARD thrust, driving it straight into the
+        /// enemy. Such stances override this to false and simply approach/hold/retrograde.
+        /// </summary>
+        protected virtual bool AllowDisengage => true;
+
         protected CombatMovement(ShipAI ai) : base(ai)
         {
             DesiredCombatRange = ai.Owner.DesiredCombatRange;
@@ -98,20 +107,20 @@ namespace Ship_Game.AI.ShipMovement.CombatManeuvers
         /// </summary>
         public override void Execute(FixedSimTime timeStep, ShipAI.ShipGoal goal)
         {
-            // Bail on invalid combat situations. 
-            if (Owner.IsPlatformOrStation || OwnerTarget == null || (Owner.AI.HasPriorityOrder && !Owner.AI.HasPriorityTarget) 
-                || Owner.engineState == Ship.MoveState.Warp) 
+            // Bail on invalid combat situations.
+            if (Owner.IsPlatformOrStation || OwnerTarget == null || (Owner.AI.HasPriorityOrder && !Owner.AI.HasPriorityTarget)
+                || Owner.engineState == Ship.MoveState.Warp)
                 return;
 
             Initialize(DesiredCombatRange);
             OverrideCombatValues(timeStep);
 
-            if (MoveState != CombatMoveState.Disengage && ShouldDisengage())
+            if (AllowDisengage && MoveState != CombatMoveState.Disengage && ShouldDisengage())
             {
                 DisengageType = RandomDisengageType(DirectionToTarget);
                 ExecuteAntiChaseDisengage(timeStep);
             }
-            else if (DisengageType != DisengageTypes.None)
+            else if (AllowDisengage && DisengageType != DisengageTypes.None)
             {
                 ExecuteAntiChaseDisengage(timeStep);
             }

--- a/Ship_Game/Audio/GameAudio.cs
+++ b/Ship_Game/Audio/GameAudio.cs
@@ -41,7 +41,9 @@ public static class GameAudio
     }
 
     static Array<AsyncSfx> AsyncSfxQueue;
-    static Thread SfxThread;
+    // volatile: cross-thread stop signal. Destroy() writes null on the main thread; the
+    // SfxEnqueueThread worker reads it each poll and exits when it sees null.
+    static volatile Thread SfxThread;
 
     public static AudioDevices Devices;
 
@@ -111,7 +113,14 @@ public static class GameAudio
     public static void Destroy()
     {
         AudioEngineGood = false;
+
+        // Stop and join the SFX consumer BEFORE disposing the fields it reads (Config/AudioEngine),
+        // so it can't deref torn-down audio state mid-batch. It breaks on SfxThread==null at its
+        // next poll and its body is non-blocking, so this returns well within the timeout.
+        Thread sfxThread = SfxThread;
         SfxThread = null;
+        sfxThread?.Join(1000);
+
         if (AsyncSfxQueue != null)
         {
             lock (SfxQueueLock)
@@ -290,10 +299,13 @@ public static class GameAudio
                 AsyncSfxQueue.Clear();
             }
 
+            AudioConfig config = Config;
+            if (config == null)
+                continue; // audio torn down (re-init); drop this batch
             for (int i = 0; i < items.Length; ++i)
             {
                 ref AsyncSfx sfx = ref items[i];
-                SoundEffect effect = Config.GetSoundEffect(sfx.EffectId);
+                SoundEffect effect = config.GetSoundEffect(sfx.EffectId);
                 IAudioInstance instance = PlayEffect(effect, sfx.Emitter);
                 if (instance != null)
                 {
@@ -324,7 +336,10 @@ public static class GameAudio
             Log.Warning($"Could not find SFX file: {sfxFile} for SoundEffect: {effect.Id}");
             return null;
         }
-        return AudioEngine.Play(effect.Category, emitter, file.FullName, volume);
+        NAudioPlaybackEngine engine = AudioEngine;
+        if (engine == null)
+            return null; // engine torn down concurrently (re-init)
+        return engine.Play(effect.Category, emitter, file.FullName, volume);
     }
 
     static IAudioInstance PlayFromFile(AudioCategory category, string audioFile)

--- a/Ship_Game/Audio/GameAudio.cs
+++ b/Ship_Game/Audio/GameAudio.cs
@@ -110,6 +110,7 @@ public static class GameAudio
     // called from GameBase.Dispose()
     public static void Destroy()
     {
+        AudioEngineGood = false;
         SfxThread = null;
         if (AsyncSfxQueue != null)
         {
@@ -275,12 +276,16 @@ public static class GameAudio
             Thread.Sleep(1); // suspend for 1-15ms
             if (SfxThread == null)
                 break;
-            if (AsyncSfxQueue.IsEmpty)
+            // Snapshot: Destroy()/Initialize() can null the queue concurrently during a re-init.
+            Array<AsyncSfx> queue = AsyncSfxQueue;
+            if (queue == null || queue.IsEmpty)
                 continue;
 
             AsyncSfx[] items;
             lock (SfxQueueLock)
             {
+                if (AsyncSfxQueue == null) // re-check under the lock
+                    continue;
                 items = AsyncSfxQueue.ToArray();
                 AsyncSfxQueue.Clear();
             }
@@ -344,7 +349,9 @@ public static class GameAudio
             return;
         lock (SfxQueueLock)
         {
-            AsyncSfxQueue.Add(new()
+            // Null-safe under the lock: Destroy()/Initialize() can null the queue concurrently
+            // (under this same lock) during an audio re-init; dropping the SFX is correct then.
+            AsyncSfxQueue?.Add(new()
             {
                 EffectId = effectId,
                 Emitter = emitter,
@@ -356,7 +363,8 @@ public static class GameAudio
     {
         lock (SfxQueueLock)
         {
-            AsyncSfxQueue.Add(new()
+            // See note above: queue may be nulled mid re-init under this same lock.
+            AsyncSfxQueue?.Add(new()
             {
                 EffectId = effectId,
                 Emitter = emitter,

--- a/Ship_Game/Espionage/Espionage.cs
+++ b/Ship_Game/Espionage/Espionage.cs
@@ -322,6 +322,9 @@ namespace Ship_Game
             return $"{theirInfiltrationLevel}";
         }
 
+        // Raw add: callers must guarantee the op isn't already active. UI checkboxes can't
+        // (sim turns change Operations under the open screen), so they go through
+        // ActivateOpsIfAble instead; reaching the duplicate here means a real logic error.
         public void AddOperation(InfiltrationOpsType type)
         {
             if (Operations.Any(m => m.Type == type))

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -145,6 +145,10 @@ namespace Ship_Game.Fleets
             ship.AI.FleetNode = node;
             ship.FleetOffset = node.RelativeFleetOffset;
             ship.RelativeFleetOffset = node.RelativeFleetOffset;
+            // A reinforcement that spawns away from the fleet body is "catching up":
+            // exclude it from the fleet's assembly throttling until it reaches formation,
+            // so it doesn't slow the established fleet down (see UpdateSpeedLimit/Update).
+            ship.CatchingUpToFleet = !IsShipInFormation(ship, 30_000);
             if (Ships.Count == 1 && HasPatrolPlan)
                 ExecutePatrol(Patrol);
 
@@ -2507,6 +2511,7 @@ namespace Ship_Game.Fleets
             if (ship.Fleet == this)
             {
                 ship.Fleet = null;
+                ship.CatchingUpToFleet = false; // don't carry catch-up state into the next fleet
                 if (ship.Active) // if ship is not dead, it means it's being transferred
                 {
                     if (clearOrders)
@@ -2672,7 +2677,16 @@ namespace Ship_Game.Fleets
             if (Ships.Count == 0)
                 return;
 
-            bool readyForWarp = true;
+            // Surface-weighted warp readiness: the fleet warps once nearly all of the
+            // established body is ready, instead of waiting for every last ship. This
+            // stops a small number of out-of-position ships from holding the whole
+            // fleet out of warp - they catch up on their own. Catching-up reinforcements
+            // are excluded entirely (tracked separately as a fallback for the degenerate
+            // case where the whole fleet is still assembling).
+            int totalWarpSurface = 0;
+            int readyWarpSurface = 0;
+            int totalWarpSurfaceAll = 0;
+            int readyWarpSurfaceAll = 0;
             Ship commandShip = null;
             var fleetTotals = new ShipAI.TargetParameterTotals();
 
@@ -2712,13 +2726,34 @@ namespace Ship_Game.Fleets
 
                 UpdateOurFleetShip(ship);
 
-                readyForWarp = readyForWarp && ship.ShipEngines.ReadyForFormationWarp == WarpStatus.ReadyToWarp;
+                // a reinforcement stops "catching up" once it reaches its formation slot
+                if (ship.CatchingUpToFleet && IsShipInFormation(ship, 30_000))
+                    ship.CatchingUpToFleet = false;
+
+                bool readyToWarp = ship.ShipEngines.ReadyForFormationWarp == WarpStatus.ReadyToWarp;
+                totalWarpSurfaceAll += ship.SurfaceArea;
+                if (readyToWarp)
+                    readyWarpSurfaceAll += ship.SurfaceArea;
+                if (!ship.CatchingUpToFleet)
+                {
+                    totalWarpSurface += ship.SurfaceArea;
+                    if (readyToWarp)
+                        readyWarpSurface += ship.SurfaceArea;
+                }
             }
 
             if (commandShip != null)
                 SetCommandShip(commandShip);
 
-            ReadyForWarp = readyForWarp;
+            // if the whole fleet is still catching up (e.g. freshly built), fall back to all ships
+            if (totalWarpSurface == 0)
+            {
+                totalWarpSurface = totalWarpSurfaceAll;
+                readyWarpSurface = readyWarpSurfaceAll;
+            }
+
+            ReadyForWarp = totalWarpSurface > 0
+                           && readyWarpSurface >= totalWarpSurface * WarpReadySurfaceRatio;
             TotalFleetAttributes = fleetTotals;
             AverageFleetAttributes = TotalFleetAttributes.GetAveragedValues();
         }

--- a/Ship_Game/GameScreens/CombatScreen/CombatScreen.cs
+++ b/Ship_Game/GameScreens/CombatScreen/CombatScreen.cs
@@ -500,7 +500,8 @@ namespace Ship_Game
 
         bool TryGetNumBombersCanBomb(out Ship[] bombersList)
         {
-            bombersList = P.System.ShipList.Filter(s => s.Loyalty == Player
+            bombersList = P.System.ShipList.Filter(s => s != null
+                                                         && s.Loyalty == Player
                                                          && s.BombBays.Count > 0
                                                          && s.Position.InRadius(P.Position, P.Radius + 15000f));
 

--- a/Ship_Game/GameScreens/Infiltration/InfiltrationOpsLevel2.cs
+++ b/Ship_Game/GameScreens/Infiltration/InfiltrationOpsLevel2.cs
@@ -83,7 +83,7 @@ namespace Ship_Game.GameScreens.EspionageNew
         void PlantMole(UICheckBox b)
         {
             if (PlantingMole)
-                Espionage.AddOperation(InfiltrationOpsType.PlantMole);
+                Espionage.ActivateOpsIfAble(InfiltrationOpsType.PlantMole);
             else
                 Espionage.RemoveOperation(InfiltrationOpsType.PlantMole);
 

--- a/Ship_Game/GameScreens/Infiltration/InfiltrationOpsLevel3.cs
+++ b/Ship_Game/GameScreens/Infiltration/InfiltrationOpsLevel3.cs
@@ -95,7 +95,7 @@ namespace Ship_Game.GameScreens.EspionageNew
         void ArrangeUprise(UICheckBox b)
         {
             if (Uprising)
-                Espionage.AddOperation(InfiltrationOpsType.Uprise);
+                Espionage.ActivateOpsIfAble(InfiltrationOpsType.Uprise);
             else
                 Espionage.RemoveOperation(InfiltrationOpsType.Uprise);
         }
@@ -103,7 +103,7 @@ namespace Ship_Game.GameScreens.EspionageNew
         void CounterEspionage(UICheckBox b)
         {
             if (CounteringEspionage)
-                Espionage.AddOperation(InfiltrationOpsType.CounterEspionage);
+                Espionage.ActivateOpsIfAble(InfiltrationOpsType.CounterEspionage);
             else
                 Espionage.RemoveOperation(InfiltrationOpsType.CounterEspionage);
 

--- a/Ship_Game/GameScreens/Infiltration/InfiltrationOpsLevel4.cs
+++ b/Ship_Game/GameScreens/Infiltration/InfiltrationOpsLevel4.cs
@@ -94,7 +94,7 @@ namespace Ship_Game.GameScreens.EspionageNew
         void Sabotage(UICheckBox b)
         {
             if (Sabotaging)
-                Espionage.AddOperation(InfiltrationOpsType.Sabotage);
+                Espionage.ActivateOpsIfAble(InfiltrationOpsType.Sabotage);
             else
                 Espionage.RemoveOperation(InfiltrationOpsType.Sabotage);
         }
@@ -102,7 +102,7 @@ namespace Ship_Game.GameScreens.EspionageNew
         void SlowResearch(UICheckBox b)
         {
             if (SlowingResearch)
-                Espionage.AddOperation(InfiltrationOpsType.SlowResearch);
+                Espionage.ActivateOpsIfAble(InfiltrationOpsType.SlowResearch);
             else
                 Espionage.RemoveOperation(InfiltrationOpsType.SlowResearch);
 

--- a/Ship_Game/GameScreens/Infiltration/InfiltrationOpsLevel5.cs
+++ b/Ship_Game/GameScreens/Infiltration/InfiltrationOpsLevel5.cs
@@ -101,7 +101,7 @@ namespace Ship_Game.GameScreens.EspionageNew
         void Rebellion(UICheckBox b)
         {
             if (IncitingRebellion)
-                Espionage.AddOperation(InfiltrationOpsType.Rebellion);
+                Espionage.ActivateOpsIfAble(InfiltrationOpsType.Rebellion);
             else
                 Espionage.RemoveOperation(InfiltrationOpsType.Rebellion);
         }
@@ -109,7 +109,7 @@ namespace Ship_Game.GameScreens.EspionageNew
         void StealTech(UICheckBox b)
         {
             if (DistuptingProjection)
-                Espionage.AddOperation(InfiltrationOpsType.DisruptProjection);
+                Espionage.ActivateOpsIfAble(InfiltrationOpsType.DisruptProjection);
             else
                 Espionage.RemoveOperation(InfiltrationOpsType.DisruptProjection);
 

--- a/Ship_Game/GameScreens/Universe/GamePlayMenuScreen.cs
+++ b/Ship_Game/GameScreens/Universe/GamePlayMenuScreen.cs
@@ -5,6 +5,7 @@ using SDGraphics;
 using SDGraphics.Input;
 using Ship_Game.Audio;
 using Ship_Game.GameScreens.MainMenu;
+using Ship_Game.Graphics;
 using Vector2 = SDGraphics.Vector2;
 
 namespace Ship_Game;
@@ -135,15 +136,23 @@ public sealed class GamePlayMenuScreen : GameScreen
     {
         if (DisallowActions()) return;
 
-        // Route through GameLoadingScreen with resetResources:true. This is the
-        // same path the mod-switch flow uses (ModManager.cs:169): it tears down
-        // the in-game graphics state via the safely-sequenced UnloadAllData →
-        // UnloadGraphicsResources, then re-runs the boot LoadContent sequence
-        // so MainMenu finds ResourceManager.Blank, Beam.BeamEffect, the Textures
-        // index, etc. populated. Direct GoToScreen(MainMenu, true) leaves the
-        // in-game content cache pinned and OOM'd on memory-tight machines when
-        // MainMenu's atlas DXT5 decompress allocated on top of it.
-        ScreenManager.GoToScreen(new GameLoadingScreen(showSplash:false, resetResources:true), clear3DObjects:true);
+        // Leaving a game to MainMenu: the in-game content cache (RootContent +
+        // ResourceManager.Textures, including decompressed DXT5 atlases in both RAM and
+        // VRAM) stays pinned, and MainMenu's own atlas decompress allocates on top of it.
+        // On memory-tight machines running Combined Arms that OOM'd inside
+        // DxtReader.DecompressDXT5 even with a healthy managed heap (OS-level pressure).
+        //
+        // If both system RAM and VRAM have comfortable headroom right now, keep the cache:
+        // fast exit, and a same-content new game reuses it. Otherwise free it first by
+        // routing through GameLoadingScreen(resetResources:true) - the same safely-sequenced
+        // UnloadAllData → UnloadGraphicsResources → boot LoadContent the mod-switch flow uses
+        // (so MainMenu finds ResourceManager.Blank, Beam.BeamEffect, the Textures index, etc.
+        // repopulated). The two are coupled: the fast path is only valid because we keep that
+        // boot content loaded.
+        if (MemoryPressure.HasHeadroomToKeepContent(Device))
+            ScreenManager.GoToScreen(new MainMenuScreen(), clear3DObjects:true);
+        else
+            ScreenManager.GoToScreen(new GameLoadingScreen(showSplash:false, resetResources:true), clear3DObjects:true);
     }
 
     void Exit_OnClick(UIButton button)

--- a/Ship_Game/Gameplay/Projectile.cs
+++ b/Ship_Game/Gameplay/Projectile.cs
@@ -989,10 +989,13 @@ namespace Ship_Game.Gameplay
         // otherwise just explode and die
         void ArmorPiercingTouch(ShipModule victim, Ship parent, Vector2 hitPos)
         {
-            // for visual consistency we want to show Projectile at hitPos
-            // if the radius is big - adjust the pos accordingly, since if the explosion radius is smaller than
-            // the projectile radius,  it will explode with no affect
-            Position = Radius <= 8 ? hitPos : hitPos + hitPos.DirectionToTarget(victim.Position)*Radius;
+            // Anchor the detonation/visual to the module we actually struck. Using hitPos here is
+            // unreliable: for fast projectiles the narrow-phase ray-cast reports hitPos a full
+            // frame back (outside the hull), and shifting it inward by the projectile radius pushed
+            // the blast PAST the armor onto an internal module (the armor-bypass bug). The struck
+            // module's own position always sits on the armor, and the directional explosion handles
+            // penetration from there.
+            Position = Radius <= 8 ? hitPos : victim.Position;
             Universe.DebugWin?.DrawGameObject(DebugModes.Targeting, this, Color.LightCyan, lifeTime:0.25f);
 
             if (!TryPhaseThroughModule(victim) && Damage(victim))

--- a/Ship_Game/Graphics/MemoryPressure.cs
+++ b/Ship_Game/Graphics/MemoryPressure.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Reflection;
+using Microsoft.Xna.Framework.Graphics;
+using SharpDX.DXGI;
+using D3D11Device = SharpDX.Direct3D11.Device;
+using DxgiDevice = SharpDX.DXGI.Device;
+
+namespace Ship_Game.Graphics;
+
+/// <summary>
+/// Best-effort live memory-pressure probes used to decide whether an expensive
+/// content unload/reload is worth doing (e.g. when leaving a game to the main menu).
+/// Every probe is conservative: if it cannot positively confirm there is headroom it
+/// reports "no headroom" / "under pressure", so the caller takes the safe path.
+/// </summary>
+public static class MemoryPressure
+{
+    /// <summary>
+    /// Fraction of the system-RAM / VRAM budget below which the resource is considered
+    /// to have comfortable headroom. We keep the in-game content cache resident (and let
+    /// the next screen allocate on top of it) only when BOTH are below this.
+    /// </summary>
+    public const float HealthyHeadroomRatio = 0.75f;
+
+    /// <summary>
+    /// TRUE only when we are confident BOTH system RAM and VRAM have enough headroom that
+    /// keeping the in-game content cache resident will not risk an out-of-memory. Returns
+    /// FALSE (= please free memory first) whenever either resource is tight OR a probe
+    /// could not be evaluated on this machine/runtime.
+    /// </summary>
+    public static bool HasHeadroomToKeepContent(GraphicsDevice device)
+    {
+        bool ramOk  = TryGetSystemRamLoad(out float ramLoad)     && ramLoad  < HealthyHeadroomRatio;
+        bool vramOk = TryGetVramLoad(device, out float vramLoad) && vramLoad < HealthyHeadroomRatio;
+        bool keep = ramOk && vramOk;
+        Log.Info($"ExitToMain memory check: RAM={ramLoad:P0} (ok={ramOk}) VRAM={vramLoad:P0} (ok={vramOk}) "
+                 + $"=> {(keep ? "keep cache (fast exit)" : "free cache (safe exit)")}");
+        return keep;
+    }
+
+    /// <summary>
+    /// System-wide physical memory load as a fraction of the GC's high-memory-load
+    /// threshold - the point past which the GC stops growing the heap and large
+    /// allocations start throwing OOM even when the managed heap itself is healthy.
+    /// </summary>
+    public static bool TryGetSystemRamLoad(out float load)
+    {
+        load = 1f; // assume worst case until proven otherwise
+        try
+        {
+            GCMemoryInfo info = GC.GetGCMemoryInfo();
+            long threshold = info.HighMemoryLoadThresholdBytes;
+            if (threshold <= 0)
+                return false;
+            load = (float)((double)info.MemoryLoadBytes / threshold);
+            return true;
+        }
+        catch
+        {
+            return false; // GCMemoryInfo unsupported on this runtime
+        }
+    }
+
+    /// <summary>
+    /// This process's local VRAM usage as a fraction of its DXGI budget. Reflectively
+    /// pulls the MonoGame WindowsDX backend's SharpDX D3D11 device (the same field the
+    /// device-removed diagnostic uses) and queries IDXGIAdapter3::QueryVideoMemoryInfo.
+    /// </summary>
+    public static bool TryGetVramLoad(GraphicsDevice device, out float load)
+    {
+        load = 1f; // assume worst case until proven otherwise
+        if (device == null)
+            return false;
+        try
+        {
+            FieldInfo fld = typeof(GraphicsDevice).GetField("_d3dDevice",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            if (fld?.GetValue(device) is not D3D11Device d3d)
+                return false;
+
+            // Each QueryInterface / Adapter hands back a separately ref-counted COM wrapper;
+            // disposing them releases only that extra ref, never the live D3D11 device.
+            using DxgiDevice dxgiDevice = d3d.QueryInterface<DxgiDevice>();
+            using Adapter adapter = dxgiDevice.Adapter;
+            using Adapter3 adapter3 = adapter.QueryInterface<Adapter3>();
+            QueryVideoMemoryInformation mem = adapter3.QueryVideoMemoryInfo(0, MemorySegmentGroup.Local);
+            if (mem.Budget <= 0)
+                return false;
+            load = (float)((double)mem.CurrentUsage / mem.Budget);
+            return true;
+        }
+        catch
+        {
+            return false; // pre-DXGI-1.4 GPU/driver, or the MonoGame field shape changed
+        }
+    }
+}

--- a/Ship_Game/Graphics/MemoryPressure.cs
+++ b/Ship_Game/Graphics/MemoryPressure.cs
@@ -11,64 +11,80 @@ namespace Ship_Game.Graphics;
 /// Best-effort live memory-pressure probes used to decide whether an expensive
 /// content unload/reload is worth doing (e.g. when leaving a game to the main menu).
 /// Every probe is conservative: if it cannot positively confirm there is headroom it
-/// reports "no headroom" / "under pressure", so the caller takes the safe path.
+/// reports zero headroom, so the caller takes the safe path.
 /// </summary>
 public static class MemoryPressure
 {
     /// <summary>
-    /// Fraction of the system-RAM / VRAM budget below which the resource is considered
-    /// to have comfortable headroom. We keep the in-game content cache resident (and let
-    /// the next screen allocate on top of it) only when BOTH are below this.
+    /// Free system RAM (MB) that must remain below the GC's high-memory-load threshold to
+    /// keep the in-game content cache resident. This is absolute headroom, NOT a percentage:
+    /// 79% load on a 32 GB machine still leaves gigabytes free, while the same percentage on
+    /// a 6 GB machine is dangerous. The margin must cover MainMenu's worst-case atlas
+    /// decompress (a Combined Arms DXT5 atlas expands ~4x into a transient buffer) plus slack.
     /// </summary>
-    public const float HealthyHeadroomRatio = 0.75f;
+    public const double MinSystemRamHeadroomMB = 2048;
+
+    /// <summary>Free VRAM budget (MB) required to keep the cache - covers MainMenu's atlas upload.</summary>
+    public const double MinVramHeadroomMB = 1024;
+
+    const double MB = 1024.0 * 1024.0;
 
     /// <summary>
-    /// TRUE only when we are confident BOTH system RAM and VRAM have enough headroom that
-    /// keeping the in-game content cache resident will not risk an out-of-memory. Returns
-    /// FALSE (= please free memory first) whenever either resource is tight OR a probe
-    /// could not be evaluated on this machine/runtime.
+    /// TRUE only when we are confident BOTH system RAM and VRAM have enough absolute headroom
+    /// that keeping the in-game content cache resident will not risk an out-of-memory. Returns
+    /// FALSE (= please free memory first) whenever either resource is tight OR a probe could
+    /// not be evaluated on this machine/runtime.
     /// </summary>
     public static bool HasHeadroomToKeepContent(GraphicsDevice device)
     {
-        bool ramOk  = TryGetSystemRamLoad(out float ramLoad)     && ramLoad  < HealthyHeadroomRatio;
-        bool vramOk = TryGetVramLoad(device, out float vramLoad) && vramLoad < HealthyHeadroomRatio;
+        Log.Info("ExitToMain memory check:");
+        bool ramOk  = TryGetSystemRamHeadroomMB(out double ramFreeMB)      && ramFreeMB  >= MinSystemRamHeadroomMB;
+        bool vramOk = TryGetVramHeadroomMB(device, out double vramFreeMB)  && vramFreeMB >= MinVramHeadroomMB;
         bool keep = ramOk && vramOk;
-        Log.Info($"ExitToMain memory check: RAM={ramLoad:P0} (ok={ramOk}) VRAM={vramLoad:P0} (ok={vramOk}) "
-                 + $"=> {(keep ? "keep cache (fast exit)" : "free cache (safe exit)")}");
+        Log.Info($"  decision: RAM free={ramFreeMB:0}MB (need {MinSystemRamHeadroomMB:0}, ok={ramOk}) "
+                 + $"VRAM free={vramFreeMB:0}MB (need {MinVramHeadroomMB:0}, ok={vramOk}) "
+                 + $"=> {(keep ? "KEEP cache (fast exit)" : "FREE cache (safe exit)")}");
         return keep;
     }
 
     /// <summary>
-    /// System-wide physical memory load as a fraction of the GC's high-memory-load
-    /// threshold - the point past which the GC stops growing the heap and large
-    /// allocations start throwing OOM even when the managed heap itself is healthy.
+    /// Free system RAM (MB) below the GC's high-memory-load threshold - the point past which
+    /// the GC stops growing the heap and large allocations start throwing OOM even when the
+    /// managed heap itself is healthy. Negative if already over the threshold.
     /// </summary>
-    public static bool TryGetSystemRamLoad(out float load)
+    public static bool TryGetSystemRamHeadroomMB(out double headroomMB)
     {
-        load = 1f; // assume worst case until proven otherwise
+        headroomMB = 0; // assume worst case until proven otherwise
         try
         {
             GCMemoryInfo info = GC.GetGCMemoryInfo();
             long threshold = info.HighMemoryLoadThresholdBytes;
             if (threshold <= 0)
+            {
+                Log.Warning("  RAM probe: HighMemoryLoadThresholdBytes <= 0");
                 return false;
-            load = (float)((double)info.MemoryLoadBytes / threshold);
+            }
+            headroomMB = (threshold - info.MemoryLoadBytes) / MB;
+            Log.Info($"  RAM: load={info.MemoryLoadBytes / MB:0}MB / threshold={threshold / MB:0}MB "
+                     + $"(total={info.TotalAvailableMemoryBytes / MB:0}MB, managed heap={info.HeapSizeBytes / MB:0}MB) "
+                     + $"=> free={headroomMB:0}MB");
             return true;
         }
-        catch
+        catch (Exception ex)
         {
+            Log.Warning($"  RAM probe failed: {ex.GetType().Name}: {ex.Message}");
             return false; // GCMemoryInfo unsupported on this runtime
         }
     }
 
     /// <summary>
-    /// This process's local VRAM usage as a fraction of its DXGI budget. Reflectively
-    /// pulls the MonoGame WindowsDX backend's SharpDX D3D11 device (the same field the
-    /// device-removed diagnostic uses) and queries IDXGIAdapter3::QueryVideoMemoryInfo.
+    /// Free local VRAM (MB) below this process's DXGI budget. Reflectively pulls the MonoGame
+    /// WindowsDX backend's SharpDX D3D11 device (the same field the device-removed diagnostic
+    /// uses) and queries IDXGIAdapter3::QueryVideoMemoryInfo. Negative if already over budget.
     /// </summary>
-    public static bool TryGetVramLoad(GraphicsDevice device, out float load)
+    public static bool TryGetVramHeadroomMB(GraphicsDevice device, out double headroomMB)
     {
-        load = 1f; // assume worst case until proven otherwise
+        headroomMB = 0; // assume worst case until proven otherwise
         if (device == null)
             return false;
         try
@@ -76,7 +92,10 @@ public static class MemoryPressure
             FieldInfo fld = typeof(GraphicsDevice).GetField("_d3dDevice",
                 BindingFlags.Instance | BindingFlags.NonPublic);
             if (fld?.GetValue(device) is not D3D11Device d3d)
+            {
+                Log.Warning("  VRAM probe: MonoGame _d3dDevice field not found / not a SharpDX device");
                 return false;
+            }
 
             // Each QueryInterface / Adapter hands back a separately ref-counted COM wrapper;
             // disposing them releases only that extra ref, never the live D3D11 device.
@@ -85,12 +104,17 @@ public static class MemoryPressure
             using Adapter3 adapter3 = adapter.QueryInterface<Adapter3>();
             QueryVideoMemoryInformation mem = adapter3.QueryVideoMemoryInfo(0, MemorySegmentGroup.Local);
             if (mem.Budget <= 0)
+            {
+                Log.Warning("  VRAM probe: DXGI reported Budget <= 0");
                 return false;
-            load = (float)((double)mem.CurrentUsage / mem.Budget);
+            }
+            headroomMB = (mem.Budget - mem.CurrentUsage) / MB;
+            Log.Info($"  VRAM: usage={mem.CurrentUsage / MB:0}MB / budget={mem.Budget / MB:0}MB => free={headroomMB:0}MB");
             return true;
         }
-        catch
+        catch (Exception ex)
         {
+            Log.Warning($"  VRAM probe failed: {ex.GetType().Name}: {ex.Message}");
             return false; // pre-DXGI-1.4 GPU/driver, or the MonoGame field shape changed
         }
     }

--- a/Ship_Game/ShipGroup.cs
+++ b/Ship_Game/ShipGroup.cs
@@ -514,6 +514,21 @@ namespace Ship_Game
             }
         }
 
+        /// <summary>
+        /// When at least this fraction of a fleet's surface area is assembled in
+        /// formation, the fleet is treated as a coherent body: it travels at full
+        /// speed without waiting for the out-of-position minority (e.g. distant
+        /// reinforcements), which catch up on their own.
+        /// </summary>
+        public const float MajorityAssembledSurfaceRatio = 0.85f;
+
+        /// <summary>
+        /// Warp readiness uses a stricter threshold than movement: we don't want to
+        /// warp off and strand the last few ships (e.g. a carrier still recalling its
+        /// fighters), so nearly the whole established body must be warp-ready first.
+        /// </summary>
+        public const float WarpReadySurfaceRatio = 0.95f;
+
         [Flags]
         public enum MoveStatus
         {
@@ -574,7 +589,7 @@ namespace Ship_Game
                     moveStatus |= MoveStatus.Dispersed;
             }
 
-            if (totalShipSurface > 0 && surfaceAssembled / totalShipSurface > 0.85f)
+            if (totalShipSurface > 0 && surfaceAssembled / totalShipSurface > MajorityAssembledSurfaceRatio)
                 moveStatus |= MoveStatus.MajorityAssembled;
 
             return moveStatus;
@@ -689,21 +704,27 @@ namespace Ship_Game
             if (Ships.Count == 0)
                 return;
 
+            // First, measure how much of the fleet (by surface area) is actually
+            // assembled in formation. If the in-formation body is the overwhelming
+            // majority, we let it travel at full speed and let the out-of-position
+            // minority (e.g. a distant reinforcement) catch up on its own, rather
+            // than throttling the whole fleet down to wait for a handful of ships.
+            int totalSurface = 0;
+            int inFormationSurface = 0;
             // some ships are staying behind, but they can still catch up
             bool gotCapableStragglers = false;
-            float speedCapSTL = 0f; // important that the default values are 0 (uncapped)
-            float speedCapFTL = 0f;
-
             for (int i = 0; i < Ships.Count; ++i)
             {
                 Ship ship = Ships[i];
-                if (ship.CanTakeFleetMoveOrders() && !ship.InCombat)
+                // catching-up reinforcements don't count toward the assembled body
+                if (!ship.CatchingUpToFleet && ship.CanTakeFleetMoveOrders() && !ship.InCombat)
                 {
-                    // the MaxFTLSpeed is often limited by WarpPercent, because the ship direction drifts too much
-                    // from its final target position, see UpdateWarpThrust() for more details on SetWarpPercent
-                    speedCapSTL = speedCapSTL != 0f ? Math.Min(speedCapSTL, ship.MaxSTLSpeed) : ship.MaxSTLSpeed;
-                    speedCapFTL = speedCapFTL != 0f ? Math.Min(speedCapFTL, ship.MaxFTLSpeed) : ship.MaxFTLSpeed;
-                    if (!gotCapableStragglers && !IsShipInFormation(ship, 30_000))
+                    totalSurface += ship.SurfaceArea;
+                    if (IsShipInFormation(ship, 30_000))
+                    {
+                        inFormationSurface += ship.SurfaceArea;
+                    }
+                    else if (!gotCapableStragglers)
                     {
                         float angleDiff = AveragePos.AngleToTargetWithFacing(ship.Position, ship.RotationDegrees);
                         if (angleDiff > 150)
@@ -712,9 +733,32 @@ namespace Ship_Game
                 }
             }
 
-            // in order to allow ships to speed up / slow down
-            // slightly to hold formation, set the fleet speed a bit lower (if some ships are not in formation)
-            if (!gotCapableStragglers)
+            bool bodyIsMajority = totalSurface > 0
+                                  && inFormationSurface >= totalSurface * MajorityAssembledSurfaceRatio;
+
+            // Compute the formation speed cap from the constraining ships. When the
+            // body is the majority, only in-formation ships constrain it, so a slow
+            // straggler can't drag the assembled fleet's cap down to its own speed.
+            float speedCapSTL = 0f; // important that the default values are 0 (uncapped)
+            float speedCapFTL = 0f;
+            for (int i = 0; i < Ships.Count; ++i)
+            {
+                Ship ship = Ships[i];
+                if (!ship.CatchingUpToFleet && ship.CanTakeFleetMoveOrders() && !ship.InCombat
+                    && (!bodyIsMajority || IsShipInFormation(ship, 30_000)))
+                {
+                    // the MaxFTLSpeed is often limited by WarpPercent, because the ship direction drifts too much
+                    // from its final target position, see UpdateWarpThrust() for more details on SetWarpPercent
+                    speedCapSTL = speedCapSTL != 0f ? Math.Min(speedCapSTL, ship.MaxSTLSpeed) : ship.MaxSTLSpeed;
+                    speedCapFTL = speedCapFTL != 0f ? Math.Min(speedCapFTL, ship.MaxFTLSpeed) : ship.MaxFTLSpeed;
+                }
+            }
+
+            // in order to allow ships to speed up / slow down slightly to hold
+            // formation, set the fleet speed a bit lower (if some ships are not in
+            // formation). But if the body is the overwhelming majority, run at full
+            // speed - the out-of-formation minority will catch up on its own.
+            if (bodyIsMajority || !gotCapableStragglers)
             {
                 // full speed ahead
                 STLSpeedLimit = speedCapSTL;

--- a/Ship_Game/Ships/ExternalSlotGrid.cs
+++ b/Ship_Game/Ships/ExternalSlotGrid.cs
@@ -118,24 +118,28 @@ namespace Ship_Game.Ships
             if (!m.Active)
                 return false;
 
-            // if our module is 2x2, we must check all slots around us
-            // [?][?][?][?]
-            // [?][m][m][?]
-            // [?][m][m][?]
-            // [?][?][?][?]
+            // A module is external only if an ORTHOGONALLY adjacent slot (N/S/E/W) is empty or
+            // inactive. Diagonal corners are deliberately NOT counted: a module sealed on all
+            // four orthogonal sides is protected even when a corner slot is open, since a
+            // straight-line shot can't slip through a zero-width corner gap to reach a face.
+            // For a 2x2 module we only test the orthogonal edges (marked o), not the corners (·):
+            // [·][o][o][·]
+            // [o][m][m][o]
+            // [o][m][m][o]
+            // [·][o][o][·]
             int x = m.Pos.X, y = m.Pos.Y;
             int left = x - 1, right  = x + m.XSize;
             int top  = y - 1, bottom = y + m.YSize;
 
-            // check top row and bottom row simultaneously
-            for (int ix = left; ix <= right; ++ix)
+            // top edge (N) and bottom edge (S): columns directly above/below, excluding corners
+            for (int ix = x; ix < right; ++ix)
                 if (IsInactiveAt(gs, ix, top) || IsInactiveAt(gs, ix, bottom))
-                    return true; // neighboring inactive slot then we are external
+                    return true; // orthogonally-adjacent inactive slot ⇒ external
 
-            // check sides, excluding the bottom corners which were already checked
+            // left edge (W) and right edge (E): rows directly beside us, excluding corners
             for (int iy = y; iy < bottom; ++iy)
                 if (IsInactiveAt(gs, left, iy) || IsInactiveAt(gs, right, iy))
-                    return true; // neighboring inactive slot then we are external
+                    return true; // orthogonally-adjacent inactive slot ⇒ external
 
             return false;
         }

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -41,6 +41,13 @@ namespace Ship_Game.Ships
         // Unrotated fleet offset from [0,0]
         [StarData] public Vector2 RelativeFleetOffset;
 
+        // TRUE while this ship is a freshly-joined reinforcement that hasn't yet
+        // reached its fleet formation slot. While set, the ship is excluded from the
+        // fleet's "majority assembled" speed/warp throttling, so a wave of new ships
+        // joining mid-transit can't drag the established fleet down - they catch up at
+        // full speed on their own. Transient: Fleet.Update clears it once in formation.
+        public bool CatchingUpToFleet;
+
         // This is the current cluster that our ship
         // belongs to in ThreatMatrix's clusters
         [StarData] public ThreatCluster CurrentCluster;

--- a/Ship_Game/Ships/Ship_ModuleGrid.cs
+++ b/Ship_Game/Ships/Ship_ModuleGrid.cs
@@ -110,13 +110,6 @@ namespace Ship_Game.Ships
             return Grid.HitTestShieldsAt(ModuleSlotList, gridPos, hitRadius);
         }
 
-        public ShipModule HitTestShieldsLocal(Vector2 localHitPos, float hitRadius)
-        {
-            if (!Active) return null;
-            Point gridPos = Grid.GridLocalToPoint(localHitPos);
-            return Grid.HitTestShieldsAt(ModuleSlotList, gridPos, hitRadius);
-        }
-
         // Gets the strongest shield currently covering internalModule
         bool IsCoveredByShield(ShipModule internalModule, out ShipModule shield)
         {
@@ -552,108 +545,63 @@ namespace Ship_Game.Ships
                 {
                     mq.Module.DamageExplosive(damageSource, ref remainingDamage);
                 }
-            
+
                 if (mq.Type is DamageTransfer.Diagonal or DamageTransfer.Root)
                     diagonalDamage = remainingDamage;
-                
+
                 currentDistance = mq.Distance;
             }
         }
 
-        void DebugGridStep(Vector2 p, Color color)
-        {
-            Vector2 gridWorldPos = GridLocalPointToWorld(GridLocalToPoint(p)) + new Vector2(8f);
-            Universe.DebugWin?.DrawCircle(DebugModes.SpatialManager, gridWorldPos, 4f, color.Alpha(0.33f), 2.0f);
-        }
+        // Fraction of a directional blast's damage that splashes each surrounding EXTERNAL
+        // armor plate (in addition to the full-strength penetration column along the ray).
+        const float LateralSplashFraction = 0.5f;
 
-        void DebugGridStep(Vector2 a, Vector2 b, Color color, float width = 1f)
+        // A projectile struck the hull and exploded. Unlike a radial blast (DamageExplosive),
+        // a projectile carries momentum: the blast punches INWARD along the projectile's flight
+        // path, and a wide blast also splashes the surrounding external armor plates.
+        //   - Penetration: armor in the flight path absorbs up to its current health and only
+        //     the EXCESS carries to the module behind it, so internal modules stay shielded
+        //     until their covering armor is destroyed (no more armor bypass).
+        //   - Lateral splash: external armor around the impact takes falloff damage; internals
+        //     are NOT splashed here — they only ever take the penetration excess above.
+        public void DamageExplosiveDirectional(GameObject damageSource, float damageAmount,
+                                               ShipModule entry, float hitRadius, bool ignoreShields)
         {
-            Vector2 worldPosA = GridLocalPointToWorld(GridLocalToPoint(a)) + new Vector2(8f);
-            Vector2 worldPosB = GridLocalPointToWorld(GridLocalToPoint(b)) + new Vector2(8f);
-            Universe.DebugWin?.DrawLine(DebugModes.SpatialManager, worldPosA, worldPosB, width, color.Alpha(0.75f), 2.0f);
-        }
+            if (!Active || entry == null) return;
+            if (Loyalty.data.ExplosiveRadiusReduction > 0f)
+                hitRadius *= 1f - Loyalty.data.ExplosiveRadiusReduction;
 
-        // take one step in the module grid
-        ShipModule TakeOneStep(Vector2 localStart, Vector2 step)
-        {
-            Point pos = GridLocalToPoint(localStart);
-            Point end = GridLocalToPoint(localStart + step);
-            if (!Grid.LocalPointInBounds(pos) || !Grid.LocalPointInBounds(end))
-                return null; // we're walking out of bounds
+            Vector2 entryPos = entry.Position;
+            // Punch along the projectile's flight path; if velocity is unavailable, fall back to
+            // punching from the entry module toward the ship interior.
+            Vector2 dir = damageSource is Projectile p && p.Velocity.Length() > 0.001f
+                        ? p.Velocity.Normalized()
+                        : entryPos.DirectionToTarget(Position);
 
-            // @note We don't check grid at [pos], because we assume prev call checked it
-            if (pos.IsDiagonalTo(end))
+            // 1. PENETRATION along the flight path.
+            float penDamage = damageAmount;
+            foreach (ShipModule m in RayHitTestWalkModules(entryPos, dir, Radius * 2f, ignoreShields))
             {
-                // check a module at the same Y height as final point
-                // this forces us to always take an L shaped step instead of diagonal \
-                var neighbor = new Point(pos.X, end.Y);
-                //if (DebugInfoScreen.Mode == DebugModes.SpatialManager)
-                //    DebugGridStep(new Vector2(start.X, endPos.Y), Color.Yellow);
+                if (m.DamageExplosive(damageSource, ref penDamage))
+                    break; // armor column absorbed it all — internals untouched
+            }
 
-                ShipModule mb = GetModuleAt(neighbor.X, neighbor.Y);
-                if (mb != null && mb.Active)
+            // 2. LATERAL SURFACE SPLASH for wide blasts — external plates only.
+            if (hitRadius >= 16f)
+            {
+                foreach (ModuleQuadrant mq in EnumModulesQuadrants(entryPos, hitRadius, !ignoreShields))
                 {
-                    //if (DebugInfoScreen.Mode == DebugModes.SpatialManager)
-                    //    DebugGridStep(start, new Vector2(start.X, endPos.Y), Color.Cyan, 4f);
-                    return mb;
+                    ShipModule m = mq.Module;
+                    if (!m.IsExternal || m == entry)
+                        continue; // internals stay protected; entry already took the penetration hit
+
+                    float falloff = ShipModule.DamageFalloff(entryPos, m.Position, hitRadius, m.Radius);
+                    float splash = damageAmount * LateralSplashFraction * falloff;
+                    if (splash > 0f)
+                        m.DamageExplosive(damageSource, ref splash);
                 }
             }
-
-            //if (DebugInfoScreen.Mode == DebugModes.SpatialManager)
-            //    DebugGridStep(endPos, Color.LightGreen);
-
-            ShipModule mc = GetModuleAt(end.X, end.Y);
-            if (mc != null && mc.Active)
-            {
-                //if (DebugInfoScreen.Mode == DebugModes.SpatialManager)
-                //    DebugGridStep(start, endPos, Color.HotPink, 4f);
-                return mc;
-            }
-            return null;
-        }
-
-        // perform a raytrace from point a to point b, visiting all grid points between them!
-        ShipModule WalkModuleGrid(in Vector2 a, in Vector2 b, float rayRadius, bool ignoreShields)
-        {
-            Vector2 pos = a;
-
-            // sometimes we directly enter the grid and hit a module:
-            Point enter = GridLocalToPoint(pos);
-            if (!ignoreShields)
-            {
-                ShipModule se = HitTestShieldsLocal(pos, rayRadius);
-                if (se != null) return se;
-            }
-
-            ShipModule me = GetModuleAt(enter.X, enter.Y);
-            if (me != null && me.Active)
-            {
-                //if (DebugInfoScreen.Mode == DebugModes.SpatialManager)
-                //    DebugGridStep(pos - step, pos, Color.DarkGoldenrod);
-                return me;
-            }
-
-            Vector2 delta = b - a;
-            Vector2 step = delta.Normalized(16f);
-
-            int n = (int)(delta.Length() / 16f);
-            for (; n >= 0; --n, pos += step)
-            {
-                if (!ignoreShields)
-                {
-                    ShipModule s = HitTestShieldsLocal(pos, rayRadius);
-                    if (s != null) return s;
-                }
-
-                ShipModule m = TakeOneStep(pos, step);
-                if (m != null)
-                {
-                    //if (DebugInfoScreen.Mode == DebugModes.Targeting)
-                    //    Universe.DebugWin?.DrawCircle(DebugModes.SpatialManager, m.Position, 6f, Color.IndianRed.Alpha(0.5f), 3f);
-                    return m;
-                }
-            }
-            return null;
         }
 
         // GridLocal walk from localA to localB
@@ -689,6 +637,28 @@ namespace Ship_Game.Ships
                 Point p = GridLocalToPoint(pos);
                 if (p == prevPos)
                     continue;
+
+                // CONSERVATIVE DIAGONAL TRAVERSAL: half-cell sampling can step straight from a
+                // cell to its diagonal neighbor, skipping the two orthogonal cells the line clips
+                // at the shared corner. If one of those flanking cells holds a module, the line is
+                // really blocked by it - otherwise a shot squeezes through a corner gap and hits a
+                // module that is sealed on all four orthogonal sides. Visit the first solid flank so
+                // it blocks the shot. One flank is enough to seal; yielding just one also avoids
+                // re-emitting a module that spans both the corner and the destination cell.
+                if (prevPos.X != -1000 && p.X != prevPos.X && p.Y != prevPos.Y)
+                {
+                    ShipModule blocker = ActiveHullModuleAt(p.X, prevPos.Y)
+                                      ?? ActiveHullModuleAt(prevPos.X, p.Y);
+                    if (blocker != null && blocker != prevModule)
+                    {
+                        prevModule = blocker;
+                        if (Universe.DebugMode == DebugModes.Targeting)
+                            Universe.DebugWin?.DrawRect(DebugModes.Targeting, blocker.Position,
+                                                        blocker.XSize*8f+1f, Rotation, Color.Red, lifeTime:0.01f);
+                        yield return blocker;
+                    }
+                }
+
                 prevPos = p;
 
                 if (Universe.DebugMode == DebugModes.Targeting)
@@ -713,6 +683,17 @@ namespace Ship_Game.Ships
                     }
                 }
             }
+        }
+
+        // Active hull module at a single grid cell, or null. Allocation-free single lookup (avoids
+        // the yield-based GetModulesAt enumerator). Used by the conservative diagonal traversal to
+        // detect a corner-sealing module. Shields are intentionally not tested here: shield bubbles
+        // span many cells and are already caught at every sampled cell by the main walk, so the
+        // corner-seal check only needs the hull module that the half-cell sampling skipped.
+        ShipModule ActiveHullModuleAt(int gridPosX, int gridPosY)
+        {
+            ShipModule m = GetModuleAt(gridPosX, gridPosY);
+            return m != null && m.Active ? m : null;
         }
 
         // guaranteed bounds safety, clips GridLocal points [a] and [b] into the local grid

--- a/Ship_Game/Spatial/SpatialManager.cs
+++ b/Ship_Game/Spatial/SpatialManager.cs
@@ -218,7 +218,10 @@ namespace Ship_Game.Gameplay
             }
             else
             {
-                victim.GetParent().DamageExplosive(source, damage, source.Position, radius, source.IgnoresShields);
+                // A projectile directly struck a module: explode directionally so the blast
+                // penetrates along the flight path and the armor shields the internals behind it
+                // (a radial blast here would let a big round's splash bypass the hull armor).
+                victim.GetParent().DamageExplosiveDirectional(source, damage, victim, radius, source.IgnoresShields);
             }
         }
 

--- a/Ship_Game/Threading/Parallel.cs
+++ b/Ship_Game/Threading/Parallel.cs
@@ -196,7 +196,66 @@ namespace Ship_Game
                 EvtNewTask.Set();
                 Thread ??= new Thread(Run) { Name = Name };
                 if (!Thread.IsAlive)
-                    Thread.Start();
+                {
+                    try
+                    {
+                        if (Parallel.TestForceThreadStartFailure)
+                            throw new OutOfMemoryException("simulated thread-start failure (test)");
+                        Thread.Start();
+                    }
+                    catch (Exception ex) when (ex is OutOfMemoryException or ThreadStartException)
+                    {
+                        // The OS refused to create a worker thread (typically low memory).
+                        // Degrade gracefully: discard the dead thread, consume the pending
+                        // signal, and run the queued task synchronously on the calling thread,
+                        // so a transient thread-creation failure doesn't crash the whole sim.
+                        // Log only the first occurrence to avoid flooding the log under sustained
+                        // pressure - the volume is tracked by Parallel.InlineFallbackCount.
+                        Thread = null;
+                        EvtNewTask.Reset();
+                        if (Interlocked.Increment(ref Parallel.InlineFallbackCount) == 1)
+                            Log.Warning($"{Name} thread start failed ({ex.GetType().Name}); running task inline. " +
+                                        "Further occurrences suppressed; see Parallel.InlineFallbackCount");
+                        RunQueuedTaskInline();
+                    }
+                }
+            }
+        }
+        // Synchronous fallback for TriggerTaskStart when no worker thread is available.
+        // Mirrors the Run() execute/catch/clear path, on the calling thread.
+        void RunQueuedTaskInline()
+        {
+            try
+            {
+                if (RangeTask != null)
+                {
+                    RangeTask.Invoke(LoopStart, LoopEnd);
+                    SetResult(null, null);
+                }
+                else if (VoidTask != null)
+                {
+                    VoidTask.Invoke();
+                    SetResult(null, null);
+                }
+                else if (ResultTask != null)
+                {
+                    object value = ResultTask.Invoke();
+                    SetResult(value, null);
+                }
+            }
+            catch (Exception ex)
+            {
+                var currentThread = Thread.CurrentThread;
+                ex.Data["Thread"] = currentThread.Name;
+                ex.Data["ThreadId"] = currentThread.ManagedThreadId;
+                Log.Warning($"{Name} inline task caught unhandled exception: {ex}");
+                SetResult(null, ex);
+            }
+            finally
+            {
+                RangeTask  = null;
+                VoidTask   = null;
+                ResultTask = null;
             }
         }
         public void Start(int start, int end, Action<int,int> taskBody, ITaskResult result)
@@ -333,6 +392,15 @@ namespace Ship_Game
 
         static readonly Array<ParallelTask> Pool = new Array<ParallelTask>(32);
         public static readonly int NumPhysicalCores = InitThreadPool();
+
+        // Number of times a worker thread could not be started (e.g. low memory) and the
+        // task was instead run synchronously on the calling thread. A non-zero/growing value
+        // signals the process is under memory pressure and the sim has degraded to inline.
+        public static int InlineFallbackCount;
+
+        // Test-only hook: when set, TriggerTaskStart simulates a thread-creation failure so the
+        // graceful inline fallback can be exercised deterministically. See TestThreadExt.
+        internal static volatile bool TestForceThreadStartFailure;
         
         [DllImport("SDNative.dll")]
         static extern int GetPhysicalCPUCoreCount();

--- a/Ship_Game/Threading/Parallel.cs
+++ b/Ship_Game/Threading/Parallel.cs
@@ -206,9 +206,13 @@ namespace Ship_Game
                     catch (Exception ex) when (ex is OutOfMemoryException or ThreadStartException)
                     {
                         // The OS refused to create a worker thread (typically low memory).
-                        // Degrade gracefully: discard the dead thread, consume the pending
-                        // signal, and run the queued task synchronously on the calling thread,
-                        // so a transient thread-creation failure doesn't crash the whole sim.
+                        // Degrade gracefully: discard the dead thread, consume the pending signal,
+                        // and DEFER the queued task to run synchronously on the calling thread once
+                        // the scheduler has released lock (Pool). We must NOT run it here: schedulers
+                        // call Start() while holding lock (Pool), so running an arbitrary task body
+                        // under that global lock would (a) serialize all other scheduling for the
+                        // body's duration and (b) order every lock the body takes under Pool, risking
+                        // a lock-ordering deadlock with any `lock(X){ Parallel.For(...) }` elsewhere.
                         // Log only the first occurrence to avoid flooding the log under sustained
                         // pressure - the volume is tracked by Parallel.InlineFallbackCount.
                         Thread = null;
@@ -216,14 +220,15 @@ namespace Ship_Game
                         if (Interlocked.Increment(ref Parallel.InlineFallbackCount) == 1)
                             Log.Warning($"{Name} thread start failed ({ex.GetType().Name}); running task inline. " +
                                         "Further occurrences suppressed; see Parallel.InlineFallbackCount");
-                        RunQueuedTaskInline();
+                        Parallel.DeferInline(this);
                     }
                 }
             }
         }
         // Synchronous fallback for TriggerTaskStart when no worker thread is available.
-        // Mirrors the Run() execute/catch/clear path, on the calling thread.
-        void RunQueuedTaskInline()
+        // Mirrors the Run() execute/catch/clear path, on the calling thread. Called by
+        // Parallel.RunDeferredInline AFTER the scheduler has released lock (Pool).
+        internal void RunQueuedTaskInline()
         {
             try
             {
@@ -401,7 +406,44 @@ namespace Ship_Game
         // Test-only hook: when set, TriggerTaskStart simulates a thread-creation failure so the
         // graceful inline fallback can be exercised deterministically. See TestThreadExt.
         internal static volatile bool TestForceThreadStartFailure;
-        
+
+        // Tasks whose worker thread could not be started (OOM) and must instead run synchronously
+        // on THIS thread. Per-thread so a scheduling thread only runs its own deferred tasks, and
+        // drained AFTER the scheduler releases lock (Pool) - see TriggerTaskStart's OOM path.
+        [ThreadStatic] static Array<ParallelTask> DeferredInline;
+        [ThreadStatic] static bool DrainingInline;
+
+        // Queue a task to run inline once lock (Pool) is released. Adds to the calling thread's list.
+        internal static void DeferInline(ParallelTask task)
+        {
+            (DeferredInline ??= new Array<ParallelTask>()).Add(task);
+        }
+
+        // Run any tasks deferred by DeferInline on the calling thread. MUST be called right after a
+        // scheduling lock (Pool) block, with no lock held, so the task bodies run unlocked. Loops
+        // until the list drains - a body may itself defer more work under sustained memory pressure -
+        // and is re-entrancy safe: a nested call no-ops and lets the outer loop pick up new items.
+        static void RunDeferredInline()
+        {
+            Array<ParallelTask> list = DeferredInline;
+            if (DrainingInline || list == null || list.Count == 0)
+                return;
+
+            DrainingInline = true;
+            try
+            {
+                while (list.Count > 0)
+                {
+                    ParallelTask task = list.PopLast();
+                    task.RunQueuedTaskInline();
+                }
+            }
+            finally
+            {
+                DrainingInline = false;
+            }
+        }
+
         [DllImport("SDNative.dll")]
         static extern int GetPhysicalCPUCoreCount();
 
@@ -510,6 +552,7 @@ namespace Ship_Game
                     results[i] = StartRangeTask(ref poolIndex, start, end, body);
                 }
             }
+            RunDeferredInline(); // run any OOM-deferred task bodies now that lock (Pool) is released
 
             Exception ex = null; // only store a single exception
             for (int i = 0; i < results.Length; ++i)
@@ -604,6 +647,7 @@ namespace Ship_Game
                 ParallelTask task = FindOrSpawnTask(ref poolIndex);
                 task.Start(action, result);
             }
+            RunDeferredInline(); // run inline now (unlocked) if the worker thread couldn't start
             return result;
         }
 
@@ -642,6 +686,7 @@ namespace Ship_Game
                 ParallelTask task = FindOrSpawnTask(ref poolIndex);
                 task.Start(AsyncFunc, result);
             }
+            RunDeferredInline(); // run inline now (unlocked) if the worker thread couldn't start
             return result;
         }
     }

--- a/StarDrive.csproj
+++ b/StarDrive.csproj
@@ -336,6 +336,7 @@
     <Compile Include="Ship_Game\Graphics\Particles\ParticleVertexBuffer.cs" />
     <Compile Include="Ship_Game\Graphics\Particles\ParticleVertexBufferShared.cs" />
     <Compile Include="Ship_Game\Graphics\RenderStates.cs" />
+    <Compile Include="Ship_Game\Graphics\MemoryPressure.cs" />
     <Compile Include="Ship_Game\Graphics\RenderTargets.cs" />
     <Compile Include="Ship_Game\Ships\LaunchShip.cs" />
     <Compile Include="Ship_Game\Ships\ConstructionShip.cs" />
@@ -1030,6 +1031,11 @@
   <ItemGroup>
     <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.1.303" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
+    <!-- Already in MonoGame.Framework.WindowsDX's closure; referenced directly so we can
+         query live VRAM pressure (IDXGIAdapter3::QueryVideoMemoryInfo) - see MemoryPressure.cs -->
+    <PackageReference Include="SharpDX" Version="4.0.1" />
+    <PackageReference Include="SharpDX.DXGI" Version="4.0.1" />
+    <PackageReference Include="SharpDX.Direct3D11" Version="4.0.1" />
     <PackageReference Include="LargeAddressAware" Version="1.0.6" />
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="Sentry" Version="3.41.4" />

--- a/UnitTests/Ships/ExternalSlotGridTests.cs
+++ b/UnitTests/Ships/ExternalSlotGridTests.cs
@@ -26,25 +26,29 @@ namespace UnitTests.Ships
 
             ship.Externals.DebugDump("TEST_Spearhead mk1-a", gs);
 
-            //      0    1    2    3    4    5  
-            //  0 |____|____|E2x2|E2x2|____|____
-            //  1 |____|E1x1|E2x2|E2x2|E1x1|____
-            //  2 |E1x1|E1x1 1x2  1x2 |E1x1|E1x1
-            //  3 |E1x1|E1x2 1x2  1x2 |E1x2|E1x1
-            //  4 |E1x1|E1x2 1x1  1x1 |E1x2|E1x1
-            //  5 |____|E1x1 1x1  1x1 |E1x1|____
-            //  6 |E1x1|E1x1 1x1  1x1 |E1x1|E1x1
-            //  7 |E1x1 2x2  2x2  2x2  2x2 |E1x1
-            //  8 |E1x1 2x2  2x2  2x2  2x2 |E1x1
-            //  9 |E1x1|E1x1 1x2  1x2 |E1x1|E1x1
-            // 10 |____|E1x1 1x2  1x2 |E1x1|____
-            // 11 |____|E1x1 1x1  1x1 |E1x1|____
-            // 12 |E1x1|E1x2 1x1  1x1 |E1x2|E1x1
-            // 13 |E1x1|E1x2 1x1  1x1 |E1x2|E1x1
-            // 14 |E1x1 1x1  2x2  2x2  1x1 |E1x1
-            // 15 |E1x1 1x1  2x2  2x2  1x1 |E1x1
-            // 16 |E1x1|E1x1 1x1  1x1 |E1x1|E1x1
-            // 17 |____|E1x1|E1x1|E1x1|E1x1|____
+            // External slots under the orthogonal-only rule (E = external, . = internal/empty).
+            // Note vs the old diagonal rule: the inner column-1 and column-4 cells (e.g. 1,2 / 4,2)
+            // are now INTERNAL — their only empty neighbor is a diagonal corner, which no longer
+            // counts. Only cells with an orthogonally-adjacent empty/edge slot stay external.
+            //      0  1  2  3  4  5
+            //  0   .  .  E  E  .  .
+            //  1   .  E  E  E  E  .
+            //  2   E  .  .  .  .  E
+            //  3   E  .  .  .  .  E
+            //  4   E  .  .  .  .  E
+            //  5   .  E  .  .  E  .
+            //  6   E  .  .  .  .  E
+            //  7   E  .  .  .  .  E
+            //  8   E  .  .  .  .  E
+            //  9   E  .  .  .  .  E
+            // 10   .  E  .  .  E  .
+            // 11   .  E  .  .  E  .
+            // 12   E  .  .  .  .  E
+            // 13   E  .  .  .  .  E
+            // 14   E  .  .  .  .  E
+            // 15   E  .  .  .  .  E
+            // 16   E  .  .  .  .  E
+            // 17   .  E  E  E  E  .
 
             ShipModule At(int x, int y) => ship.GetModuleAt(x,y);
 
@@ -59,9 +63,9 @@ namespace UnitTests.Ships
             AssertEqual(At(1,1), ship.Externals.Get(gs, 1,1), "must be external - NW,N,W empty");
 
             //ship.Externals.UpdateSlotsUnderModule(gs, At(2,1));
-            AssertEqual(At(2,1), ship.Externals.Get(gs, 2,1), "must be external - NW empty");
-            AssertEqual(At(3,1), ship.Externals.Get(gs, 3,1), "must be external - NE empty");
-            AssertEqual(At(4,1), ship.Externals.Get(gs, 4,1), "must be external - NE,N,E empty");
+            AssertEqual(At(2,1), ship.Externals.Get(gs, 2,1), "must be external - top edge at hull front");
+            AssertEqual(At(3,1), ship.Externals.Get(gs, 3,1), "must be external - top edge at hull front");
+            AssertEqual(At(4,1), ship.Externals.Get(gs, 4,1), "must be external - N,E empty");
             AssertEqual(null,    ship.Externals.Get(gs, 5,1));
 
             // edges of the front section
@@ -72,17 +76,17 @@ namespace UnitTests.Ships
             AssertEqual(At(5,3), ship.Externals.Get(gs, 5,3));
             AssertEqual(At(5,4), ship.Externals.Get(gs, 5,4));
 
-            // inner corners of the front section should be external
-            // because 1 neighboring tile is empty
-            AssertEqual(At(1,2), ship.Externals.Get(gs, 1,2));
-            AssertEqual(At(1,3), ship.Externals.Get(gs, 1,3)); // this is a 1x2 module
-            AssertEqual(At(1,4), ship.Externals.Get(gs, 1,4)); // this is a 1x2 module
+            // inner corners of the front section are now INTERNAL: their only empty neighbor is a
+            // diagonal corner, and orthogonally-sealed modules are protected (no corner exposure).
+            AssertEqual(null, ship.Externals.Get(gs, 1,2));
+            AssertEqual(null, ship.Externals.Get(gs, 1,3)); // this is a 1x2 module
+            AssertEqual(null, ship.Externals.Get(gs, 1,4)); // this is a 1x2 module
 
-            AssertEqual(At(4,2), ship.Externals.Get(gs, 4,2));
-            AssertEqual(At(4,4), ship.Externals.Get(gs, 4,4)); // this is a 1x2 module
-            AssertEqual(At(4,3), ship.Externals.Get(gs, 4,3)); // this is a 1x2 module
+            AssertEqual(null, ship.Externals.Get(gs, 4,2));
+            AssertEqual(null, ship.Externals.Get(gs, 4,4)); // this is a 1x2 module
+            AssertEqual(null, ship.Externals.Get(gs, 4,3)); // this is a 1x2 module
 
-            AssertEqual(49, ship.Externals.NumModules);
+            AssertEqual(37, ship.Externals.NumModules);
 
             // 13 |E1x1|E1x2 1x1  1x1 |E1x2|E1x1
             // 14 |E1x1 1x1  2x2  2x2  1x1 |E1x1
@@ -92,19 +96,20 @@ namespace UnitTests.Ships
 
             // kill a few engine modules, which should trigger an update to external slots
             ship.GetModuleAt(2, 17).SetHealth(0, "Test"); // this is a 1x1 engine slot
-            // killing that module should count -1 slot and expose +2 1x1 modules
-            AssertEqual(49-1+2, ship.Externals.NumModules);
+            // -1 (the dead slot) and +1 (the module above it is now orthogonally exposed) = net 0.
+            // Under the old diagonal rule this exposed +2; corner-only neighbors no longer count.
+            AssertEqual(37, ship.Externals.NumModules);
 
             // and if we resurrect the module, it should go back to previous value
             ship.GetModuleAt(2, 17).SetHealth(100, "Test");
-            AssertEqual(49, ship.Externals.NumModules);
+            AssertEqual(37, ship.Externals.NumModules);
 
             // kill two 1x1 modules, exposing the 2x2 reactor
             ship.GetModuleAt(3, 17).SetHealth(0, "Test");
             ship.GetModuleAt(3, 16).SetHealth(0, "Test");
             AssertEqual(At(3,15), ship.Externals.Get(gs, 3,15));
-            // lose one, but gain 3 externals
-            AssertEqual(49-1+3, ship.Externals.NumModules);
+            // two slots killed, but their orthogonal neighbors get exposed: net 37 -> 39
+            AssertEqual(39, ship.Externals.NumModules);
         }
     }
 }

--- a/UnitTests/TestThreadExt.cs
+++ b/UnitTests/TestThreadExt.cs
@@ -86,6 +86,49 @@ namespace UnitTests
             });
         }
 
+        // Reproduces the Sentry crash where the OS refused to create a worker thread under
+        // memory pressure (OutOfMemoryException from Thread.Start in ParallelTask). The engine
+        // must degrade gracefully: run the queued task synchronously on the calling thread
+        // instead of letting the OOM crash the sim. TestForceThreadStartFailure simulates the
+        // thread-creation failure deterministically.
+        [TestMethod]
+        public void TestInlineFallbackWhenThreadStartFails()
+        {
+            Parallel.ClearPool(); // cold pool: freshly spawned tasks have an unstarted thread, so
+                                  // TriggerTaskStart hits the (simulated) start-failure path.
+            int baseline = Parallel.InlineFallbackCount;
+            int callerThreadId = Thread.CurrentThread.ManagedThreadId;
+            Parallel.TestForceThreadStartFailure = true;
+            try
+            {
+                // VoidTask path: Parallel.Run always dispatches through the pool/thread-start,
+                // regardless of core count, so it deterministically exercises the fallback.
+                bool ranVoid = false;
+                int voidThreadId = -1;
+                Parallel.Run(() => { ranVoid = true; voidThreadId = Thread.CurrentThread.ManagedThreadId; }).Wait();
+                Assert.IsTrue(ranVoid, "Run(Action) body must still execute when the worker thread can't start");
+                AssertEqual(callerThreadId, voidThreadId, "Fallback must run the task inline on the calling thread");
+
+                // ResultTask path: the computed value must come back through the inline fallback.
+                var typed = Parallel.Run(() => 6 * 7);
+                typed.Wait();
+                AssertEqual(42, typed.Result, "Run(Func) must return the result computed inline");
+
+                // Exceptions from the body must still surface (not be swallowed by the fallback).
+                var faulted = Parallel.Run((Action)(() => throw new ArgumentException("boom")));
+                var ex = Assert.ThrowsExactly<ParallelTaskException>(() => faulted.Wait());
+                AssertEqual("boom", ex.InnerException?.Message);
+
+                Assert.IsTrue(Parallel.InlineFallbackCount > baseline,
+                    "Inline fallback counter should increment while thread-start is forced to fail");
+            }
+            finally
+            {
+                Parallel.TestForceThreadStartFailure = false;
+                Parallel.ClearPool(); // discard tasks left thread-less by the fallback
+            }
+        }
+
         [TestMethod]
         public void TestPForExceptions()
         {

--- a/UnitTests/TestThreadExt.cs
+++ b/UnitTests/TestThreadExt.cs
@@ -109,6 +109,15 @@ namespace UnitTests
                 Assert.IsTrue(ranVoid, "Run(Action) body must still execute when the worker thread can't start");
                 AssertEqual(callerThreadId, voidThreadId, "Fallback must run the task inline on the calling thread");
 
+                // Fire-and-forget: a Run whose result is never waited on must STILL execute, because
+                // the fallback runs inline at scheduling time (after lock (Pool) is released) - not
+                // deferred to a Wait() that may never come. Regression guard for the unlocked drain.
+                bool ranForget = false;
+                int forgetThreadId = -1;
+                Parallel.Run(() => { ranForget = true; forgetThreadId = Thread.CurrentThread.ManagedThreadId; });
+                Assert.IsTrue(ranForget, "Fire-and-forget Run(Action) must execute inline even without Wait()");
+                AssertEqual(callerThreadId, forgetThreadId, "Deferred fallback must run on the scheduling thread");
+
                 // ResultTask path: the computed value must come back through the inline fallback.
                 var typed = Parallel.Run(() => 6 * 7);
                 typed.Wait();


### PR DESCRIPTION
Rolling fixes batch off `main` for Jupiter 1.60. Each commit is self-contained; grouped below.

## Combat
- **Armor bypass (explosions + corner shots).** Explosive rounds against a station were dealing full damage to internal modules through intact armor. Fixed end-to-end: the detonation now anchors on the struck armor (not shoved past it by projectile radius); a direct hit explodes *directionally* — penetrating along the flight path (armor absorbs, only excess carries inward) with a lateral splash to external armor plates only; the external-slot rule counts only orthogonal neighbors (so a module sealed on all four orthogonal sides is protected); and the hit-test ray-walk no longer squeezes through a diagonal corner gap. Non-projectile explosions (ship death, reactor, space nuke) keep the radial model. Dead code removed (`WalkModuleGrid`, `TakeOneStep`, `HitTestShieldsLocal`, `DebugGridStep`). Verified in-game at 1× and 0.25×.
- **Artillery stance.** Long-range ships no longer charge into the target — Artillery never disengages (the anti-chase maneuver was driving it forward into the enemy) and brakes earlier so it holds standoff range instead of overshooting.
- **Scout gravity-well routing.** `GravityWellRouter` now treats a system whose star isn't in our influence as an obstacle, so scouts route *around* neutral systems instead of beelining through their wells.

## Fleet
- **Reinforcement crawl.** A fleet no longer crawls (or waits at the warp gate) for a small minority of out-of-position or newly-built ships. Gating is surface-area-weighted: ~85% assembled to move at full speed, 95% for the warp gate; ships still catching up are excluded so mid-transit reinforcements don't drag the body down.

## Memory
- **ExitToMain content unload.** Returning to the main menu only forces the expensive content unload when system RAM or VRAM headroom is actually low (new `MemoryPressure` helper). On machines with headroom it keeps content for a faster return. Probing is fail-closed — any failure takes the safe (force-unload) path.

## Crash / robustness
- **Parallel OOM.** `Parallel.For`/`Run` runs the task body inline on the caller when a worker thread can't start (OOM) instead of throwing.
- **GameAudio.** Null-safe async SFX queue across audio re-init, and the SFX consumer is quiesced before audio teardown (fixes an NRE/race).
- **CombatScreen.** Null-guard a cross-thread NRE in the bomber filter.
- **Espionage.** Infiltration UI ops routed through `ActivateOpsIfAble` (guards active/can-activate).

## Testing
- New/updated unit tests: `ExternalSlotGridTests` (orthogonal-only external rule, 49→37), `TestThreadExt` / Parallel inline-fallback.
- Per-commit self-review + full-branch review (clean, no blockers); full suite runs via the PR hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)