### PR TITLE
jupiter-1.60/fixes_23: diplomacy hand-over, PreEvaluate goal hoist, pirate raid aborts, shield-bypass fix

### DIFF
--- a/Ship_Game/AI/EmpireAI/EmpireAI.DiplomacyOffers.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.DiplomacyOffers.cs
@@ -105,6 +105,7 @@ namespace Ship_Game.AI
 
                     toRemove.Add(p);
                     p.SetOwner(them);
+                    p.Construction.ClearQueue();
 
                     p.System.OwnerList.Clear();
                     foreach (Planet pl in p.System.PlanetList)

--- a/Ship_Game/AI/Goal.cs
+++ b/Ship_Game/AI/Goal.cs
@@ -213,9 +213,22 @@ namespace Ship_Game.AI
         public float LifeTime => UState.StarDate - StarDateAdded;
         public bool IsMainGoalCompleted => MainGoalCompleted;
 
+        // Optional per-evaluation guard run before the current step. Subclasses return a
+        // non-null GoalStep to short-circuit (abort/complete) the goal before it steps;
+        // null means "proceed normally". Keeps the step-advance/self-remove contract below
+        // sealed so it can't be accidentally overridden away.
+        protected virtual GoalStep? PreEvaluate() => null;
+
         // @note Goals are mainly evaluated during Empire update
         public GoalStep Evaluate()
         {
+            if (PreEvaluate() is GoalStep preStep)
+            {
+                if (preStep is GoalStep.GoalComplete or GoalStep.GoalFailed)
+                    RemoveThisGoal();
+                return preStep;
+            }
+
             if ((uint)Step >= Steps.Length)
             {
                 Log.Error($"{Type} invalid Goal.Step: {Step}, Steps.Length: {Steps.Length}");

--- a/Ship_Game/Commands/Goals/AssaultBombers.cs
+++ b/Ship_Game/Commands/Goals/AssaultBombers.cs
@@ -31,11 +31,12 @@ namespace Ship_Game.Commands.Goals  // Created by Fat Bastard
             TargetEmpire = enemy;
         }
 
+        // We can only bomb from a planet we still own; bail the instant it's lost.
+        protected override GoalStep? PreEvaluate()
+            => PlanetBuildingAt.Owner != Owner ? GoalStep.GoalFailed : null;
+
         GoalStep LaunchBoardingShips()
         {
-            if (PlanetBuildingAt.Owner != Owner)
-                return GoalStep.GoalFailed;
-
             int numTroopCanLaunch = PlanetBuildingAt.NumTroopsCanLaunchFor(Owner);
             if (numTroopCanLaunch == 0)
                 return GoalStep.GoToNextStep; // Cant do anything about it, just wait until combat ends
@@ -87,9 +88,6 @@ namespace Ship_Game.Commands.Goals  // Created by Fat Bastard
 
         GoalStep WaitForCombatEnd()
         {
-            if (PlanetBuildingAt.Owner != Owner)
-                return GoalStep.GoalFailed;
-
             return PlanetBuildingAt.System.DangerousForcesPresent(Owner) ? GoalStep.TryAgain : GoalStep.GoalComplete;
         }
     }

--- a/Ship_Game/Commands/Goals/DeepSpaceBuildGoal.cs
+++ b/Ship_Game/Commands/Goals/DeepSpaceBuildGoal.cs
@@ -49,6 +49,22 @@ namespace Ship_Game.Commands.Goals
         }
         public override bool IsDeploymentGoal => true;
 
+        bool TetherPlanetTakenByOtherEmpire => TetherPlanet?.Owner != null && TetherPlanet.Owner != Owner;
+
+        protected override GoalStep? PreEvaluate()
+        {
+            if (TetherPlanetTakenByOtherEmpire)
+            {
+                // We no longer own the planet this orbital was for: scrap the in-flight
+                // constructor (if one was already built) and abandon the goal. The base
+                // Evaluate removes the goal once we return GoalFailed.
+                FinishedShip?.AI.OrderScuttleShip();
+                return GoalStep.GoalFailed;
+            }
+
+            return null;
+        }
+
         public override Vector2 BuildPosition
         {
             get

--- a/Ship_Game/Commands/Goals/PirateRaidCombatShip.cs
+++ b/Ship_Game/Commands/Goals/PirateRaidCombatShip.cs
@@ -33,11 +33,19 @@ namespace Ship_Game.Commands.Goals
 
         public override bool IsRaid => true;
 
+        // Stand down the moment the victim pays protection or is defeated - on every step, not
+        // just the first - unless we've already taken the target (let that capture conclude).
+        protected override GoalStep? PreEvaluate()
+        {
+            if ((Pirates.PaidBy(TargetEmpire) || Pirates.VictimIsDefeated(TargetEmpire))
+                && TargetShip?.Loyalty != Pirates.Owner)
+                return GoalStep.GoalFailed;
+
+            return null;
+        }
+
         GoalStep DetectAndSpawnRaidForce()
         {
-            if (Pirates.PaidBy(TargetEmpire) || Pirates.VictimIsDefeated(TargetEmpire))
-                return GoalStep.GoalFailed; // They paid or dead
-
             if (Pirates.GetTarget(TargetEmpire, Pirates.TargetType.CombatShipAtWarp, out Ship combatShip))
             {
                 combatShip.HyperspaceReturn();

--- a/Ship_Game/Commands/Goals/PirateRaidOrbital.cs
+++ b/Ship_Game/Commands/Goals/PirateRaidOrbital.cs
@@ -36,11 +36,19 @@ namespace Ship_Game.Commands.Goals
 
         public override bool IsRaid => true;
 
+        // Stand down the moment the victim pays protection or is defeated - on every step, not
+        // just the first - unless we've already taken the target (let that capture conclude).
+        protected override GoalStep? PreEvaluate()
+        {
+            if ((Pirates.PaidBy(TargetEmpire) || Pirates.VictimIsDefeated(TargetEmpire))
+                && TargetShip?.Loyalty != Pirates.Owner)
+                return GoalStep.GoalFailed;
+
+            return null;
+        }
+
         GoalStep DetectAndSpawnRaidForce()
         {
-            if (Pirates.PaidBy(TargetEmpire) || Pirates.VictimIsDefeated(TargetEmpire))
-                return GoalStep.GoalFailed; // They paid or dead
-
             StarDateAdded = Owner.Universe.StarDate;
             var orbitalType = GetOrbital();
             // orbitalType = Pirates.TargetType.Projector; // TODO for testing

--- a/Ship_Game/Commands/Goals/PirateRaidOrbital.cs
+++ b/Ship_Game/Commands/Goals/PirateRaidOrbital.cs
@@ -38,13 +38,42 @@ namespace Ship_Game.Commands.Goals
 
         // Stand down the moment the victim pays protection or is defeated - on every step, not
         // just the first - unless we've already taken the target (let that capture conclude).
+        // Unlike the other raids this one spawns an untracked escort force plus several boarding
+        // ships, so send the whole raiding party home rather than a single tracked ship.
         protected override GoalStep? PreEvaluate()
         {
             if ((Pirates.PaidBy(TargetEmpire) || Pirates.VictimIsDefeated(TargetEmpire))
                 && TargetShip?.Loyalty != Pirates.Owner)
+            {
+                RecallRaidForce();
                 return GoalStep.GoalFailed;
+            }
 
             return null;
+        }
+
+        // We keep no handles to the spawned raiders, so find our ships by the target's system
+        // when it has one, otherwise by proximity (deep-space targets have a null System), and
+        // order them back to base. Bases/platforms are skipped - only the mobile raiders flee.
+        void RecallRaidForce()
+        {
+            if (TargetShip == null)
+                return;
+
+            SolarSystem system = TargetShip.System;
+            var ourShips = Owner.OwnedShips;
+            for (int i = 0; i < ourShips.Count; i++)
+            {
+                Ship s = ourShips[i];
+                if (s == null || s.IsPlatformOrStation)
+                    continue;
+
+                bool inRange = system != null
+                    ? s.System == system
+                    : s.Position.InRadius(TargetShip.Position, 100_000);
+                if (inRange)
+                    s.AI.OrderPirateFleeHome();
+            }
         }
 
         GoalStep DetectAndSpawnRaidForce()

--- a/Ship_Game/Commands/Goals/PirateRaidProjector.cs
+++ b/Ship_Game/Commands/Goals/PirateRaidProjector.cs
@@ -42,11 +42,23 @@ namespace Ship_Game.Commands.Goals
 
         public override bool IsRaid => true;
 
+        // Stand down the moment the victim pays protection or is defeated - on every step, not
+        // just the first - unless we've already taken the target (let that capture conclude).
+        // Send the boarding ship home, as the other mid-raid abort paths do.
+        protected override GoalStep? PreEvaluate()
+        {
+            if ((Pirates.PaidBy(TargetEmpire) || Pirates.VictimIsDefeated(TargetEmpire))
+                && TargetShip?.Loyalty != Pirates.Owner)
+            {
+                BoardingShip?.AI.OrderPirateFleeHome(true);
+                return GoalStep.GoalFailed;
+            }
+
+            return null;
+        }
+
         GoalStep DetectAndSpawnRaidForce()
         {
-            if (Pirates.PaidBy(TargetEmpire) || Pirates.VictimIsDefeated(TargetEmpire))
-                return GoalStep.GoalFailed; // They paid or dead
-
             if (Pirates.GetTarget(TargetEmpire, Pirates.TargetType.Projector, out Ship orbital))
             {
                 Vector2 where = orbital.Position.GenerateRandomPointOnCircle(3000, Owner.Random);

--- a/Ship_Game/Commands/Goals/PirateRaidTransport.cs
+++ b/Ship_Game/Commands/Goals/PirateRaidTransport.cs
@@ -41,11 +41,23 @@ namespace Ship_Game.Commands.Goals
 
         public override bool IsRaid => true;
 
+        // Stand down the moment the victim pays protection or is defeated - on every step, not
+        // just the first - unless we've already taken the target (let that capture conclude).
+        // Send the boarding ship home, as the other mid-raid abort paths do.
+        protected override GoalStep? PreEvaluate()
+        {
+            if ((Pirates.PaidBy(TargetEmpire) || Pirates.VictimIsDefeated(TargetEmpire))
+                && TargetShip?.Loyalty != Pirates.Owner)
+            {
+                BoardingShip?.AI.OrderPirateFleeHome();
+                return GoalStep.GoalFailed;
+            }
+
+            return null;
+        }
+
         GoalStep DetectAndSpawnRaidForce()
         {
-            if (Pirates.PaidBy(TargetEmpire) || Pirates.VictimIsDefeated(TargetEmpire))
-                return GoalStep.GoalFailed; // They paid or dead
-
             if (Pirates.GetTarget(TargetEmpire, Pirates.TargetType.FreighterAtWarp, out Ship freighter))
             {
                 Vector2 where = freighter.Position.GenerateRandomPointOnCircle(1000, Owner.Random);

--- a/Ship_Game/Commands/Goals/SupplyGoodsToStation.cs
+++ b/Ship_Game/Commands/Goals/SupplyGoodsToStation.cs
@@ -39,11 +39,12 @@ namespace Ship_Game.Commands.Goals
         }
 
 
+        // The target station must still exist and belong to us for the whole trade run.
+        protected override GoalStep? PreEvaluate()
+            => StationApplicable ? null : GoalStep.GoalFailed;
+
         GoalStep SetupTrade()
         {
-            if (!StationApplicable)
-                return GoalStep.GoalFailed;
-
             if (Owner.TryDispatchGoodsSupplyToStation(Goods, TargetStation, out Empire.ExportPlanetAndFreighter exportAndFreighter))
             {
                 Planet exportPlanet = exportAndFreighter.Planet;
@@ -57,9 +58,6 @@ namespace Ship_Game.Commands.Goals
 
         GoalStep WaitForFrieghter()
         {
-            if (!StationApplicable)
-                return GoalStep.GoalFailed;
-
             if (Freighter == null || !Freighter.Active)
                 return GoalStep.GoalFailed;
 

--- a/Ship_Game/Commands/Goals/WarManager.cs
+++ b/Ship_Game/Commands/Goals/WarManager.cs
@@ -30,11 +30,13 @@ namespace Ship_Game.Commands.Goals
         WarType GetWarType() => Owner.GetRelations(TargetEmpire).ActiveWar.WarType;
         War ActiveWar => Owner.GetRelations(TargetEmpire).ActiveWar;
 
+        // The whole goal is moot once the war is over - completing here also keeps every step's
+        // ActiveWar/GetWarType access safe, since they never run while we're not at war.
+        protected override GoalStep? PreEvaluate()
+            => Owner.IsAtWarWith(TargetEmpire) ? null : GoalStep.GoalComplete;
+
         GoalStep SelectTargetSystems()
         {
-            if (!Owner.IsAtWarWith(TargetEmpire))
-                return GoalStep.GoalComplete;
-
             if (!Owner.GetPotentialTargetPlanets(TargetEmpire, GetWarType(), out Planet[] planetTargets))
             {
                 if (!Owner.TryGetMissionsVsEmpire(TargetEmpire, out _))
@@ -58,17 +60,14 @@ namespace Ship_Game.Commands.Goals
 
         GoalStep ProcessWar()
         {
-            if (!Owner.IsAtWarWith(TargetEmpire))
-                return GoalStep.GoalComplete;
-
-            return Owner.GetPotentialTargetPlanets(TargetEmpire, GetWarType(), out _) && Owner.CanAddAnotherWarGoal(TargetEmpire) 
+            return Owner.GetPotentialTargetPlanets(TargetEmpire, GetWarType(), out _) && Owner.CanAddAnotherWarGoal(TargetEmpire)
                 ? GoalStep.RestartGoal 
                 : GoalStep.TryAgain;
         }
 
         GoalStep RequestPeaceOrEscalate()
         {
-            if (!Owner.IsAtWarWith(TargetEmpire) || TargetEmpire.IsDefeated)
+            if (TargetEmpire.IsDefeated)
                 return GoalStep.GoalComplete;
 
             var warType = GetWarType();

--- a/Ship_Game/Remnants.cs
+++ b/Ship_Game/Remnants.cs
@@ -655,7 +655,7 @@ namespace Ship_Game
             foreach (SolarSystem system in portal.Universe.Systems)
             {
                 Ship chosenGuardian = Owner.Random.ItemFilter(system.ShipList,
-                    s => s is { IsGuardian: true, InCombat: false, BaseStrength: < 1000 }
+                    s => s is { IsGuardian: true, InCombat: false, BaseStrength: < 1000, BombBays.Count: 0 }
                 );
                 chosenGuardian?.AI.AddEscortGoal(portal);
             }

--- a/Ship_Game/Ships/Ship_ModuleGrid.cs
+++ b/Ship_Game/Ships/Ship_ModuleGrid.cs
@@ -557,6 +557,11 @@ namespace Ship_Game.Ships
         // armor plate (in addition to the full-strength penetration column along the ray).
         const float LateralSplashFraction = 0.5f;
 
+        // Reused per-explosion to dedup splash targets without allocating. EnumModulesQuadrants
+        // yields a module once per covered cell, so without this a wide module (or a shield bubble
+        // covering many cells) would be damaged many times over for a single blast.
+        [System.ThreadStatic] static HashSet<ShipModule> SplashHitScratch;
+
         // A projectile struck the hull and exploded. Unlike a radial blast (DamageExplosive),
         // a projectile carries momentum: the blast punches INWARD along the projectile's flight
         // path, and a wide blast also splashes the surrounding external armor plates.
@@ -572,6 +577,12 @@ namespace Ship_Game.Ships
             if (Loyalty.data.ExplosiveRadiusReduction > 0f)
                 hitRadius *= 1f - Loyalty.data.ExplosiveRadiusReduction;
 
+            // Capture the shield state AT IMPACT: the penetration column below can drain the entry
+            // shield to zero this same blast, but per the rule "a blast that hit an active shield
+            // stays on the shield layer" the splash must key off whether the shield was live when
+            // it was struck - not its leftover power after penetration.
+            bool hitActiveShield = !ignoreShields && entry.ShieldsAreActive;
+
             Vector2 entryPos = entry.Position;
             // Punch along the projectile's flight path; if velocity is unavailable, fall back to
             // punching from the entry module toward the ship interior.
@@ -581,20 +592,59 @@ namespace Ship_Game.Ships
 
             // 1. PENETRATION along the flight path.
             float penDamage = damageAmount;
+            // When the blast struck a live shield, the overflow that breaches it disperses over the
+            // depth of the bubble before reaching the hull. Attenuate the excess ONCE, as it crosses
+            // from the shield(s) to the first real hull module, by the distance from the bubble's
+            // outer impact point to that module (decay range = bubble radius + blast radius). A wide
+            // bubble pushes the impact point far out, so little overflow survives; a tight bubble
+            // barely attenuates.
+            bool attenuateShieldOverflow = hitActiveShield;
+            Vector2 shieldImpact = entryPos - dir * entry.ShieldHitRadius;
             foreach (ShipModule m in RayHitTestWalkModules(entryPos, dir, Radius * 2f, ignoreShields))
             {
+                if (attenuateShieldOverflow && m.ShieldPowerMax <= 0f)
+                {
+                    penDamage *= ShipModule.DamageFalloff(shieldImpact, m.Position,
+                                     entry.ShieldHitRadius + hitRadius, m.Radius);
+                    attenuateShieldOverflow = false;
+                }
+
                 if (m.DamageExplosive(damageSource, ref penDamage))
                     break; // armor column absorbed it all — internals untouched
             }
 
-            // 2. LATERAL SURFACE SPLASH for wide blasts — external plates only.
+            // 2. LATERAL SURFACE SPLASH for wide blasts, respecting the shield layer.
+            //   - If the blast landed on an ACTIVE shield it stays on the shield layer: it spreads
+            //     only to other active shields covering the blast area and NEVER leaks onto a hull
+            //     module (splash never transfers from a shield to a module).
+            //   - If the blast landed on the bare hull it spreads to surrounding EXTERNAL plates,
+            //     but any plate an active shield covers is protected by that shield.
+            //   - A shield-ignoring projectile splashes external modules directly, as before.
+            //   - Each module is hit at most once (the per-cell yields used to multiply the damage
+            //     and drain a multi-cell shield in a single blast).
             if (hitRadius >= 16f)
             {
-                foreach (ModuleQuadrant mq in EnumModulesQuadrants(entryPos, hitRadius, !ignoreShields))
+                HashSet<ShipModule> splashed = SplashHitScratch ??= new HashSet<ShipModule>();
+                splashed.Clear();
+
+                foreach (ModuleQuadrant mq in EnumModulesQuadrants(entryPos, hitRadius, checkShields: !ignoreShields))
                 {
                     ShipModule m = mq.Module;
-                    if (!m.IsExternal || m == entry)
-                        continue; // internals stay protected; entry already took the penetration hit
+                    if (m == entry || !splashed.Add(m))
+                        continue; // entry took the penetration hit; damage each module at most once
+
+                    if (!ignoreShields && m.ShieldsAreActive)
+                    {
+                        // an active shield always absorbs splash over the area it covers
+                    }
+                    else if (hitActiveShield)
+                    {
+                        continue; // shield-layer blast never damages a non-shield module
+                    }
+                    else if (!m.IsExternal || (!ignoreShields && HitTestShields(m.Position, 8f) != null))
+                    {
+                        continue; // hull blast: only exposed external plates — skip internals and shielded plates
+                    }
 
                     float falloff = ShipModule.DamageFalloff(entryPos, m.Position, hitRadius, m.Radius);
                     float splash = damageAmount * LateralSplashFraction * falloff;

--- a/UnitTests/SDUnitTests.csproj
+++ b/UnitTests/SDUnitTests.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Serialization\TypeSerializerTests.cs" />
     <Compile Include="Serialization\YamlSerializerTests.cs" />
     <Compile Include="Ships\ExternalSlotGridTests.cs" />
+    <Compile Include="Ships\ExplosionShieldTests.cs" />
     <Compile Include="Ships\ModuleGridFlyweightTests.cs" />
     <Compile Include="Ships\ShipDesignWriterTests.cs" />
     <Compile Include="Ships\TestResupplyLogic.cs" />

--- a/UnitTests/Ships/ExplosionShieldTests.cs
+++ b/UnitTests/Ships/ExplosionShieldTests.cs
@@ -1,0 +1,186 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SDGraphics;
+using Ship_Game;
+using Ship_Game.Ships;
+using Vector2 = SDGraphics.Vector2;
+
+namespace UnitTests.Ships
+{
+    /// <summary>
+    /// Regression coverage for the "LALA" Remnant ship shield bypass: a single explosive round
+    /// was (1) draining a whole shield because the lateral splash hit it once per covered grid
+    /// cell, and (2) splashing turrets / reactors directly through the shield bubble.
+    ///
+    /// The rule under test: a blast that lands on an ACTIVE shield stays on the shield layer -
+    /// it may spread to other active shields covering the area but never transfers onto a hull
+    /// module, and each module is damaged at most once per blast.
+    /// </summary>
+    [TestClass]
+    public class ExplosionShieldTests : StarDriveTest
+    {
+        public ExplosionShieldTests()
+        {
+            LoadStarterShips("TEST_ShipShield");
+            CreateUniverseAndPlayerEmpire();
+        }
+
+        // TEST_ShipShield 4x4 layout:
+        //      x0        x1        x2         x3
+        // y0   -         Amplifier Amplifier  -
+        // y1   -         Cockpit   Cockpit    -
+        // y2   Shield    Reactor   Reactor    Shield
+        // y3   Reactor   Engine    WarpEngine Reactor
+
+        static bool IsShield(ShipModule m) => m.ShieldPowerMax > 0;
+
+        [TestMethod]
+        public void ExplosionOnActiveShield_LeavesHullModulesUndamaged()
+        {
+            Ship ship = SpawnShip("TEST_ShipShield", Player, Vector2.Zero);
+            Ship attacker = SpawnShip("TEST_ShipShield", Enemy, new Vector2(1000, 0));
+
+            ShipModule shield = ship.GetModuleAt(0, 2);
+            Assert.IsTrue(IsShield(shield), "Module at (0,2) should be a shield");
+            Assert.IsTrue(shield.ShieldsAreActive, "Shield must be charged for this test");
+
+            const float damage = 200f;
+            Assert.IsTrue(shield.ShieldPower >= damage, "Shield must have enough power to absorb the blast");
+
+            var before = new Dictionary<ShipModule, float>();
+            foreach (ShipModule m in ship.Modules)
+                before[m] = m.Health;
+
+            // Detonate directly on the active shield.
+            ship.DamageExplosiveDirectional(attacker, damage, shield, hitRadius: 60f, ignoreShields: false);
+
+            foreach (ShipModule m in ship.Modules)
+            {
+                if (IsShield(m))
+                    continue; // shields legitimately lose POWER (not health) here
+                AssertEqual(before[m], m.Health,
+                    $"{m.UID} must take NO explosion damage behind an active shield");
+            }
+        }
+
+        [TestMethod]
+        public void ExplosionOnActiveShield_DoesNotDrainOtherShieldPerCell()
+        {
+            Ship ship = SpawnShip("TEST_ShipShield", Player, Vector2.Zero);
+            Ship attacker = SpawnShip("TEST_ShipShield", Enemy, new Vector2(1000, 0));
+
+            ShipModule nearShield = ship.GetModuleAt(0, 2);
+            ShipModule farShield  = ship.GetModuleAt(3, 2);
+            Assert.IsTrue(IsShield(nearShield) && IsShield(farShield), "Both (0,2) and (3,2) should be shields");
+            Assert.IsTrue(nearShield.ShieldsAreActive && farShield.ShieldsAreActive, "Both shields must be charged");
+
+            const float damage = 200f;
+            float farBefore = farShield.ShieldPower;
+
+            ship.DamageExplosiveDirectional(attacker, damage, nearShield, hitRadius: 60f, ignoreShields: false);
+
+            float farLost = farBefore - farShield.ShieldPower;
+            // The far shield is inside the blast radius so it takes exactly ONE splash hit. Before
+            // the fix it was hit once per covered grid cell and drained by many multiples of this.
+            Assert.IsTrue(farLost > 0f, "Far shield should take one splash hit (it is within the blast radius)");
+            Assert.IsTrue(farLost <= damage * 0.5f + 1f,
+                $"Far shield should lose at most one splash hit (<= {damage * 0.5f}), but lost {farLost}");
+        }
+
+        [TestMethod]
+        public void ExplosionThatDrainsEntryShield_StillContainsSplashToShieldLayer()
+        {
+            Ship ship = SpawnShip("TEST_ShipShield", Player, Vector2.Zero);
+            Ship attacker = SpawnShip("TEST_ShipShield", Enemy, new Vector2(1000, 0));
+
+            ShipModule shield = ship.GetModuleAt(0, 2);
+            Assert.IsTrue(IsShield(shield) && shield.ShieldsAreActive, "Entry must be a charged shield");
+
+            const float damage = 100f;
+            // Trim the entry shield to exactly the blast size so the penetration column drains it to
+            // zero THIS blast. It was still live at impact, so the splash must stay on the shield
+            // layer - regression for the ordering bug where the shield-state was read AFTER
+            // penetration had already zeroed it, making the splash treat it as a bare-hull hit.
+            shield.DamageShield(shield.ShieldPower - damage, null, out _);
+            AssertEqual(1f, damage, shield.ShieldPower, "precondition: entry shield trimmed to the blast size");
+
+            var before = new Dictionary<ShipModule, float>();
+            foreach (ShipModule m in ship.Modules)
+                before[m] = m.Health;
+
+            ship.DamageExplosiveDirectional(attacker, damage, shield, hitRadius: 60f, ignoreShields: false);
+
+            Assert.IsTrue(shield.ShieldPower <= 1f, "precondition: penetration should have drained the entry shield");
+            foreach (ShipModule m in ship.Modules)
+            {
+                if (IsShield(m))
+                    continue;
+                AssertEqual(before[m], m.Health,
+                    $"{m.UID} must stay undamaged - the blast struck a LIVE shield, so splash stays on the shield layer");
+            }
+        }
+
+        [TestMethod]
+        public void ExplosionOverwhelmingShield_AttenuatesOverflowByBubbleDepth()
+        {
+            Ship ship = SpawnShip("TEST_ShipShield", Player, Vector2.Zero);
+            Ship attacker = SpawnShip("TEST_ShipShield", Enemy, new Vector2(1000, 0));
+
+            ShipModule shield = ship.GetModuleAt(0, 2);
+            ShipModule farShield = ship.GetModuleAt(3, 2);
+            ShipModule behind = ship.GetModuleAt(1, 2);
+            Assert.IsTrue(IsShield(shield) && shield.ShieldsAreActive, "(0,2) must be a charged shield");
+            Assert.IsFalse(IsShield(behind), "(1,2) must be a hull module behind the shield");
+
+            const float hitRadius = 60f;
+            const float shieldLeft = 20f;
+            // Drop the OTHER shield first: its bubble also covers the module behind, and an active
+            // shield over a cell re-absorbs the overflow (shield-layer containment). With it down,
+            // the module is genuinely exposed once the entry shield is overwhelmed.
+            farShield.DamageShield(farShield.ShieldPower, null, out _);
+            Assert.IsFalse(farShield.ShieldsAreActive, "far shield must be down so it can't re-absorb the overflow");
+            shield.DamageShield(shield.ShieldPower - shieldLeft, null, out _);
+
+            // Replicate the production attenuation to size a non-flaky scenario: the overflow that
+            // breaches the shield decays from a point one bubble-radius out along the flight path,
+            // over a (bubble + blast) range.
+            Vector2 dir = shield.Position.DirectionToTarget(ship.Position);
+            Vector2 impact = shield.Position - dir * shield.ShieldHitRadius;
+            float falloff = ShipModule.DamageFalloff(impact, behind.Position, shield.ShieldHitRadius + hitRadius, behind.Radius);
+            Assert.IsTrue(falloff is > 0.01f and < 0.5f, $"precondition: bubble should heavily attenuate (falloff={falloff:0.00})");
+
+            // Size the excess so the ATTENUATED overflow is ~half the module's health: the module
+            // survives - which proves the attenuation, because the RAW excess is several times its
+            // health and would have destroyed it outright without the bubble-depth falloff.
+            float behindBefore = behind.Health;
+            float excess = behindBefore * 0.5f / falloff; // > behindBefore since falloff < 0.5
+            Assert.IsTrue(excess > behindBefore, "precondition: raw excess would destroy the module without attenuation");
+
+            ship.DamageExplosiveDirectional(attacker, shieldLeft + excess, shield, hitRadius: hitRadius, ignoreShields: false);
+
+            Assert.IsTrue(behind.Active && behind.Health > 0f,
+                "module behind must SURVIVE - the bubble attenuates the overflow far below the raw excess that would have destroyed it");
+            Assert.IsTrue(behind.Health < behindBefore,
+                "but the attenuated overflow should still reach and damage the module");
+        }
+
+        [TestMethod]
+        public void ShieldPiercingExplosion_StillReachesHullModules()
+        {
+            Ship ship = SpawnShip("TEST_ShipShield", Player, Vector2.Zero);
+            Ship attacker = SpawnShip("TEST_ShipShield", Enemy, new Vector2(1000, 0));
+
+            ShipModule reactor = ship.GetModuleAt(1, 2);
+            Assert.IsFalse(IsShield(reactor), "Module at (1,2) should not be a shield");
+
+            float reactorBefore = reactor.Health;
+
+            // A shield-ignoring explosive (e.g. a piercing Remnant weapon) entering on the reactor:
+            // the shield-aware splash logic must NOT block these - they still reach the hull.
+            ship.DamageExplosiveDirectional(attacker, 300f, reactor, hitRadius: 60f, ignoreShields: true);
+
+            Assert.IsTrue(reactor.Health < reactorBefore,
+                "Shield-piercing explosion must still damage the hull module it struck");
+        }
+    }
+}


### PR DESCRIPTION
Rolling `fixes_23` batch off `main`. Five commits across four themes; each commit self-reviewed and the whole branch passed a full-branch review.

## Diplomacy colony hand-over (`d38bd9b5`)
- `GiveColonies` now clears the gifted planet''s construction queue, so the new owner doesn''t inherit the giver''s pending builds (mirrors `ChangeOwnerByInvasion`).
- Orbital-build goals tethered to a planet that changes hands self-cancel via a new `Goal.PreEvaluate()` hook: `DeepSpaceBuildGoal` scuttles the in-flight constructor and fails the goal when its tether planet is owned by another empire. Research/mining stations (unowned tether bodies) are unaffected.

## PreEvaluate goal hoist (`ba927f8f`)
Pure refactor: `AssaultBombers`, `SupplyGoodsToStation`, `WarManager` each re-checked one precondition at the top of every Step. Hoisted into a single `PreEvaluate` override and dropped the per-step copies. Behavior-preserving (the guard was already on every step); WarManager also loses a latent `ActiveWar` NRE.

## Pirate raids stand down when paid (`fa514c6b`, `90e05ac7`)
- The `PaidBy || VictimIsDefeated` guard was only on a raid''s first step, so a multi-step raid kept boarding after the victim paid. Moved to a per-goal `PreEvaluate` so raids abort immediately; the boarding ship is sent home, and an already-captured target''s success tail is preserved.
- `PirateRaidOrbital` also recalls its untracked escort force (`SpawnForce` + boarding ships) on abort.

## Shield-bypass combat fix (`7b045c8e`)
Explosive projectiles were bypassing active shields onto hull modules. The lateral splash applied falloff damage to every external module **once per covered grid cell** with no shield awareness — one round drained a whole shield and splashed turrets/reactors through the bubble. Reworked:
- A blast on a **live shield** stays on the shield layer (spreads only to other active shields), never to hull modules.
- A bare-hull blast spreads to external plates but skips any plate an active shield covers; internals never splashed.
- Each module hit at most once (thread-static dedup).
- When a shield **is** overwhelmed, the overflow that pierces to the module behind attenuates by bubble depth — decays over `(ShieldHitRadius + blastRadius)` from the bubble''s impact point.
- `IgnoresShields` weapons still bypass.

Covered by 5 new regression tests (`ExplosionShieldTests`).

## Testing
Relevant suites pass locally (goals, shields, explosion, serialization, supply/space-roads). Full suite runs in the PR gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)