### PR TITLE
Fix fertility displayed as -0 (#325)

### DIFF
--- a/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet.cs
@@ -1108,7 +1108,7 @@ namespace Ship_Game
             if (BaseFertility < totalFertility)
                 BaseFertility = (BaseFertility + 0.01f).Clamped(0, totalFertility); // FB - Slowly increase fertility to max fertility
             else if (BaseFertility > totalFertility)
-                BaseFertility = BaseFertility.Clamped(0, BaseFertility - 0.01f); // FB - Slowly decrease fertility to max fertility
+                BaseFertility = (BaseFertility - 0.01f).LowerBound(totalFertility.LowerBound(0)); // FB - Slowly decrease fertility to max fertility, never below 0
         }
 
         public void SetBaseFertility(float fertility, float maxFertility)


### PR DESCRIPTION
`UpdateBaseFertility`'s decrease branch could write a small negative `BaseFertility`: `Clamped(0, BaseFertility - 0.01f)` returns the max bound when `BaseFertility` is between 0 and 0.01, so the value went below the documented `>= 0` floor and the UI rendered it as "-0" (both reported screenshots are that transient, caught during the one planet-turn it lasts).

The fix decreases by the same 0.01 step, floored at `totalFertility` but never below 0. The negative building deficit (the "virtual counting below zero" described in the issue) still lives in `totalFertility`, so the gameplay hurdle is unchanged.

Fixes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)
