### PR TITLE
Loading screen: Click to Continue no longer overlaps the advice text

### DIFF
--- a/Ship_Game/GameScreens/LoadGame/LoadUniverseScreen.cs
+++ b/Ship_Game/GameScreens/LoadGame/LoadUniverseScreen.cs
@@ -112,7 +112,7 @@ namespace Ship_Game
 
             if (AsyncUniverse.IsComplete)
             {
-                cursor.Y -= Fonts.Pirulen16.LineSpacing - 10f;
+                cursor.Y -= Fonts.Pirulen16.LineSpacing + 10f; // Ludoal fork: sign slip vs CreatingNewGameScreen — label overlapped the advice text
                 const string begin = "Click to Continue!";
                 cursor.X = ScreenCenter.X - Fonts.Pirulen16.MeasureString(begin).X / 2f;
                 batch.DrawString(Fonts.Pirulen16, begin, cursor, CurrentFlashColor);


### PR DESCRIPTION
On the load-game screen, "Click to Continue!" overlapped the advice/hint text: the vertical offset was derived from the twin block in `CreatingNewGameScreen` but with the sign of the `LineSpacing` term flipped the wrong way. One-character fix, reported on the fork from a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
