### PR TITLE
SnapViewShip: set ShipToView so ship notifications zoom to the right ship

### DIFF
--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Camera.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Camera.cs
@@ -155,6 +155,9 @@ namespace Ship_Game
 
             SnapViewTo(new(s.Position.X, s.Position.Y + 400, 2500), 5f, 2f);
             LookingAtPlanet = false;
+            // snappingToShip follows ShipToView - without this the camera snapped to
+            // whatever ship was viewed LAST (station-built notifications zoomed wrong)
+            ShipToView = s;
             snappingToShip = true;
             ViewingShip = true;
         }


### PR DESCRIPTION
`SnapViewShip` armed the camera follow flags (`snappingToShip` / `ViewingShip`) but never assigned `ShipToView`, and the camera update loop follows `ShipToView` — so clicking a "Research/Mining Station built" notification (or any other `SnapToShip` notification) zoomed to whatever ship was viewed last instead of the referenced ship. Mostly latent while `ShipToView` stayed null; any feature that sets it makes the wrong-zoom reproducible.

Assign the target ship, matching what `ViewToShip` already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
