### PR TITLE
A UI draw failure must not starve the simulation thread

### DIFF
--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Draw.cs
@@ -440,7 +440,22 @@ namespace Ship_Game
                 DrawShipAndPlanetIcons(batch);
                 DrawSolarSystems(batch);
                 DrawSystemThreatIndicators(batch);
-                DrawGeneralUI(batch, elapsed);
+                // Ludoal fork: a UI draw failure must never starve the sim thread —
+                // an exception here used to skip DrawCompletedEvt.Set() below, freezing
+                // the simulation for as long as the failing element kept drawing
+                // (battle sim arena: selecting a ship froze the game). Log and go on.
+                try
+                {
+                    DrawGeneralUI(batch, elapsed);
+                }
+                catch (System.Exception ex)
+                {
+                    if (!LoggedGeneralUIDrawError)
+                    {
+                        LoggedGeneralUIDrawError = true;
+                        Log.Error(ex, "DrawGeneralUI failed (UI suppressed, sim kept alive)");
+                    }
+                }
             }
             batch.SafeEnd();
             IconsGroupTotalPerf.Stop();

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.cs
@@ -39,6 +39,7 @@ namespace Ship_Game
 
         public Array<Bomb> BombList  = new();
         readonly AutoResetEvent DrawCompletedEvt = new(false);
+        bool LoggedGeneralUIDrawError; // Ludoal fork: log the first UI-draw failure only
 
         public const double MinCamHeight = 450.0;
         protected double MaxCamHeight;


### PR DESCRIPTION
`UniverseScreen.Draw` signals `DrawCompletedEvt` at the end of the frame — it is what lets the simulation thread run its next turn. An exception anywhere in `DrawGeneralUI` skipped that signal, freezing the entire simulation for as long as the failing UI element kept drawing, with no diagnostic. We hit this on the fork (a UI element threw every frame: game appeared hard-frozen); with the guard, the failure logs once with a stack trace and the sim thread stays alive.

The catch is deliberately broad and logs only the first occurrence: a UI draw failure should degrade the UI, never starve the simulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
