### PR TITLE
Planet cartouche: show deployed research station status

### DIFF
--- a/Ship_Game/Universe/SolarBodies/PlanetInfoUIElement.cs
+++ b/Ship_Game/Universe/SolarBodies/PlanetInfoUIElement.cs
@@ -357,7 +357,12 @@ namespace Ship_Game
         void DrawResearchStation(SpriteBatch batch, Vector2 mousePos)
         {
             if (P.IsResearchStationDeployedBy(Player))
+            {
+                // show the deployed state instead of drawing nothing
+                var okPos = new Vector2(ExoticRect.X + 13, ExoticRect.Y + 13 - Font12.LineSpacing / 2 - 2);
+                batch.DrawString(Font12, "Research station operational", okPos, Color.LightGreen);
                 return;
+            }
 
             Vector2 textPos = new Vector2(ExoticRect.X + 13, ExoticRect.Y + 13 - Font12.LineSpacing / 2 - 2);
             batch.Draw(ResourceManager.Texture(Player.CanBuildResearchStations ? "NewUI/dan_button_blue_clear" 


### PR DESCRIPTION
Once a research station is deployed on a researchable planet, the selection cartouche currently draws nothing at all where the Deploy button used to be — there is no way to see the deployed state at a glance (the button simply vanishes).

This shows a green `Research station operational` line in the button's slot instead, mirroring the information the espionage/notification flows already rely on.

Test status: compiled and verified in-game on our fork (deployed and not-yet-deployed states, researchable planets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)