### PR TITLE
Camera chase survives selection: stop clearing ViewingShip every frame

### DIFF
--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.SetSelectedItem.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.SetSelectedItem.cs
@@ -58,7 +58,7 @@ public partial class UniverseScreen
         int num = SelectedShipList.Count();
         SelectedShipList.RemoveInActiveObjects();
         if (SelectedShip != null)
-            SetSelectedShip(SelectedShip, SelectedFleet);
+            SetSelectedShip(SelectedShip, SelectedFleet, clearFlags: false); // same ship, UI refresh only - keep the chase camera alive
         else if (num != SelectedShipList.Count())
             SetSelectedShipList(SelectedShipList, SelectedFleet);
     }
@@ -89,13 +89,17 @@ public partial class UniverseScreen
     /// <summary>
     /// Sets the currently selected ship and clears selected ships list
     /// </summary>
-    public void SetSelectedShip(Ship selectedShip, Fleet fleet = null)
+    // clearFlags=false lets the per-frame UI refresh in UpdateSelectedShips keep the
+    // chase camera alive - the unconditional clear switched ViewingShip off EVERY frame
+    // while a ship was selected, which is exactly the chase use-case (why 'follow'
+    // never survived the initial snap).
+    public void SetSelectedShip(Ship selectedShip, Fleet fleet = null, bool clearFlags = true)
     {
         SelectedSomethingTimer = 3f;
 
         // manually update prev selected ship
         UpdatePrevSelectedShip(selectedShip);
-        ClearSelectedItems(updatePrevSelectedShip: false, fleet: fleet);
+        ClearSelectedItems(clearFlags: clearFlags, updatePrevSelectedShip: false, fleet: fleet);
 
         SelectedShip = selectedShip;
 


### PR DESCRIPTION
`UpdateSelectedShips` refreshes the selected ship's UI every frame via `SetSelectedShip`, which unconditionally called `ClearSelectedItems` with `clearFlags: true` — so `ViewingShip`/`snappingToShip` were switched off EVERY frame while a ship was selected. Since chasing a ship implies having it selected, the chase camera could never survive its initial snap; the middle-click follow feature has effectively been broken by this for a long time.

`SetSelectedShip` gains a `clearFlags` pass-through (default `true`, so every other call site keeps its exact behavior); the per-frame refresh passes `false`. Field-tested on the Ludoal fork since Patch 45 builds — follow now works and disengages normally on player camera input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
