### PR TITLE
Diplomacy: tech offer count matches the list actually shown (#342)

### DIFF
--- a/Ship_Game/GameScreens/DiplomacyScreen/DiplomacyOffersComponent.cs
+++ b/Ship_Game/GameScreens/DiplomacyScreen/DiplomacyOffersComponent.cs
@@ -104,16 +104,21 @@ namespace Ship_Game.GameScreens.DiplomacyScreen
             var theirDesigns = Them.AllFactionShipDesigns;
             
             Us.AI.TradableTechs(Them, out Array<TechEntry> tradeAbleTechs);
-            LocalizedText techsHeader = LocalizedText.Parse($"{{Technology}} ({tradeAbleTechs.Count})");
-
-            ItemToOffer techs = AddHeader(techsHeader);
+            // filter BEFORE counting: the header advertised techs the loop below then skipped,
+            // showing e.g. "Technology (1)" with an empty list on the player's side
+            var offerableTechs = new Array<TechEntry>();
             foreach (TechEntry entry in tradeAbleTechs)
             {
-                Technology tech = entry.Tech;
                 // FB - Do not trade ship tech that the AI cannot use due to lack of pre-made designs
-                if (!Them.isPlayer && !Them.WeCanUseThisTech(entry, theirDesigns))
-                    continue;
-                
+                if (Them.isPlayer || Them.WeCanUseThisTech(entry, theirDesigns))
+                    offerableTechs.Add(entry);
+            }
+            LocalizedText techsHeader = LocalizedText.Parse($"{{Technology}} ({offerableTechs.Count})");
+
+            ItemToOffer techs = AddHeader(techsHeader);
+            foreach (TechEntry entry in offerableTechs)
+            {
+                Technology tech = entry.Tech;
                 var text = LocalizedText.Parse($"{{{tech.NameIndex}}}: {(int)entry.TechCost}");
                 techs.AddSubItem(new ItemToOffer(text, "Tech") { SpecialInquiry = entry.UID });
             }


### PR DESCRIPTION
The Technology header in the negotiation panel counted all tradable techs, but the sublist then skipped every tech the receiving AI cannot use (no pre-made designs) — so the player could see "Technology (1)" expand to an empty list, while the AI's own side always displayed correctly. Filter first, count after; the design rule itself (FB: don't trade ship tech the AI can't use) is unchanged.

Fixes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)
