### PR TITLE
Refresh Ships Array status after a scrap order actually runs (#322)

### DIFF
--- a/Ship_Game/ShipListScreenItem.cs
+++ b/Ship_Game/ShipListScreenItem.cs
@@ -405,7 +405,10 @@ namespace Ship_Game
                         }
                         else
                         {
+                            // OrderScrapShip defers the ScrapShip goal to the sim thread,
+                            // so refresh the status only after the goal has actually run
                             Ship.AI.OrderScrapShip();
+                            Screen.Universe.RunOnSimThread(() => Screen.ResetStatus());
                         }
                     }
                     StatusText = GetStatusText(Ship);


### PR DESCRIPTION
`OrderScrapShip` defers its `ScrapShip` goal to the sim thread via `AddGoalAndEvaluate`, so the immediate `GetStatusText` refresh in the click handler still saw the pre-scrap AI state and the row kept its old status until the screen was reopened.

Queue a `ResetStatus` on the sim thread right after the order — the same pattern the shift-click `MassScrap` branch already uses. (The reporter's hunch that this is the same family as the fleet-requisition "Need spaceport" issue was right: both are UI reads racing the deferred sim-thread goal, see #320.)

Fixes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)
