### PR TITLE
Sort fleet button ship icons big-to-small (#318)

### DIFF
--- a/Ship_Game/GameScreens/FleetDesign/FleetButton.cs
+++ b/Ship_Game/GameScreens/FleetDesign/FleetButton.cs
@@ -121,10 +121,12 @@ public class FleetButton : UIPanel
     void DrawFleetShipIcons30(SpriteBatch batch, Fleet fleet, float x, float y)
     {
         // Draw ship icons to right of button
+        // sort by role, big ships first, so the order is consistent between fleets
+        Ship[] ships = fleet.Ships.Sorted(s => (-(int)s.DesignRole, s.Name));
         Vector2 shipSpacingH = new(x, y);
-        for (int i = 0; i < fleet.Ships.Count; ++i)
+        for (int i = 0; i < ships.Length; ++i)
         {
-            Ship ship = fleet.Ships[i];
+            Ship ship = ships[i];
             RectF iconHousing = new(shipSpacingH.X, shipSpacingH.Y, 15, 15);
             shipSpacingH.X += 18f;
             if (shipSpacingH.X >= x + 180) // 10 Ships per row
@@ -151,9 +153,11 @@ public class FleetButton : UIPanel
     {
         Color color  = fleet.Owner.EmpireColor;
         Map<TacticalIcon, int> sums = new();
-        for (int i = 0; i < fleet.Ships.Count; ++i)
+        // sort by role, big ships first, so the icon groups are consistent between fleets
+        Ship[] ships = fleet.Ships.Sorted(s => (-(int)s.DesignRole, s.Name));
+        for (int i = 0; i < ships.Length; ++i)
         {
-            Ship ship = fleet.Ships[i];
+            Ship ship = ships[i];
 
             TacticalIcon icon = ship.TacticalIcon();
             if (sums.TryGetValue(icon, out int value))


### PR DESCRIPTION
Both fleet button icon modes (per-ship icons and grouped sums) iterated `fleet.Ships` in raw list order, so the icon order differed between fleets and made them hard to compare at a glance.

Ships are now sorted by `DesignRole` descending (capital … fighter, matching the enum order) with design name as tie-breaker, so every fleet shows its ships big-to-small in a stable order — the ordering suggested in the issue.

Fixes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)
