### PR TITLE
Cancel a manual colonization when its colony ship is redirected by the player (#324)

### DIFF
--- a/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
+++ b/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
@@ -94,7 +94,11 @@ namespace Ship_Game.Universe
 
             // if ALT key is down, always Orbit the planet
             if (Input.IsAltKeyDown)
+            {
                 ship.OrderToOrbit(planet, clearOrders, GetStanceType());
+                if (clearOrders)
+                    CancelAbandonedColonizationGoal(ship);
+            }
             else if (ship.ShipData.IsColonyShip)
                 PlanetRightClickColonyShip(ship, planet, clearOrders); // This ship can colonize planets
             else if (ship.Carrier.AnyAssaultOpsAvailable)
@@ -114,7 +118,26 @@ namespace Ship_Game.Universe
             else
             {
                 ship.OrderToOrbit(planet, clearOrders);
+                if (clearOrders)
+                    CancelAbandonedColonizationGoal(ship);
             }
+        }
+
+        // Issue 324: a direct player order that pulls a colony ship off a manual colonization
+        // is the player changing their mind - retire the empire goal too, so the automation
+        // stops feeding replacement colony ships to that planet. Triggered only by explicit
+        // player input (never by load or transient AI states - the lesson of the first fix),
+        // and the ship itself is not touched: it is already following the new order.
+        void CancelAbandonedColonizationGoal(Ship ship)
+        {
+            if (!ship.ShipData.IsColonyShip)
+                return;
+
+            var goal = Universe.Player.AI.FindGoal(g => g is MarkForColonization m
+                                                     && m.IsManualColonizationOrder
+                                                     && m.FinishedShip == ship);
+            if (goal != null)
+                Universe.Player.AI.RemoveGoal(goal);
         }
 
         void PlanetRightClickTroopShip(Ship ship, Planet planet, bool clearOrders, AI.MoveOrder order)
@@ -300,6 +323,8 @@ namespace Ship_Game.Universe
 
             Vector2 corrected = HelperFunctions.GetCorrectedMovePosWithAudio([ship], enemyShips, pos);
             ship.AI.OrderMoveTo(corrected, direction, GetMoveOrderType());
+            if (!Input.QueueAction) // a queued waypoint is not a change of mind
+                CancelAbandonedColonizationGoal(ship);
         }
     }
 }


### PR DESCRIPTION
When a player-ordered colonization's colony ship was manually sent elsewhere, `WaitForColonizationComplete` looped back and grabbed the next idle colony ship, so the automation kept feeding ships to the target — deadly for an unexplored planet guarded by Remnants, where no UI exists to cancel the order.

This hooks the actual player gesture: a direct, non-queued move or orbit order issued through `ShipMoveCommands` to a colony ship that is the assigned ship of a manual `MarkForColonization` retires that goal (a shift-queued waypoint is not treated as a change of mind). Ordering colonization of another planet was already handled by the goal constructor. AI and auto-colonize goals keep their retry behavior, and the ship itself is never touched — it is already following the new player order.

Note: an earlier attempt keyed on the absence of the ship's colonize plan misfired on legitimate transients (in-flight route replans) and mass-killed colonization goals; hooking the explicit input path avoids that whole class of false positives.

Fixes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)
