### PR TITLE
Fix NullRef in Ships Array status text when no solar system is reachable

### DIFF
--- a/Ship_Game/ShipListScreenItem.cs
+++ b/Ship_Game/ShipListScreenItem.cs
@@ -298,8 +298,10 @@ namespace Ship_Game
 
                         if (!ship.AI.OrderQueue.TryPeekLast(out ShipAI.ShipGoal last))
                         {
+                            // Ludoal fork: FindClosestSystem is null in a system-less
+                            // universe (battle simulator arena) — NullRef froze the UI
                             SolarSystem system = ship.Universe.FindClosestSystem(ship.AI.MovePosition);
-                            if (system.IsExploredBy(ship.Universe.Player))
+                            if (system != null && system.IsExploredBy(ship.Universe.Player))
                                 return string.Concat(moveText, Localizer.Token(GameText.DeepSpaceNear), " ", system.Name);
                             return Localizer.Token(GameText.ExploringTheGalaxy);
                         }
@@ -313,7 +315,7 @@ namespace Ship_Game
                         else
                         {
                             SolarSystem system = ship.Universe.FindClosestSystem(ship.AI.MovePosition);
-                            if (system.IsExploredBy(ship.Universe.Player))
+                            if (system != null && system.IsExploredBy(ship.Universe.Player))
                                 return moveText + system.Name;
                             return Localizer.Token(GameText.ExploringTheGalaxy);
                         }


### PR DESCRIPTION
`ShipListScreenItem.GetStatusText` calls `FindClosestSystem` and dereferences the result; in universes where the relevant ship has no reachable system this threw a NullReferenceException while drawing the Ships Array. Found via a draw-loop crash log on the fork's battle-simulator arena (a minimal universe), but the guard is valid for any universe where FindClosestSystem legitimately returns null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
