### PR TITLE
Clear captured ship orders before the transfer handlers run (#316)

### DIFF
--- a/Ship_Game/Ships/Components/LoyaltyChanges.cs
+++ b/Ship_Game/Ships/Components/LoyaltyChanges.cs
@@ -66,6 +66,13 @@ namespace Ship_Game.Ships.Components
 
         static bool DoLoyaltyChange(Ship ship, Type type, Empire changeTo)
         {
+            // Spawned ships should not clear orders since some of them are given immediate orders
+            // Like pirates and meteors.
+            // Clear BEFORE the transfer handlers run: they may issue orders for the new owner
+            // (pirate boarding orders the ship to flee to a pirate base) which must survive.
+            if (type != Type.Spawn)
+                ship.AI.ClearOrdersAndWayPoints();
+
             switch (type)
             {
                 default:
@@ -76,11 +83,6 @@ namespace Ship_Game.Ships.Components
                 case Type.Absorbed:       LoyaltyChangeDueToFederation(ship, changeTo, false); break;
                 case Type.AbsorbedNotify: LoyaltyChangeDueToFederation(ship, changeTo, true);  break;
             }
-
-            // Spawned ships should not clear orders since some of them are given immediate orders
-            // Like pirates and meteors
-            if (type != Type.Spawn)
-                ship.AI.ClearOrdersAndWayPoints();
 
             return true;
         }


### PR DESCRIPTION
The main complaint of this issue (captured colony ships continuing their old colonization orders) appears to be already handled in 1.60 by the order clears inside the transfer path. What remains is a sequencing bug in the same code: `DoLoyaltyChange` cleared orders AFTER the loyalty-change handlers, which stomped the flee-to-base order that `PiratePostChangeLoyalty` had just issued to a freshly captured ship — captured ships ended up idling instead of fleeing home with their prize.

The clear now runs BEFORE the transfer handlers (same guarantee: `ClearOrders` + waypoints purge for every non-spawn change), so the new owner's immediate orders survive.

Fixes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)
