### PR TITLE
Jupiter 1.60 fixes_25: fleet focus-fire + SimThread crash guards

### DIFF
--- a/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.Combat.cs
@@ -5,6 +5,7 @@ using SDGraphics;
 using SDUtils;
 using Ship_Game.Data.Serialization;
 using Ship_Game.Empires;
+using Ship_Game.Fleets;
 using Ship_Game.Spatial;
 using Vector2 = SDGraphics.Vector2;
 using Vector3 = SDGraphics.Vector3;
@@ -391,6 +392,8 @@ namespace Ship_Game.AI
             return target != null && target.Active && !target.Dying;
         }
 
+        Fleet.FleetFocus FocusClump;
+
         public Ship GetHighestPriorityTarget()
         {
             if (Owner.Weapons.Count == 0 && !Owner.Carrier.HasActiveHangars)
@@ -398,6 +401,8 @@ namespace Ship_Game.AI
 
             if (PotentialTargets.Length > 0)
             {
+                Fleet governing = Owner.Fleet ?? (Owner.IsHangarShip ? Owner.Mothership?.Fleet : null);
+                FocusClump = governing?.Focus;
                 return PotentialTargets.FindMax(GetTargetPriority);
             }
             return null;
@@ -405,6 +410,9 @@ namespace Ship_Game.AI
 
         // Set this to get debug output of GetTargetPriority() weights
         public static bool EnableTargetPriorityDebug;
+
+        const float FocusClumpBias = 3f;
+        const float WarpToCloseRange = 15_000f;
 
         float GetTargetPriority(Ship tgt)
         {
@@ -446,6 +454,12 @@ namespace Ship_Game.AI
                 value *= 2.0f;
             if (tgt.Resupplying) // lower priority to enemies that are retreating
                 value *= 0.5f;
+            if (distance > WarpToCloseRange.LowerBound(Owner.DesiredCombatRange))
+            {
+                value *= 0.5f;
+                if (Owner.Inhibited)
+                    value *= 0.2f;
+            }
 
             // Prefer closer targets: gently (linear) inside weapon range so the
             // ship commits to the single nearest in-range target, steeply (cubed)
@@ -454,8 +468,7 @@ namespace Ship_Game.AI
             value /= distanceNorm <= 1f ? distanceNorm : distanceNorm * distanceNorm * distanceNorm;
             if (debug) Debug($"dn={distanceNorm.String(2),-4}");
 
-            // prefer targets near our own size; the size multiplier is floored at
-            // 0.05 so nothing is ever fully ignored on size alone.
+            // prefer targets near our own size; floored low so a lone small ship is still pickable
             float relSize = (float)tgt.SurfaceArea / Owner.SurfaceArea;
             if (relSize < 1f)
             {
@@ -463,7 +476,7 @@ namespace Ship_Game.AI
                 if (Owner.ShipData.HangarDesignation == HangarOptions.Interceptor)
                     value *= (1 / relSize);
                 else
-                    value *= (relSize * relSize).LowerBound(0.05f);
+                    value *= (relSize * relSize).LowerBound(0.005f);
             }
             else if (relSize > 1f)
             {
@@ -479,6 +492,10 @@ namespace Ship_Game.AI
                 else
                     value *= (relSize <= 2f ? relSize : 4f / relSize).LowerBound(0.05f);
             }
+
+            // fleet focus-fire: boost targets inside the fleet's committed clump
+            if (FocusClump != null && tgt.Position.InRadius(FocusClump.Center, FocusClump.Radius))
+                value *= FocusClumpBias;
 
             // keep reserach and mining stations as very low priority targets
             if (tgt.IsResearchStation || tgt.IsMiningStation)

--- a/Ship_Game/AI/ShipAI/ShipAI.cs
+++ b/Ship_Game/AI/ShipAI/ShipAI.cs
@@ -211,9 +211,8 @@ namespace Ship_Game.AI
         {
             get
             {
-                if (OrderQueue.NotEmpty)
+                if (OrderQueue.TryPeekFirst(out ShipGoal goal) && goal != null)
                 {
-                    ShipGoal goal = OrderQueue.PeekFirst;
                     Vector2 pos = goal.TargetPlanet?.Position ?? goal.MovePosition;
                     if (pos.NotZero())
                         return pos;

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -2789,12 +2789,14 @@ namespace Ship_Game.Fleets
                 return;
             }
 
-            // closest killable: clusters are distance-sorted, take the nearest we can favourably engage
+            // closest killable: clusters are distance-sorted, take the nearest we can favourably engage.
+            // Weight enemy strength by the per-empire fleet multiplier (Remnants/difficulty scaling),
+            // matching CanTakeThisFight and the cluster-distribution code above.
             float killable = GetStrength() * (Owner.PersonalityModifiers?.CanWeTakeThisFightMultiplier ?? 1f);
             ThreatCluster chosen = null;
             for (int i = 0; i < clusters.Length; i++)
             {
-                if (clusters[i].Strength <= killable)
+                if (clusters[i].Strength * Owner.GetFleetStrEmpireMultiplier(clusters[i].Loyalty) <= killable)
                 {
                     chosen = clusters[i];
                     break;

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -10,6 +10,7 @@ using Ship_Game.Fleets.FleetTactics;
 using Ship_Game.AI;
 using Ship_Game.Commands.Goals;
 using Ship_Game.Data.Serialization;
+using Ship_Game.Empires;
 using Vector2 = SDGraphics.Vector2;
 using Ship_Game.Universe;
 using Microsoft.Xna.Framework;
@@ -32,6 +33,13 @@ namespace Ship_Game.Fleets
         [StarData] public string Name = "";
         public ShipAI.TargetParameterTotals TotalFleetAttributes;
         public ShipAI.TargetParameterTotals AverageFleetAttributes;
+
+        // immutable focus-fire snapshot; swapped atomically on the sim thread, read lock-free by ship-update threads
+        public FleetFocus Focus { get; private set; }
+        float FocusClumpTimer;
+        const float MinFocusSearchRadius = 50_000f;
+
+        public sealed record FleetFocus(Vector2 Center, float Radius);
 
         [StarData] readonly Array<Ship> CenterShips  = new();
         [StarData] readonly Array<Ship> LeftShips    = new();
@@ -2756,6 +2764,40 @@ namespace Ship_Game.Fleets
                            && readyWarpSurface >= totalWarpSurface * WarpReadySurfaceRatio;
             TotalFleetAttributes = fleetTotals;
             AverageFleetAttributes = TotalFleetAttributes.GetAveragedValues();
+
+            UpdateFocusClump(timeStep);
+        }
+
+        void UpdateFocusClump(FixedSimTime timeStep)
+        {
+            FocusClumpTimer -= timeStep.FixedTime;
+            if (FocusClumpTimer > 0f)
+                return;
+            FocusClumpTimer += EmpireConstants.TargetSelectionInterval;
+
+            Vector2 pos = AveragePosition();
+            float searchRadius = AverageFleetAttributes.MaxSensorRange.LowerBound(MinFocusSearchRadius);
+            ThreatCluster[] clusters = Owner.AI.ThreatMatrix.FindHostileClustersByDist(pos, searchRadius);
+            if (clusters.Length == 0)
+            {
+                Focus = null;
+                return;
+            }
+
+            // closest killable: clusters are distance-sorted, take the nearest we can favourably engage
+            float killable = GetStrength() * (Owner.PersonalityModifiers?.CanWeTakeThisFightMultiplier ?? 1f);
+            ThreatCluster chosen = null;
+            for (int i = 0; i < clusters.Length; i++)
+            {
+                if (clusters[i].Strength <= killable)
+                {
+                    chosen = clusters[i];
+                    break;
+                }
+            }
+            chosen ??= clusters[0]; // nothing killable -> still commit to the closest
+
+            Focus = new FleetFocus(chosen.Position, chosen.Radius);
         }
 
         public void OffensiveTactic()

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -849,6 +849,9 @@ namespace Ship_Game.Fleets
 
         bool ShouldGatherAtRallyFirst(MilitaryTask task)
         {
+            if (task.RallyPlanet?.System == null)
+                return false;
+
             Vector2 enemySystemPos = task.TargetSystem?.Position ?? task.TargetPlanet.System.Position;
             Vector2 rallySystemPos = task.RallyPlanet.System.Position;
             Vector2 fleetPos       = AveragePosition(force: true);

--- a/Ship_Game/Fleets/Fleet.cs
+++ b/Ship_Game/Fleets/Fleet.cs
@@ -34,7 +34,9 @@ namespace Ship_Game.Fleets
         public ShipAI.TargetParameterTotals TotalFleetAttributes;
         public ShipAI.TargetParameterTotals AverageFleetAttributes;
 
-        // immutable focus-fire snapshot; swapped atomically on the sim thread, read lock-free by ship-update threads
+        // immutable focus-fire snapshot; written on the sim or input thread (Fleet.Update),
+        // swapped via a single atomic reference assignment so the parallel ship-update phase
+        // reads it lock-free and always sees a complete old-or-new snapshot
         public FleetFocus Focus { get; private set; }
         float FocusClumpTimer;
         const float MinFocusSearchRadius = 50_000f;

--- a/Ship_Game/Ships/ShipModule.cs
+++ b/Ship_Game/Ships/ShipModule.cs
@@ -1106,8 +1106,10 @@ namespace Ship_Game.Ships
             if (HangarTimer <= 0f && HangarShip == null) // launch the troopship
             {
                 string assaultShuttle = Parent.Loyalty.GetAssaultShuttleName();
-                ship = Ship.CreateTroopShipAtPoint(Parent.Universe, assaultShuttle, Parent.Loyalty, 
+                ship = Ship.CreateTroopShipAtPoint(Parent.Universe, assaultShuttle, Parent.Loyalty,
                     Position, troop, LaunchPlan.Hangar, rotationDeg: ActualRotationDegrees);
+                if (ship == null)
+                    return false;
 
                 Parent.OnShipLaunched(ship, this);
                 HangarShip.DoEscort(Parent);

--- a/Ship_Game/Ships/Ship_Initialize.cs
+++ b/Ship_Game/Ships/Ship_Initialize.cs
@@ -392,6 +392,8 @@ namespace Ship_Game.Ships
             Vector2 point, Troop troop, LaunchPlan launchPlan, float rotationDeg = -1f)
         {
             Ship ship = CreateShipAtPoint(us, shipName, owner, point);
+            if (ship == null)
+                return null;
             ship.VanityName = troop.DisplayName;
             troop.LandOnShip(ship);
             ship.InitLaunch(launchPlan, rotationDeg);

--- a/Ship_Game/Ships/Ship_Troop.cs
+++ b/Ship_Game/Ships/Ship_Troop.cs
@@ -220,8 +220,10 @@ namespace Ship_Game.Ships
             for (int i = 0; i < troopsToRemove && i < toRemove.Length; ++i)
             {
                 Troop troop = toRemove[i];
-                Ship assaultShip = CreateTroopShipAtPoint(Universe, Loyalty.GetAssaultShuttleName(), 
+                Ship assaultShip = CreateTroopShipAtPoint(Universe, Loyalty.GetAssaultShuttleName(),
                     Loyalty, Position, troop, LaunchPlan.Hangar);
+                if (assaultShip == null)
+                    continue;
 
                 assaultShip.Velocity = Velocity + Loyalty.Random.Direction2D() * assaultShip.MaxSTLSpeed;
                 Ship friendlyTroopShipToRebase = FindClosestAllyToRebase(assaultShip);

--- a/Ship_Game/Ships/Ship_Troop.cs
+++ b/Ship_Game/Ships/Ship_Troop.cs
@@ -305,8 +305,11 @@ namespace Ship_Game.Ships
             float currentHealPoints = totalHealPoints;
             for (int i = 0; i < OurTroops.Count; i++)
             {
+                // OurTroops can be torn-read while another thread clears/removes troops
+                // (e.g. the ship dies during this planet-supply heal); skip null slots,
+                // matching the ship==null guard in GeodeticManager.AffectNearbyShips.
                 Troop troop = OurTroops[i];
-                if (troop.IsWounded)
+                if (troop != null && troop.IsWounded)
                 {
                     troop.HealTroop(1);
                     currentHealPoints -= 1;

--- a/Ship_Game/Universe/SolarBodies/GeodeticManager.cs
+++ b/Ship_Game/Universe/SolarBodies/GeodeticManager.cs
@@ -175,7 +175,10 @@ namespace Ship_Game.Universe.SolarBodies // Fat Bastard - Refactored March 21, 2
             for (int i = 0; i < ParentSystem.ShipList.Count; i++)
             {
                 Ship ship = ParentSystem.ShipList[i];
-                if (ship == null)
+                // skip dead ships still lingering in ShipList: Active flips false in
+                // QueueTotalRemoval before their troops/modules are torn down
+                // (OurTroops.Clear / = null), which would NRE in SupplyShip below.
+                if (ship == null || !ship.Active)
                     continue;
 
                 bool loyaltyMatch = ship.Loyalty == Owner || ship.Loyalty.IsAlliedWith(Owner);

--- a/UnitTests/Fleets/FleetFocusFireTests.cs
+++ b/UnitTests/Fleets/FleetFocusFireTests.cs
@@ -1,0 +1,106 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SDUtils;
+using Ship_Game;
+using Ship_Game.Fleets;
+using Ship_Game.Ships;
+using Ship_Game.Utils;
+using Vector2 = SDGraphics.Vector2;
+
+namespace UnitTests.Fleets;
+
+// Fleet focus-fire: the fleet commits to ONE hostile threat cluster (its Focus) so member
+// ships converge fire instead of each independently spreading. Doctrine is "closest
+// killable" - the nearest cluster the fleet can favourably engage.
+[TestClass]
+public class FleetFocusFireTests : StarDriveTest
+{
+    const string COMBAT_SHIP = "Terran-Prototype";
+    const string SCOUT = "TEST_Vulcan Scout";
+
+    public FleetFocusFireTests()
+    {
+        LoadStarterShips(COMBAT_SHIP, SCOUT);
+        CreateUniverseAndPlayerEmpire();
+        UState.Events.Disabled = true;
+    }
+
+    float SpawnClump(Vector2 pos, Empire owner, string shipName, int numShips)
+    {
+        var random = new SeededRandom(1337);
+        float strength = 0f;
+        for (int i = 0; i < numShips; ++i)
+            strength += SpawnShip(shipName, owner, pos + random.Vector2D(2000)).GetStrength();
+        return strength;
+    }
+
+    Fleet CreatePlayerFleetAt(Vector2 pos, int numShips)
+    {
+        var ships = new Array<Ship>();
+        for (int i = 0; i < numShips; ++i)
+            ships.Add(SpawnShip(COMBAT_SHIP, Player, pos + new Vector2(i * 500, 0)));
+
+        Fleet fleet = Player.CreateFleet(1, null);
+        fleet.AddShips(ships);
+        return fleet;
+    }
+
+    void ScanAndUpdateThreats()
+    {
+        UState.Objects.Update(new(time: 2.0f));
+        Player.Threats.Update(new(time: 2.0f));
+    }
+
+    [TestMethod]
+    public void FleetCommitsToClosestKillableClump()
+    {
+        Vector2 near = new(15_000, 0);
+        Vector2 far  = new(45_000, 0);
+
+        Fleet fleet = CreatePlayerFleetAt(Vector2.Zero, 4);
+
+        // pickets to guarantee the empire observes BOTH enemy clumps (the fleet only reads
+        // empire-wide ThreatMatrix intel, so vision can come from anywhere we own)
+        SpawnShip(SCOUT, Player, near);
+        SpawnShip(SCOUT, Player, far);
+
+        // two weak (killable) enemy clumps, near and far
+        SpawnClump(near, Enemy, SCOUT, 4);
+        SpawnClump(far,  Enemy, SCOUT, 4);
+        ScanAndUpdateThreats();
+
+        fleet.Update(FixedSimTime.Zero);
+
+        AssertTrue(fleet.Focus != null, "Fleet must commit to a focus clump when hostiles are known");
+        AssertTrue(fleet.Focus.Center.Distance(near) < fleet.Focus.Center.Distance(far),
+            $"Focus must be the nearer clump. Focus.Center={fleet.Focus.Center}");
+    }
+
+    [TestMethod]
+    public void FleetSkipsTooStrongClumpForKillableFar()
+    {
+        Vector2 near = new(15_000, 0);
+        Vector2 far  = new(45_000, 0);
+
+        // small fleet so the near clump out-muscles it
+        Fleet fleet = CreatePlayerFleetAt(Vector2.Zero, 2);
+
+        SpawnShip(SCOUT, Player, near);
+        SpawnShip(SCOUT, Player, far);
+
+        // near clump is a wall of combat ships (NOT killable); far clump is a couple of
+        // scouts (killable)
+        float nearStr = SpawnClump(near, Enemy, COMBAT_SHIP, 12);
+        SpawnClump(far, Enemy, SCOUT, 2);
+        ScanAndUpdateThreats();
+
+        fleet.Update(FixedSimTime.Zero);
+
+        // setup sanity: the near clump really is too strong to take
+        AssertTrue(nearStr > fleet.GetStrength(),
+            $"test setup: near clump ({nearStr}) must out-strength the fleet ({fleet.GetStrength()})");
+
+        AssertTrue(fleet.Focus != null, "Fleet must still commit to a focus clump");
+        AssertTrue(fleet.Focus.Center.Distance(far) < fleet.Focus.Center.Distance(near),
+            $"Focus must skip the too-strong near clump for the killable far one. Focus.Center={fleet.Focus.Center}");
+    }
+}

--- a/UnitTests/SDUnitTests.csproj
+++ b/UnitTests/SDUnitTests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Data\TestLocalizedText.cs" />
     <Compile Include="Empires\IncomingThreatDetectorTests.cs" />
     <Compile Include="ExoticSystems\ResearchStations.cs" />
+    <Compile Include="Fleets\FleetFocusFireTests.cs" />
     <Compile Include="Fleets\FleetTests.cs" />
     <Compile Include="Graphics\BloomFilterTests.cs" />
     <Compile Include="Graphics\DistortionComponentTests.cs" />


### PR DESCRIPTION
## Summary

The `fixes_25` batch off `main`. Two themes: a combat improvement (fleet focus-fire) plus five late-game SimThread crash guards.

### Combat: fleet focus-fire + target-priority tuning
- Each `Fleet` now computes a `Focus` clump — the closest hostile `ThreatCluster` it can favourably engage ("closest killable", falling back to the nearest cluster when nothing is killable). Recomputed once per `TargetSelectionInterval` on the sim thread, stored as an immutable `FleetFocus` record and swapped via a single atomic reference assignment so the parallel ship-update phase reads it lock-free.
- Member ships (and their hangar fighters via the mothership's fleet) bias target priority toward targets inside that clump (`FocusClumpBias`), so the fleet converges fire instead of each ship spreading independently.
- Target-priority tuning: deprioritize distant / warp-range targets (and harder when inhibited), and lower the small-ship size floor so a lone small ship stays pickable.
- New `FleetFocusFireTests` covering both doctrine branches (closest-killable, skip-too-strong-for-killable-far).

### Crash: SimThread null / torn-read guards
Late-game cross-thread null dereferences in the sim/draw split (dead objects linger `Active=false` before teardown; collections torn-read mid-clear):
- `ShipAI.GoalTarget` — atomic `TryPeekFirst` instead of `NotEmpty` + `PeekFirst`.
- `Fleet.ShouldGatherAtRallyFirst` — guard null `RallyPlanet.System`.
- `GeodeticManager.AffectNearbyShips` — skip dead ships (`!Active`).
- `Ship.HealTroops` — skip torn-read null troop slots.
- Assault-launch / `CreateTroopShipAtPoint` — handle null troop-ship creation; all three call sites guarded.

## Review
Full-PR review run (threading deep-pass): no blockers. Concurrency claim verified — `Focus` written only from `Fleet.Update`, atomic ref swap of an immutable payload, per-ship `FocusClump` cache is single-threaded per AI pass. All changed-signature callers (`CreateTroopShipAtPoint` null return) accounted for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)