### PR TITLE
jupiter-1.60/fixes_24: AI, sim-thread, and lifecycle stability fixes

### DIFF
--- a/Ship_Game/AI/EmpireAI/EmpireAI.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.cs
@@ -541,21 +541,43 @@ namespace Ship_Game.AI
             return GoalsList.Count(predicate);
         }
 
+        // GoalsList is owned by the simulation thread (it's iterated & evaluated in Update()).
+        // Any caller NOT on the sim thread must not mutate it directly or the sim thread's
+        // snapshot reads a torn slot (null) -> NRE. Off-thread callers are the UI windows
+        // (build/scrap/refit) and the parallel ship-update path (Ship.Update -> Die ->
+        // AddGoalAndEvaluate runs on a Parallel.For worker). Marshal those onto the sim thread
+        // via the pending-action queue; sim-thread callers (the common case) run inline with no
+        // closure allocation, so ordering and hot-path performance are preserved.
+        UniverseScreen MarshalScreen => UState?.Screen is { IsOnSimThread: false } s ? s : null;
+
         public void AddGoal(Goal goal)
         {
-            GoalsList.Add(goal);
+            if (MarshalScreen is { } screen)
+                screen.RunOnSimThread(() => GoalsList.Add(goal));
+            else
+                GoalsList.Add(goal);
         }
 
         public void AddGoalAndEvaluate(Goal goal)
         {
-            GoalsList.Add(goal);
-            goal.Evaluate();
+            if (MarshalScreen is { } screen)
+                screen.RunOnSimThread(() => { GoalsList.Add(goal); goal.Evaluate(); });
+            else
+            {
+                GoalsList.Add(goal);
+                goal.Evaluate();
+            }
         }
 
         public void RemoveGoal(Goal goal)
         {
-            goal.OnRemoved();
-            GoalsList.Remove(goal);
+            if (MarshalScreen is { } screen)
+                screen.RunOnSimThread(() => { goal.OnRemoved(); GoalsList.Remove(goal); });
+            else
+            {
+                goal.OnRemoved();
+                GoalsList.Remove(goal);
+            }
         }
 
         public void ClearGoals()

--- a/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
@@ -683,7 +683,7 @@ namespace Ship_Game.AI
         {
             bool badGuysNear = BadGuysNear;
             bool inCombat = Owner.InCombat;
- 
+
             // if there are Enemies nearby, or ship is in combat, always set HighAlert
             if (badGuysNear || inCombat)
             {

--- a/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.DoAction.cs
@@ -229,7 +229,11 @@ namespace Ship_Game.AI
 
             bool ShouldTryOvertakeTarget()
             {
-                if (Owner.IsInWarp || target.IsInWarp || Owner.Loyalty.Random.RollDice(95 - Owner.Level))
+                // A stationary ship (station/platform) can't overtake anything; issuing a Pursue
+                // priority-order move only drops it out of combat (it never reaches the prediction
+                // point). This is what left Remnant portals oscillating Combat<->Pursue instead of
+                // fighting in place.
+                if (Owner.IsInWarp || target.IsInWarp || Owner.Stats.IsStationary || Owner.Loyalty.Random.RollDice(95 - Owner.Level))
                     return false;
 
                 float distance = Owner.Position.Distance(target.Position);

--- a/Ship_Game/Commands/Goals/BuildConstructionShip.cs
+++ b/Ship_Game/Commands/Goals/BuildConstructionShip.cs
@@ -24,18 +24,16 @@ namespace Ship_Game.Commands.Goals
             };
         }
 
-        public BuildConstructionShip(Vector2 buildPos, string platformUid, Empire owner, bool rush = false)
+        public BuildConstructionShip(Vector2 buildPos, string platformUid, Empire owner, bool rush = false, bool manualPlacement = false)
             : this(owner)
         {
             Initialize(platformUid, buildPos, null);
             Build.Rush = rush;
 
-            // try catch multipler projector build on same place
-            if (ToBuild.IsSubspaceProjector)
-            {
-                if (owner.FindProjectorAt(buildPos, 100, out Ship _))
-                    Log.Error($"Build pos of projector is near {buildPos}");
-            }
+            // Manual UI placement may intentionally drop a projector anywhere. Only automated
+            // builders (AI road/bridge planners, player automation) get the dedupe diagnostic.
+            if (!manualPlacement && ToBuild.IsSubspaceProjector && owner.FindProjectorAt(buildPos, 100, out Ship _))
+                Log.Error($"Build pos of projector is near {buildPos}");
         }
 
         /// <summary>

--- a/Ship_Game/Commands/Goals/RemnantEngageEmpire.cs
+++ b/Ship_Game/Commands/Goals/RemnantEngageEmpire.cs
@@ -16,7 +16,7 @@ namespace Ship_Game.Commands.Goals
         [StarData] public sealed override Empire TargetEmpire { get; set; }
         [StarData] int BombersLevel;
         [StarData] public override Planet TargetPlanet { get; set; }
-        
+
         Remnants Remnants => Owner.Remnants;
         
         public override bool IsRaid => true;

--- a/Ship_Game/Commands/Goals/RemnantPortal.cs
+++ b/Ship_Game/Commands/Goals/RemnantPortal.cs
@@ -115,7 +115,11 @@ namespace Ship_Game.Commands.Goals
 
         void ScrambleDefense()
         {
-            if (Portal.InCombat && Portal.HealthPercent < 0.95f && !Owner.AI.Goals.Any(g => g.IsRemnantDefendingPortal(Portal)))
+            if (!Portal.InCombat)
+                return;
+
+            bool alreadyDefending = Owner.AI.Goals.Any(g => g.IsRemnantDefendingPortal(Portal));
+            if ((Portal.HealthPercent < 0.99f || Portal.ShieldPercent < 80f) && !alreadyDefending)
                 Owner.AI.AddGoalAndEvaluate(new RemnantDefendPortal(Owner, Portal));
         }
 

--- a/Ship_Game/DeepSpaceBuildingWindow.cs
+++ b/Ship_Game/DeepSpaceBuildingWindow.cs
@@ -168,7 +168,7 @@ namespace Ship_Game
                     if (TargetPlanet != null)
                         Player.AI.AddGoalAndEvaluate(new BuildConstructionShip(worldPos, ShipToBuild.Name, Player, TargetPlanet, TetherOffset));
                     else
-                        Player.AI.AddGoalAndEvaluate(new BuildConstructionShip(worldPos, ShipToBuild.Name, Player));
+                        Player.AI.AddGoalAndEvaluate(new BuildConstructionShip(worldPos, ShipToBuild.Name, Player, manualPlacement: true));
                 }
 
                 GameAudio.EchoAffirmative();

--- a/Ship_Game/DeepSpaceBuildingWindow.cs
+++ b/Ship_Game/DeepSpaceBuildingWindow.cs
@@ -177,8 +177,6 @@ namespace Ship_Game
             {
                 GameAudio.NegativeClick();
             }
-
-            Screen.UpdateClickableItems();
         }
 
         bool OkToBuild(Planet targetPlanet, SolarSystem targetSystem)

--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -599,7 +599,10 @@ namespace Ship_Game
 
         public void RemovePlanet(Planet planet, Empire attacker)
         {
-            GetRelations(attacker).LostAColony(planet, attacker);
+            // No relationship when attacker == us (e.g. a meteor wiping an Unknown-faction
+            // colony, attributed to Universe.Unknown): skip the colony-loss bookkeeping.
+            if (GetRelations(attacker, out Relationship rel))
+                rel.LostAColony(planet, attacker);
             RemovePlanet(planet);
 
             if (!isPlayer && attacker.data.IsRebelFaction)

--- a/Ship_Game/Empire_Borders.cs
+++ b/Ship_Game/Empire_Borders.cs
@@ -301,7 +301,7 @@ public sealed partial class Empire
         }
         foreach (ref InfluenceNode n in sensorPlanets)
         {
-            n.Position = n.Source.System.Position;
+            n.Position = n.Source.Position;
             n.KnownToPlayer = knownToPlayer;
         }
     }

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -1665,7 +1665,7 @@ namespace Ship_Game.Fleets
                     break;
                 case 1:
                     MoveStatus moveStatus = FleetMoveStatus(task.RallyPlanet.System.Radius);
-                    if (moveStatus.IsSet(MoveStatus.MajorityAssembled) && !task.RallyPlanet.System.HostileForcesPresent(Owner))
+                    if (moveStatus.IsSet(MoveStatus.MajorityAssembled) && !task.RallyPlanet.System.DangerousForcesPresent(Owner))
                     {
                         AddFleetProjectorGoal();
                         TaskStep = 2;
@@ -1745,7 +1745,7 @@ namespace Ship_Game.Fleets
             bool threatIncoming = Owner.IsSystemUnderThreatForUs(FleetTask.TargetSystem)
                 || Owner.IsSystemUnderThreatForAllies(FleetTask.TargetSystem);
 
-            if (threatIncoming && EndInvalidTask(!CanTakeThisFight(enemyStrength*0.5f, task, inCombat: TaskStep >= 2))) 
+            if (threatIncoming && EndInvalidTask(!CanTakeThisFight(enemyStrength*0.5f, task, inCombat: TaskStep >= 2)))
                 return; // If no threat is incoming, stay put to clear remaining lone ships
 
             float aoRadius = task.TargetSystem?.Radius * 2 ?? task.RallyPlanet.System.Radius * 2;
@@ -1772,7 +1772,7 @@ namespace Ship_Game.Fleets
                     break;
                 case 1:
                     MoveStatus moveStatus = FleetMoveStatus(task.RallyPlanet.System.Radius);
-                    if (moveStatus.IsSet(MoveStatus.MajorityAssembled) && !task.RallyPlanet.System.HostileForcesPresent(Owner))
+                    if (moveStatus.IsSet(MoveStatus.MajorityAssembled) && !task.RallyPlanet.System.DangerousForcesPresent(Owner))
                     {
                         GatherAtAO(task, distanceFromAO: aoRadius);
                         TaskStep = 2;
@@ -1883,7 +1883,7 @@ namespace Ship_Game.Fleets
 
         bool EndInvalidTask(bool condition)
         {
-            if (!condition) 
+            if (!condition)
                 return false;
 
             FleetTask?.EndTask();

--- a/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Build.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Build.cs
@@ -85,9 +85,11 @@ namespace Ship_Game
 
             if (!ConstructionQueue.IsDragging)
             {
-                if (!ConstructionQueue.AllEntries.Select(item => item.Item).EqualElements(P.ConstructionQueue))
+                // Snapshot once under lock: the sim thread mutates the live queue while we read it.
+                QueueItem[] queue = P.ConstructionQueueSnapshot;
+                if (!ConstructionQueue.AllEntries.Select(item => item.Item).EqualElements(queue))
                 {
-                    var newItems = P.ConstructionQueue.Select(qi => new ConstructionQueueScrollListItem(qi, LowRes));
+                    var newItems = queue.Select(qi => new ConstructionQueueScrollListItem(qi, LowRes));
                     ConstructionQueue.SetItems(newItems);
                 }
             }

--- a/Ship_Game/GameScreens/Universe/ColoniesListItem.cs
+++ b/Ship_Game/GameScreens/Universe/ColoniesListItem.cs
@@ -301,24 +301,26 @@ namespace Ship_Game
 
             DrawStorage(batch);
 
-            if (P.ConstructionQueue.Count > 0)
+            // Snapshot under lock: the sim thread mutates the live queue while we draw.
+            QueueItem[] queue = P.ConstructionQueueSnapshot;
+            if (queue.Length > 0)
             {
-                QueueItem qi = P.ConstructionQueue[0];
+                QueueItem qi = queue[0];
                 qi.DrawAt(P.Universe, batch, new Vector2(QueueRect.X + 10, QueueRect.Y + QueueRect.Height / 2 - 30), LowRes);
                 batch.Draw((ApplyProdHover ? ResourceManager.Texture("NewUI/icon_queue_rushconstruction_hover1") : ResourceManager.Texture("NewUI/icon_queue_rushconstruction")), ApplyProductionRect, Color.White);
                 batch.Draw((CancelProdHover ? ResourceManager.Texture("NewUI/icon_queue_delete_hover1") : ResourceManager.Texture("NewUI/icon_queue_delete")), CancelProductionRect, Color.White);
-                DrawQueueStats(batch);
+                DrawQueueStats(batch, queue.Length);
             }
 
             batch.DrawRectangle(Rect, TextColor2);
         }
 
-        void DrawQueueStats(SpriteBatch batch)
+        void DrawQueueStats(SpriteBatch batch, int queueCount)
         {
-            if (P.ConstructionQueue.Count < 2)
+            if (queueCount < 2)
                 return;
 
-            string stats = $"In Queue ({P.ConstructionQueue.Count}):";
+            string stats = $"In Queue ({queueCount}):";
             if (NumShipsInQueue > 0)
                 stats = $"{stats} ships ({NumShipsInQueue}),";
 
@@ -369,13 +371,15 @@ namespace Ship_Game
 
         void UpdateQueueItemsList()
         {
-            if (P.ConstructionQueue.Count < 2)
+            // Snapshot once under lock; the live queue is mutated on the sim thread.
+            QueueItem[] queue = P.ConstructionQueueSnapshot;
+            if (queue.Length < 2)
                 return;
 
-            NumShipsInQueue     = P.ConstructionQueue.Filter(q => q.isShip).Length;
-            NumBuildingsInQueue = P.ConstructionQueue.Filter(q => q.isBuilding).Length;
-            NumTroopsInQueue    = P.ConstructionQueue.Filter(q => q.isTroop).Length;
-            TotalProdNeeded     = (int)P.TotalProdNeededInQueue();
+            NumShipsInQueue     = queue.Count(q => q.isShip);
+            NumBuildingsInQueue = queue.Count(q => q.isBuilding);
+            NumTroopsInQueue    = queue.Count(q => q.isTroop);
+            TotalProdNeeded     = (int)queue.Sum(q => q.ProductionNeeded);
         }
     }
 }

--- a/Ship_Game/Gameplay/Projectile.cs
+++ b/Ship_Game/Gameplay/Projectile.cs
@@ -995,7 +995,22 @@ namespace Ship_Game.Gameplay
             // the blast PAST the armor onto an internal module (the armor-bypass bug). The struck
             // module's own position always sits on the armor, and the directional explosion handles
             // penetration from there.
-            Position = Radius <= 8 ? hitPos : victim.Position;
+            if (victim.ShieldsAreActive)
+            {
+                // ...but a shield module's center is the BUBBLE center, up to ShieldHitRadius
+                // (~60-210u) behind the surface the projectile actually struck. Anchoring there
+                // draws the explosion/sparks deep inside the bubble. Snap to the bubble surface
+                // along the incoming direction so the visual reads at the point of hit. Damage is
+                // unaffected: DamageExplosiveDirectional derives its geometry from the module, and
+                // shield damage uses no position at all.
+                Vector2 fromCenter = hitPos - victim.Position;
+                Vector2 dir = fromCenter.AlmostZero() ? -VelocityDirection : fromCenter.Normalized();
+                Position = victim.Position + dir * victim.ShieldHitRadius;
+            }
+            else
+            {
+                Position = Radius <= 8 ? hitPos : victim.Position;
+            }
             Universe.DebugWin?.DrawGameObject(DebugModes.Targeting, this, Color.LightCyan, lifeTime:0.25f);
 
             if (!TryPhaseThroughModule(victim) && Damage(victim))

--- a/Ship_Game/GlobalStats.cs
+++ b/Ship_Game/GlobalStats.cs
@@ -242,8 +242,22 @@ public static class GlobalStats
     //////// DEV AppConfig Options
 
     // DEV APP CONFIG OPTION
-    // Dev Option for AUTOPERF
-    public static bool RestrictAIPlayerInteraction;
+    // Dev Option for AUTOPERF.
+    // Backing field holds ONLY the value read from / written to the user config.
+    // AUTO/AUTOFAST soak builds force the *effective* value on via the getter below, but
+    // must never persist that forced value: SaveSettings writes the backing field, not the
+    // getter, so an Auto run can't leak RestrictAIPlayerInteraction=true into the shared
+    // user config and poison subsequent normal Debug/Release play.
+    static bool RestrictAIPlayerInteractionSetting;
+    public static bool RestrictAIPlayerInteraction
+    {
+#if AUTO || AUTOFAST
+        get => true; // soak builds always lock the player out; runtime-only, never persisted
+#else
+        get => RestrictAIPlayerInteractionSetting;
+#endif
+        set => RestrictAIPlayerInteractionSetting = value;
+    }
 
     // When TRUE, UniverseScreen.UpdateGame auto-ramps UState.GameSpeed up to whatever
     // the simulation can sustain — used by AUTOFAST soak runs. The 'Auto' build
@@ -333,7 +347,7 @@ public static class GlobalStats
             
         var config = OpenUserConfiguration();
         GetSetting(config, "ConfigVersion", ref ConfigVersion);
-        GetSetting(config, "RestrictAIPlayerInteraction", ref RestrictAIPlayerInteraction);
+        GetSetting(config, "RestrictAIPlayerInteraction", ref RestrictAIPlayerInteractionSetting);
         GetSetting(config, "XRES", ref XRES);
         GetSetting(config, "YRES", ref YRES);
         GetSetting(config, "MaxParallelism", ref MaxParallelism);
@@ -379,13 +393,12 @@ public static class GlobalStats
             VerboseLogging = true;
         #endif
         #if AUTOFAST
-            RestrictAIPlayerInteraction = true;
+            // Player lockout is forced on via the RestrictAIPlayerInteraction getter (not
+            // persisted). AUTOFAST also ramps the sim speed.
             AutoRampGameSpeed = true;
         #endif
-        #if AUTO
-            // Same input lockout as AUTOFAST, but no simulation-speed ramping.
-            RestrictAIPlayerInteraction = true;
-        #endif
+        // NOTE: AUTO is the same player lockout as AUTOFAST without sim-speed ramping; it is
+        // handled entirely by the RestrictAIPlayerInteraction getter, so nothing to force here.
 
         Log.Write(ConsoleColor.DarkYellow, "Loaded App Settings");
 
@@ -528,7 +541,7 @@ public static class GlobalStats
         Configuration config = OpenUserConfiguration();
 
         WriteSetting(config, "ConfigVersion", ConfigVersion);
-        WriteSetting(config, "RestrictAIPlayerInteraction", RestrictAIPlayerInteraction);
+        WriteSetting(config, "RestrictAIPlayerInteraction", RestrictAIPlayerInteractionSetting);
         WriteSetting(config, "XRES", XRES);
         WriteSetting(config, "YRES", YRES);
         WriteSetting(config, "MaxParallelism", MaxParallelism);

--- a/Ship_Game/Shield.cs
+++ b/Ship_Game/Shield.cs
@@ -29,7 +29,14 @@ namespace Ship_Game
         // a fraction of a second so it reads as a transient hit, not a
         // persistent halo.
         float DistortionTimeLeft;
-        const float DistortionDuration = 0.2f;
+        const float DistortionDuration = 0.1f;
+
+        // Screen-space shield-hit ripple is disabled: it doesn't look good in game
+        // (the warp reads as a distracting smear rather than a clean impact). The
+        // shield bubble glow is unaffected. Tuning constants below (DistortionDuration,
+        // and RippleRadiusScale in ShieldManager) are kept for anyone who wants to
+        // revisit the effect — set this back to false to re-enable.
+        const bool RippleDisabled = true;
 
         public Shield()
         {
@@ -214,17 +221,17 @@ namespace Ship_Game
         public bool LightEnabled => Light?.Enabled == true;
 
         // Phase 3.7 step 2 distortion signal. Active during the brief window
-        // (~80 frames for ship shields, fewer for planet shields) when a
-        // shield was just hit and Light.Intensity is decaying toward zero.
-        // The returned worldCenter is z=0 for ship shields and z=2500 for
-        // planet shields (matches UpdateWorldTransform).
+        // (DistortionDuration seconds) after a shield was just hit, gated by
+        // DistortionTimeLeft and refreshed on each impact. The returned
+        // worldCenter is z=0 for ship shields and z=2500 for planet shields
+        // (matches UpdateWorldTransform).
         public bool TryGetDistortionSource(out Vector3 worldCenter, out float worldRadius, out float intensity)
         {
             worldCenter = default;
             worldRadius = 0f;
             intensity   = 0f;
 
-            if (Radius <= 0f || DistortionTimeLeft <= 0f)
+            if (RippleDisabled || Radius <= 0f || DistortionTimeLeft <= 0f)
                 return false;
 
             // 1.0 right after hit, fading linearly to 0 over DistortionDuration.

--- a/Ship_Game/ShieldManager.cs
+++ b/Ship_Game/ShieldManager.cs
@@ -186,6 +186,11 @@ public sealed class ShieldManager : IDisposable
         AppendActive(planetShields, u, destWidth, destHeight, output);
     }
 
+    // Ripple disk radius as a fraction of the shield bubble radius. <1 keeps the
+    // screen-space distortion tight around the impact point instead of warping the
+    // whole bubble. Frustum/sub-pixel culls below still use the full bubble radius.
+    const float RippleRadiusScale = 0.4f;
+
     static void AppendActive(Shield[] arr, UniverseScreen u, int destW, int destH,
                              List<DistortionComponent.DistortionSource> output)
     {
@@ -217,7 +222,7 @@ public sealed class ShieldManager : IDisposable
             output.Add(new DistortionComponent.DistortionSource
             {
                 CenterUV  = new Vector2((float)(centerPx.X * invW), (float)(centerPx.Y * invH)),
-                RadiusUV  = (float)(radiusPx * invW), // assume square pixels; UV radius in X
+                RadiusUV  = (float)(radiusPx * invW) * RippleRadiusScale, // assume square pixels; UV radius in X
                 Intensity = intensity,
             });
         }

--- a/Ship_Game/Ships/Ship.cs
+++ b/Ship_Game/Ships/Ship.cs
@@ -359,6 +359,9 @@ namespace Ship_Game.Ships
 
         public bool PlayerShipCanTakeFleetOrders(bool forAttack = false)
         {
+            if (!Active)
+                return false;
+
             if (Loyalty.isPlayer)
             {
                 if (!forAttack && (IsPlatformOrStation || IsSubspaceProjector))

--- a/Ship_Game/Universe/ExplorableGameObject.cs
+++ b/Ship_Game/Universe/ExplorableGameObject.cs
@@ -1,4 +1,5 @@
-﻿using Ship_Game.Data.Serialization;
+﻿using System.Collections.Generic;
+using Ship_Game.Data.Serialization;
 using Ship_Game.Utils;
 
 namespace Ship_Game.Universe
@@ -39,7 +40,12 @@ namespace Ship_Game.Universe
 
         public bool IsResearchStationDeployedBy(Empire empire)
         {
-            return IsResearchable && empire.Universe.ResearchableSolarBodies[this].Contains(empire.Id);
+            // TryGetValue, not the throwing indexer: a save crossing a patch can restore
+            // IsResearchable=true on a body whose ResearchableSolarBodies entry is absent.
+            // Not in the map means no station is tracked there, so none is deployed.
+            return IsResearchable
+                && empire.Universe.ResearchableSolarBodies.TryGetValue(this, out HashSet<int> deployedBy)
+                && deployedBy.Contains(empire.Id);
         }
     }
 }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -95,6 +95,9 @@ namespace Ship_Game
 
         public IReadOnlyList<QueueItem> ConstructionQueue => Construction.GetConstructionQueue();
 
+        // Locked copy for cross-thread (UI) readers; see SBProduction.GetConstructionQueueSnapshot.
+        public QueueItem[] ConstructionQueueSnapshot => Construction.GetConstructionQueueSnapshot();
+
         public bool WeCanLandTroopsViaSpacePort(Empire us) => HasSpacePort && Owner == us && !SpaceCombatNearPlanet;
 
         public int CountEmpireTroops(Empire us) => Troops.NumTroopsHere(us);

--- a/Ship_Game/Universe/SolarBodies/SBProduction.cs
+++ b/Ship_Game/Universe/SolarBodies/SBProduction.cs
@@ -28,6 +28,11 @@ namespace Ship_Game.Universe.SolarBodies
         /// </summary>
         [StarData] readonly Array<QueueItem> ConstructionQueue = new();
 
+        // Cached cross-thread snapshot (see GetConstructionQueueSnapshot). Rebuilt lazily only
+        // when the queue's membership/order changes, so per-frame UI readers don't allocate.
+        QueueItem[] CachedQueueSnapshot;
+        bool QueueSnapshotDirty = true;
+
         float ProductionHere
         {
             get => P.ProdHere;
@@ -50,10 +55,19 @@ namespace Ship_Game.Universe.SolarBodies
         // Thread-safe snapshot for cross-thread (UI) readers. The live queue is
         // mutated on the sim thread under lock(ConstructionQueue), so UI code must
         // not iterate GetConstructionQueue() directly or it can index a shrinking list.
+        // The snapshot array is cached and only rebuilt when the queue's membership or
+        // order changed (QueueSnapshotDirty), so per-frame UI Draw doesn't re-allocate.
         public QueueItem[] GetConstructionQueueSnapshot()
         {
             lock (ConstructionQueue)
-                return ConstructionQueue.ToArray();
+            {
+                if (QueueSnapshotDirty || CachedQueueSnapshot == null)
+                {
+                    CachedQueueSnapshot = ConstructionQueue.IsEmpty ? Empty<QueueItem>.Array : ConstructionQueue.ToArray();
+                    QueueSnapshotDirty = false;
+                }
+                return CachedQueueSnapshot;
+            }
         }
 
         // Rush button is used only in debug mode for fast debug rush
@@ -467,6 +481,7 @@ namespace Ship_Game.Universe.SolarBodies
             lock (ConstructionQueue)
             {
                 ConstructionQueue.Add(item);
+                QueueSnapshotDirty = true;
                 if (!P.OwnerIsPlayer)
                 {
                     int totalFreighters = Owner.TotalFreighters;
@@ -500,7 +515,10 @@ namespace Ship_Game.Universe.SolarBodies
         void Finish(QueueItem q)
         {
             lock (ConstructionQueue)
+            {
                 ConstructionQueue.Remove(q);
+                QueueSnapshotDirty = true;
+            }
         }
 
         public bool Cancel(Building b)
@@ -545,7 +563,10 @@ namespace Ship_Game.Universe.SolarBodies
             }
 
             lock (ConstructionQueue)
+            {
                 ConstructionQueue.Remove(q);
+                QueueSnapshotDirty = true;
+            }
             if (q.isBuilding)
                 P.RefreshBuildingsWeCanBuildHere();
         }
@@ -649,6 +670,7 @@ namespace Ship_Game.Universe.SolarBodies
                 if ((uint)newIndex < ConstructionQueue.Count)
                 {
                     ConstructionQueue.Reorder(oldIndex, newIndex);
+                    QueueSnapshotDirty = true;
                 }
             }
         }
@@ -662,6 +684,7 @@ namespace Ship_Game.Universe.SolarBodies
                 currentIndex = currentIndex.Clamped(0, cq.Count - 1);
 
                 (cq[swapTo], cq[currentIndex]) = (cq[currentIndex], cq[swapTo]);
+                QueueSnapshotDirty = true;
             }
         }
 
@@ -672,6 +695,7 @@ namespace Ship_Game.Universe.SolarBodies
                 QueueItem item = ConstructionQueue[currentIndex];
                 ConstructionQueue.RemoveAt(currentIndex);
                 ConstructionQueue.Insert(moveTo, item);
+                QueueSnapshotDirty = true;
             }
         }
 
@@ -699,7 +723,10 @@ namespace Ship_Game.Universe.SolarBodies
         public void ClearQueue()
         {
             lock (ConstructionQueue)
+            {
                 ConstructionQueue.Clear();
+                QueueSnapshotDirty = true;
+            }
             foreach (PlanetGridSquare tile in P.TilesList)
                 tile.RemoveQueueItem(); // Clear all planned buildings from tiles
         }

--- a/Ship_Game/Universe/SolarBodies/SBProduction.cs
+++ b/Ship_Game/Universe/SolarBodies/SBProduction.cs
@@ -47,6 +47,15 @@ namespace Ship_Game.Universe.SolarBodies
             return ConstructionQueue;
         }
 
+        // Thread-safe snapshot for cross-thread (UI) readers. The live queue is
+        // mutated on the sim thread under lock(ConstructionQueue), so UI code must
+        // not iterate GetConstructionQueue() directly or it can index a shrinking list.
+        public QueueItem[] GetConstructionQueueSnapshot()
+        {
+            lock (ConstructionQueue)
+                return ConstructionQueue.ToArray();
+        }
+
         // Rush button is used only in debug mode for fast debug rush
         public bool RushProduction(int itemIndex, float maxAmount, bool rushButton = false)
         {

--- a/Ship_Game/Universe/SolarBodies/TroopManager.cs
+++ b/Ship_Game/Universe/SolarBodies/TroopManager.cs
@@ -640,34 +640,51 @@ namespace Ship_Game
         }
 
         // tries to take up to N Launchable troops
+        // Snapshots under lock: callers (and parallel ship updates) can launch troops,
+        // mutating TroopsHere; a lazy iterator would index a shrinking list and throw.
         public IEnumerable<Troop> GetLaunchableTroops(Empire of, int maxToTake = int.MaxValue, bool forceLaunch = false)
         {
-            for (int i = TroopsHere.Count - 1; i >= 0; --i)
+            var result = new Array<Troop>();
+            lock (TroopsHere)
             {
-                Troop troop = TroopsHere[i];
-                if (troop.Loyalty == of && (troop.CanLaunch || forceLaunch) && maxToTake-- > 0)
-                    yield return troop;
+                for (int i = TroopsHere.Count - 1; i >= 0; --i)
+                {
+                    Troop troop = TroopsHere[i];
+                    if (troop.Loyalty == of && (troop.CanLaunch || forceLaunch) && maxToTake-- > 0)
+                        result.Add(troop);
+                }
             }
+            return result;
         }
 
         public IEnumerable<Troop> GetTroopsOf(Empire of)
         {
-            for (int i = TroopsHere.Count - 1; i >= 0; --i)
+            var result = new Array<Troop>();
+            lock (TroopsHere)
             {
-                Troop troop = TroopsHere[i];
-                if (troop.Loyalty == of)
-                    yield return troop;
+                for (int i = TroopsHere.Count - 1; i >= 0; --i)
+                {
+                    Troop troop = TroopsHere[i];
+                    if (troop.Loyalty == of)
+                        result.Add(troop);
+                }
             }
+            return result;
         }
 
         public IEnumerable<Troop> GetTroopsNotOf(Empire notOf)
         {
-            for (int i = TroopsHere.Count - 1; i >= 0; --i)
+            var result = new Array<Troop>();
+            lock (TroopsHere)
             {
-                Troop troop = TroopsHere[i];
-                if (troop.Loyalty != notOf)
-                    yield return troop;
+                for (int i = TroopsHere.Count - 1; i >= 0; --i)
+                {
+                    Troop troop = TroopsHere[i];
+                    if (troop.Loyalty != notOf)
+                        result.Add(troop);
+                }
             }
+            return result;
         }
 
         // Added by McShooterz: heal builds and troops every turn

--- a/Ship_Game/Universe/SolarBodies/TroopManager.cs
+++ b/Ship_Game/Universe/SolarBodies/TroopManager.cs
@@ -644,47 +644,47 @@ namespace Ship_Game
         // mutating TroopsHere; a lazy iterator would index a shrinking list and throw.
         public IEnumerable<Troop> GetLaunchableTroops(Empire of, int maxToTake = int.MaxValue, bool forceLaunch = false)
         {
-            var result = new Array<Troop>();
+            Array<Troop> result = null;
             lock (TroopsHere)
             {
-                for (int i = TroopsHere.Count - 1; i >= 0; --i)
+                for (int i = TroopsHere.Count - 1; i >= 0 && (result?.Count ?? 0) < maxToTake; --i)
                 {
                     Troop troop = TroopsHere[i];
-                    if (troop.Loyalty == of && (troop.CanLaunch || forceLaunch) && maxToTake-- > 0)
-                        result.Add(troop);
+                    if (troop.Loyalty == of && (troop.CanLaunch || forceLaunch))
+                        (result ??= new Array<Troop>()).Add(troop);
                 }
             }
-            return result;
+            return result ?? (IEnumerable<Troop>)Empty<Troop>.Array;
         }
 
         public IEnumerable<Troop> GetTroopsOf(Empire of)
         {
-            var result = new Array<Troop>();
+            Array<Troop> result = null;
             lock (TroopsHere)
             {
                 for (int i = TroopsHere.Count - 1; i >= 0; --i)
                 {
                     Troop troop = TroopsHere[i];
                     if (troop.Loyalty == of)
-                        result.Add(troop);
+                        (result ??= new Array<Troop>()).Add(troop);
                 }
             }
-            return result;
+            return result ?? (IEnumerable<Troop>)Empty<Troop>.Array;
         }
 
         public IEnumerable<Troop> GetTroopsNotOf(Empire notOf)
         {
-            var result = new Array<Troop>();
+            Array<Troop> result = null;
             lock (TroopsHere)
             {
                 for (int i = TroopsHere.Count - 1; i >= 0; --i)
                 {
                     Troop troop = TroopsHere[i];
                     if (troop.Loyalty != notOf)
-                        result.Add(troop);
+                        (result ??= new Array<Troop>()).Add(troop);
                 }
             }
-            return result;
+            return result ?? (IEnumerable<Troop>)Empty<Troop>.Array;
         }
 
         // Added by McShooterz: heal builds and troops every turn

--- a/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
+++ b/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
@@ -219,7 +219,8 @@ namespace Ship_Game.Universe
         {
             fleet.FinalPosition = shipToAttack.Position;
             fleet.AssignPositions(Vectors.Up);
-            if (fleet.Ships.Any(s => s.Position.Distance(shipToAttack.Position) > 7500f
+            if (fleet.Ships.Any(s => s.Active
+                   && s.Position.Distance(shipToAttack.Position) > 7500f
                    && !HelperFunctions.CanExitWarpForChangingDirectionByCommand([s], s.AI.PotentialTargets)))
             {
                 GameAudio.NegativeClick();

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.UpdateGame.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.UpdateGame.cs
@@ -17,6 +17,13 @@ namespace Ship_Game
         public bool CreateSimThread = true;
         Thread SimThread;
 
+        /// <summary>
+        /// True when the caller is already on the simulation thread (or no sim thread exists,
+        /// e.g. headless/unit-test runs). Used to decide whether a sim-state mutation must be
+        /// marshaled via RunOnSimThread() or can run inline.
+        /// </summary>
+        public bool IsOnSimThread => SimThread == null || Thread.CurrentThread == SimThread;
+
         // This is our current time in simulation time axis [0 .. current .. target]
         public float CurrentSimTime;
 

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.cs
@@ -806,7 +806,15 @@ namespace Ship_Game
             Thread processTurnsThread = SimThread;
             SimThread = null;
             DrawCompletedEvt.Set(); // notify processTurnsThread that we're terminating
-            processTurnsThread?.Join(250);
+
+            // Wait for the in-flight simulation turn to finish before Dispose() below tears
+            // down UState (which disposes every Planet/Ship). A single turn is bounded, but a
+            // heavy one (e.g. an empire federation AbsorbEmpire) on a memory-pressured machine
+            // can take far longer than the old 250ms timeout. Disposing underneath a running
+            // turn makes the sim thread dereference a disposed planet (NRE in ProcessTurns).
+            // Use a generous timeout that still guards against a genuinely stuck thread.
+            if (processTurnsThread != null && !processTurnsThread.Join(10_000))
+                Log.Warning("UniverseScreen.ExitScreen: sim thread did not stop within 10s; tearing down anyway");
 
             RemoveLighting();
             ScreenManager.StopMusic();

--- a/StarDrive.csproj
+++ b/StarDrive.csproj
@@ -57,10 +57,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <!-- AUTOFAST defines the symbol that GlobalStats.LoadConfig checks (line ~362)
-       to flip RestrictAIPlayerInteraction = true at startup. That flag, in turn,
-       lets the AI play full-speed among itself with the player ignored — used
-       for unattended balance/perf soak runs. UniverseScreen also auto-tunes
+  <!-- AUTOFAST defines a symbol that the GlobalStats.RestrictAIPlayerInteraction
+       getter checks: under AUTO/AUTOFAST the getter returns true (runtime-only, never
+       persisted) so the AI plays full-speed among itself with the player ignored —
+       used for unattended balance/perf soak runs. UniverseScreen also auto-tunes
        simulation FPS when the flag is on. Otherwise these mirror Debug/Release
        settings; warning gate stays off here per §4.3 (Release|x64 only). -->
   <PropertyGroup Condition="'$(Configuration)' == 'Debug - Auto Fast'">

--- a/UnitTests/Universe/ThreatMatrixTests.cs
+++ b/UnitTests/Universe/ThreatMatrixTests.cs
@@ -93,6 +93,38 @@ public class ThreatMatrixTests : StarDriveTest
             owner.Threats.Update(new(time:2.0f));
     }
 
+    // Regression: a planet's sensor coverage must be centered on the planet itself,
+    // not on the solar system center. While it was centered on the star (Mars 1.50),
+    // a planet orbiting beyond its sensor range got zero coverage around itself, so a
+    // bare outpost never detected ships circling it. ScanForShipsFromPlanet scans around
+    // node.Position, so asserting the node is centered on the planet guards detection too.
+    [TestMethod]
+    public void PlanetSensorNodeIsCenteredOnThePlanetNotTheStar()
+    {
+        // a planet well offset from its system center
+        Planet planet = AddDummyPlanet(new(500_000, 500_000), 1, 1, 0,
+            pos: new(560_000, 500_000), explored: false);
+        planet.SetOwner(Player);
+        AssertTrue(planet.Position.Distance(planet.System.Position) > 1000f,
+            "test setup: planet must be offset from its system center");
+
+        // ResetBorders (which builds SensorNodes) runs inside Objects.Update
+        UState.Objects.Update(new(time: 1f));
+
+        bool found = false;
+        Empire.InfluenceNode[] nodes = Player.SensorNodes;
+        for (int i = 0; i < nodes.Length; ++i)
+        {
+            if (nodes[i].Source == planet)
+            {
+                found = true;
+                AssertEqual(planet.Position, nodes[i].Position,
+                    "Planet sensor coverage must be centered on the planet, not the system center");
+            }
+        }
+        AssertTrue(found, "Player must have a sensor node for its owned planet");
+    }
+
     [TestMethod]
     public void FindClusters_OfASingleEmpire()
     {


### PR DESCRIPTION
Rolling `fixes_24` batch off `main` for Jupiter 1.60 — a set of mostly-independent stability/AI bugfixes. Each commit is self-contained.

## Remnants / AI combat
- **Portals never fought in place or scrambled defense** (`c6c4965`): a tethered, engine-less portal kept issuing an `AIState.Pursue` overtake move it could never complete, which set `HasPriorityOrder` and suppressed combat entry, so `Ship.InCombat` never latched and the Ancient Defense Fleet never spawned. Guard `ShouldTryOvertakeTarget` with `IsStationary`, and trigger `ScrambleDefense` on `InCombat && (hull < 99% || shield < 80%)` so heavily-shielded portals respond before hull damage.
- **Fleets deadlocking at a rally held only by harmless enemy structures** (`0f645b6`): switch the gate from `HostileForcesPresent` to `DangerousForcesPresent` (requires real strength/troops/meteor).
- **Dying ship NRE-ing fleet attack orders** (`b291f00`): gate order-issuing on `Ship.Active`.

## Sim-thread / concurrency
- **UniverseScreen exit disposing sim state mid-turn** (`4339373`): `ExitScreen` waited only 250 ms before `Dispose()` tore down `UState`; a heavy in-flight turn (e.g. an empire `AbsorbEmpire`) then dereferenced a disposed planet. Wait for the bounded turn to finish (10 s cap with a warning).
- **Construction queue cross-thread reads** (`cdc8345`): UI now reads a locked snapshot instead of the live list.
- **TroopsHere enumeration crashing under parallel ship updates** (`d81efc5`): materialize troop reads under lock.

## Crash guards
- **Research body missing from the map** (`d9c2a98`) and **meteor wiping an Unknown-faction colony** (`f7a5af0`): replace throwing map indexers with `TryGetValue` / `GetRelations(out)`.

## Config / dev-tooling
- **AUTO builds leaking `RestrictAIPlayerInteraction` into the shared user config** (`7450d30`): split the persisted setting from the runtime-forced value so an Auto soak run can't silently disable AI hostility toward the player in subsequent normal play.

## Misc
- **Planet sensor coverage centered on the planet, not the star** (`4da9fee` + test `af0d1f9`).
- **Projector dedupe error no longer logged for manual UI placement** (`5dbc58d`).

## Review
- Per-commit self-review + full-PR deep review (caller-impact, project-convention, exception-path, and sensitive-subsystem passes on threading/config/lifecycle). No blockers.
- Built Debug and Debug-Auto-Fast (0 warnings, warnings-as-errors on); ThreatMatrix + ShipAI/Combat/Remnant/Move test suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)