### PR TITLE
Colony: honor orbital/shipyard caps in shift/ctrl batch builds

### DIFF
--- a/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Build.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Build.cs
@@ -262,9 +262,12 @@ namespace Ship_Game
 
         public void Build(IShipDesign ship, int repeat = 1)
         {
+            // Orbitals are added via marshalled goals that don't apply until the sim thread runs,
+            // so the limit check can't see what we queued earlier in this same loop. Track it locally.
+            int orbitalsQueued = 0;
             for (int i = 0; i < repeat; i++)
             {
-                if (P.IsOutOfOrbitalsLimit(ship))
+                if (P.IsOutOfOrbitalsLimit(ship, orbitalsQueued))
                 {
                     GameAudio.NegativeClick();
                     return;
@@ -273,6 +276,7 @@ namespace Ship_Game
                 if (ship.IsPlatformOrStation || ship.IsShipyard)
                 {
                     P.AddOrbital(ship);
+                    orbitalsQueued++;
                 }
                 else
                 {

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
@@ -334,13 +334,16 @@ namespace Ship_Game
         public int NumPlatforms => FilterOrbitals(RoleName.platform).Count;
         public int NumStations  => FilterOrbitals(RoleName.station).Count;
 
-        public bool IsOutOfOrbitalsLimit(IShipDesign ship) => IsOutOfOrbitalsLimit(ship, Owner, 0);
-        public bool IsOverOrbitalsLimit(IShipDesign ship)  => IsOutOfOrbitalsLimit(ship, Owner, 1);
+        // extraPending: orbitals already queued in the same batch that the marshalled goal-add
+        // (RunOnSimThread) hasn't applied to the empire goals list yet, so OrbitalsBeingBuilt/
+        // ShipyardsBeingBuilt still under-counts them. Callers that enqueue in a tight loop pass it.
+        public bool IsOutOfOrbitalsLimit(IShipDesign ship, int extraPending = 0) => IsOutOfOrbitalsLimit(ship, Owner, 0, extraPending);
+        public bool IsOverOrbitalsLimit(IShipDesign ship)  => IsOutOfOrbitalsLimit(ship, Owner, 1, 0);
 
-        bool IsOutOfOrbitalsLimit(IShipDesign ship, Empire owner, int overLimit)
+        bool IsOutOfOrbitalsLimit(IShipDesign ship, Empire owner, int overLimit, int extraPending)
         {
-            int numOrbitals  = OrbitalStations.Count + OrbitalsBeingBuilt(ship.Role, owner);
-            int numShipyards = OrbitalStations.Count(s => s.ShipData.IsShipyard) + ShipyardsBeingBuilt(owner);
+            int numOrbitals  = OrbitalStations.Count + OrbitalsBeingBuilt(ship.Role, owner) + extraPending;
+            int numShipyards = OrbitalStations.Count(s => s.ShipData.IsShipyard) + ShipyardsBeingBuilt(owner) + extraPending;
             if (numOrbitals >= ShipBuilder.OrbitalsLimit + overLimit && ship.IsPlatformOrStation)
                 return true;
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_BuildDefenses.cs
@@ -337,6 +337,9 @@ namespace Ship_Game
         // extraPending: orbitals already queued in the same batch that the marshalled goal-add
         // (RunOnSimThread) hasn't applied to the empire goals list yet, so OrbitalsBeingBuilt/
         // ShipyardsBeingBuilt still under-counts them. Callers that enqueue in a tight loop pass it.
+        // Assumes a homogeneous batch (one design repeated): extraPending is added to both the orbital
+        // and shipyard counts, which is only safe because the unused count's gate can't fire for that
+        // design (a platform never trips the shipyard branch). Mixed-design batches would miscount.
         public bool IsOutOfOrbitalsLimit(IShipDesign ship, int extraPending = 0) => IsOutOfOrbitalsLimit(ship, Owner, 0, extraPending);
         public bool IsOverOrbitalsLimit(IShipDesign ship)  => IsOutOfOrbitalsLimit(ship, Owner, 1, 0);
 

--- a/UnitTests/Planets/TestOrbitalBuildLimit.cs
+++ b/UnitTests/Planets/TestOrbitalBuildLimit.cs
@@ -1,0 +1,80 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ship_Game;
+using Ship_Game.AI;
+using Ship_Game.Ships;
+using Vector2 = SDGraphics.Vector2;
+#pragma warning disable CA2213
+
+namespace UnitTests.Planets;
+
+// Colony screen "+" button shift/ctrl-clicks queue 5/10 orbitals in one batch. The orbital build
+// limit (ShipBuilder.OrbitalsLimit platforms+stations, ShipBuilder.ShipYardsLimit shipyards) is
+// enforced via Planet.IsOutOfOrbitalsLimit, which counts pending build goals. Those goals are added
+// on the sim thread (deferred via RunOnSimThread), so a tight batch loop can't see what it already
+// queued earlier in the same loop - it must pass the in-batch count through extraPending. These
+// tests pin that extraPending accounting so a batch can never breach either limit.
+[TestClass]
+public class TestOrbitalBuildLimit : StarDriveTest
+{
+    readonly Planet Homeworld;
+    readonly IShipDesign Platform;
+    readonly IShipDesign Shipyard;
+
+    public TestOrbitalBuildLimit()
+    {
+        LoadStarterShips("Platform Base mk1-a", "Shipyard");
+        CreateUniverseAndPlayerEmpire();
+        Homeworld = AddHomeWorldToEmpire(new Vector2(2000), Player);
+        Platform  = ResourceManager.GetShipTemplate("Platform Base mk1-a").ShipData;
+        Shipyard  = ResourceManager.GetShipTemplate("Shipyard").ShipData;
+
+        // Guard the assumptions the threshold tests rely on: design roles and an empty baseline.
+        Assert.IsTrue(Platform.IsPlatformOrStation && !Platform.IsShipyard, "Platform design role changed");
+        Assert.IsTrue(Shipyard.IsShipyard, "Shipyard design role changed");
+        Assert.AreEqual(0, Homeworld.OrbitalStations.Count, "Fresh homeworld must start with no orbital stations");
+        Assert.AreEqual(0, Homeworld.OrbitalsBeingBuilt(Platform.Role), "Fresh homeworld must have no pending orbital goals");
+    }
+
+    [TestMethod]
+    public void FreshPlanet_IsNotOutOfLimit()
+    {
+        Assert.IsFalse(Homeworld.IsOutOfOrbitalsLimit(Platform), "A planet with no orbitals should allow building");
+        Assert.IsFalse(Homeworld.IsOutOfOrbitalsLimit(Shipyard), "A planet with no shipyards should allow building");
+    }
+
+    [TestMethod]
+    public void PlatformBatch_StopsAtOrbitalsLimit()
+    {
+        // extraPending models orbitals already queued earlier in the same batch (shift/ctrl click).
+        // One slot below the limit is still buildable; reaching the limit blocks the rest of the batch.
+        Assert.IsFalse(Homeworld.IsOutOfOrbitalsLimit(Platform, ShipBuilder.OrbitalsLimit - 1),
+            "Should still allow the last orbital before the limit");
+        Assert.IsTrue(Homeworld.IsOutOfOrbitalsLimit(Platform, ShipBuilder.OrbitalsLimit),
+            "Must block once the in-batch count reaches the orbitals limit");
+    }
+
+    [TestMethod]
+    public void ShipyardBatch_StopsAtShipyardLimit()
+    {
+        // Shipyards have their own, much smaller limit on top of the shared orbitals limit.
+        Assert.IsFalse(Homeworld.IsOutOfOrbitalsLimit(Shipyard, ShipBuilder.ShipYardsLimit - 1),
+            "Should still allow the last shipyard before the shipyard limit");
+        Assert.IsTrue(Homeworld.IsOutOfOrbitalsLimit(Shipyard, ShipBuilder.ShipYardsLimit),
+            "Must block once the in-batch count reaches the shipyard limit");
+    }
+
+    [TestMethod]
+    public void ExistingOrbitalsCountAgainstBatch()
+    {
+        // Seed real stations so the baseline isn't empty; the batch headroom shrinks accordingly.
+        const int seeded = 5;
+        for (int i = 0; i < seeded; i++)
+            Homeworld.OrbitalStations.Add(SpawnShip("Platform Base mk1-a", Player, new Vector2(3000 + i*50)));
+
+        int headroom = ShipBuilder.OrbitalsLimit - seeded;
+        Assert.IsFalse(Homeworld.IsOutOfOrbitalsLimit(Platform, headroom - 1),
+            "With existing stations, the batch can still fill the remaining slots");
+        Assert.IsTrue(Homeworld.IsOutOfOrbitalsLimit(Platform, headroom),
+            "Existing stations plus the in-batch count must not exceed the orbitals limit");
+    }
+}

--- a/UnitTests/Planets/TestOrbitalBuildLimit.cs
+++ b/UnitTests/Planets/TestOrbitalBuildLimit.cs
@@ -30,9 +30,14 @@ public class TestOrbitalBuildLimit : StarDriveTest
 
         // Guard the assumptions the threshold tests rely on: design roles and an empty baseline.
         Assert.IsTrue(Platform.IsPlatformOrStation && !Platform.IsShipyard, "Platform design role changed");
-        Assert.IsTrue(Shipyard.IsShipyard, "Shipyard design role changed");
+        // A shipyard must consume BOTH a shipyard slot and a shared orbital slot - if it ever stopped
+        // counting as IsPlatformOrStation the orbital-cap branch would silently skip it.
+        Assert.IsTrue(Shipyard.IsShipyard && Shipyard.IsPlatformOrStation,
+            "Shipyard must count as both a shipyard and an orbital");
         Assert.AreEqual(0, Homeworld.OrbitalStations.Count, "Fresh homeworld must start with no orbital stations");
-        Assert.AreEqual(0, Homeworld.OrbitalsBeingBuilt(Platform.Role), "Fresh homeworld must have no pending orbital goals");
+        Assert.AreEqual(0, Homeworld.OrbitalsBeingBuilt(Platform.Role), "Fresh homeworld must have no pending platform goals");
+        Assert.AreEqual(0, Homeworld.OrbitalsBeingBuilt(Shipyard.Role), "Fresh homeworld must have no pending station goals");
+        Assert.AreEqual(0, Homeworld.ShipyardsBeingBuilt(), "Fresh homeworld must have no pending shipyard goals");
     }
 
     [TestMethod]

--- a/UnitTests/SDUnitTests.csproj
+++ b/UnitTests/SDUnitTests.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Planets\CapitalTransfer.cs" />
     <Compile Include="Planets\LandOnTiles.cs" />
     <Compile Include="Planets\TestOrbitalBomb.cs" />
+    <Compile Include="Planets\TestOrbitalBuildLimit.cs" />
     <Compile Include="Planets\TestRefitQueuePlacement.cs" />
     <Compile Include="Planets\TestSabotageWorkDistribution.cs" />
     <Compile Include="Serialization\BinaryReadWriteTests.cs" />


### PR DESCRIPTION
## Problem
In the colony screen build list, the **+** button supports shift-click (queue 5) and ctrl-click (queue 10). For orbitals there are build caps — `ShipBuilder.OrbitalsLimit` (27 platforms+stations) and a separate `ShipBuilder.ShipYardsLimit` (3 shipyards). Shift/ctrl batch-queuing **breached both caps**.

## Root cause
`Planet.AddOrbital(ship)` enqueues via `Owner.AI.AddGoal(...)`, which marshals `GoalsList.Add(goal)` onto the sim thread (`RunOnSimThread`) — so the add is **deferred, not synchronous**. `IsOutOfOrbitalsLimit` counts pending orbitals by scanning the empire goals list (`OrbitalsBeingBuilt`/`ShipyardsBeingBuilt`). Inside the tight `for (i < repeat)` loop in `ColonyScreen.Build`, none of the just-queued goals have landed yet, so every iteration reads the same stale count and the whole batch passes the gate.

## Fix
- Thread an `extraPending` count through `IsOutOfOrbitalsLimit` (added to both the orbital and shipyard counts).
- The `Build` loop tracks how many it already queued this batch (`orbitalsQueued`) and passes it in, so the cap is honored per item.
- A shipyard satisfies both `IsPlatformOrStation` and `IsShipyard`, so it correctly consumes one orbital slot and one shipyard slot.

All other callers of `IsOutOfOrbitalsLimit` / `IsOverOrbitalsLimit` are single-build and take the new `extraPending=0` default — behavior unchanged.

## Tests
Adds `TestOrbitalBuildLimit` (4 cases) pinning the `extraPending` contract for both caps, including a baseline-with-existing-stations case. The tests fail if `extraPending` is dropped from the count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)