### PR TITLE
Show total EMP tolerance in the shipyard design panel (#323)

### DIFF
--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignInfoPanel.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignInfoPanel.cs
@@ -97,7 +97,9 @@ namespace Ship_Game.GameScreens.ShipDesign
             Val(() => S.ShieldMax, GT.ShieldPower, GT.TT_ShieldPower, Tint.Pos, protect, vis: Ds.HasRegularShields);
             Val(() => S.ShieldMax, GT.ShieldPower, GT.TT_ShieldPower, Tint.Pos, Color.Gold, vis: Ds.HasAmplifiedMains);
             ValNZ(() => (int)S.Stats.ShieldAmplifyPerShield, GT.ShieldAmplify, GT.TT_ShieldAmplify, Tint.Pos, protect);
-            ValNZ(() => S.BonusEMPProtection, GT.EmpProtection, GT.TT_EmpProtection, Tint.Pos, protect);
+            // the tooltip promises the TOTAL protection of the design, and the load-list
+            // overlay already shows EmpTolerance - show the same effective value here
+            Val(() => S.EmpTolerance, GT.EmpProtection, GT.TT_EmpProtection, Tint.Pos, protect);
             ValNZ(() => S.ECMValue, GT.Ecm3, GT.TT_Ecm3, Tint.Pos, protect);
             Line();
 


### PR DESCRIPTION
The shipyard design info panel displayed `BonusEMPProtection` (modules only) while the design load-list overlay shows `EmpTolerance` (hull surface area + modules) — the inconsistency described in the issue. The panel's own tooltip promises "the total EMP protection of this design".

Both now display the effective `EmpTolerance`, the value combat actually tests against (`EMPDisabled = EMPDamage > EmpTolerance`).

Fixes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)
