### PR TITLE
Refresh clickable build goals every frame: paused DSB orders show on the map (#285)

### DIFF
--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.cs
@@ -701,6 +701,12 @@ namespace Ship_Game
             {
                 SystemInfoOverlay.Update(elapsed);
             }
+            // The clickable build goals froze while paused (their screen positions are
+            // camera-dependent and the sim loop owns the refresh): platforms ordered via
+            // the deep space building menu were invisible on the map until unpausing, and
+            // selecting a DSB under construction was impossible in pause. Refreshing here
+            // too is trivially cheap (player deployment goals only).
+            UpdateClickableItems();
             if (ShowPlanetInfo)
             {
                 pInfoUI.Update(elapsed);


### PR DESCRIPTION
Platforms ordered via the deep space building menu were not shown on the map while the game was paused (a regression the report notes — they used to appear instantly), and DSB icons under construction could not be selected in pause either.

Cause: `UpdateClickableItems` only ran from the simulation path, which does not advance while paused, and the icons' screen positions are camera-dependent so they also went stale on any camera move in pause. The fix refreshes the clickable build goals from the screen update as well — the scan covers player deployment goals only, so the per-frame cost is trivial.

This fix has been running in the Ludoal fork since Patch 45 builds (it was originally made for the selection-in-pause half of the symptom) with no observed side effects.

Fixes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)
