### PR TITLE
Resolve fleet requisition goals while the Fleet Manager is open (#320)

### DIFF
--- a/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_Update.cs
+++ b/Ship_Game/GameScreens/FleetDesign/FleetDesignScreen_Update.cs
@@ -10,6 +10,11 @@ namespace Ship_Game
     {
         public override void Update(float fixedDeltaTime)
         {
+            // This screen hides the universe, which parks the sim thread and would leave
+            // requisition goals frozen in the pending queue (they showed "Need spaceport"
+            // until the screen was closed). Pump the queue so they resolve while we watch.
+            Universe.PumpPendingSimThreadActions();
+
             CamPos.X = CamPos.X.SmoothStep(DesiredCamPos.X, 0.2f);
             CamPos.Y = CamPos.Y.SmoothStep(DesiredCamPos.Y, 0.2f);
             CamPos.Z = CamPos.Z.SmoothStep(DesiredCamPos.Z, 0.2f);

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.UpdateGame.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.UpdateGame.cs
@@ -394,6 +394,19 @@ namespace Ship_Game
         }
 
         /// <summary>
+        /// Wakes up the parked simulation thread so queued RunOnSimThread actions still
+        /// execute while a fullscreen game screen hides the universe (normally Draw()
+        /// signals the sim loop, but a hidden universe never draws). The UState.Paused
+        /// guard means only the paused fast-path runs: pending actions are invoked,
+        /// simulation time never advances.
+        /// </summary>
+        public void PumpPendingSimThreadActions()
+        {
+            if (UState.Paused && !Visible)
+                DrawCompletedEvt.Set();
+        }
+
+        /// <summary>
         /// Queues action to run on the Simulation thread, aka ProcessTurns thread.
         /// </summary>
         public void RunOnSimThread(Action action)


### PR DESCRIPTION
The Fleet Manager is a fullscreen (non-popup) screen: it hides the `UniverseScreen`, whose `Draw()` is what signals `DrawCompletedEvt` to the simulation thread. With the universe hidden the sim thread parks, so the requisition goals queued via `AddGoalAndEvaluate` never ran and every node showed "Need spaceport" until the screen was closed — which also explains the "leave and return and it looks right" behavior in the report.

This adds `UniverseScreen.PumpPendingSimThreadActions()`: when the universe is hidden and the game paused, it signals the sim loop so it runs its paused fast-path (pending actions only, simulation time never advances), and `FleetDesignScreen.Update` calls it. Requisitioned nodes now switch to "Building at: <planet>" while you watch.

Fixes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)
