### PR TITLE
Starving planets no longer export their food buffer

### DIFF
--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Resources.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Resources.cs
@@ -161,12 +161,12 @@ namespace Ship_Game
 
             float ratio               = Storage.FoodRatio;
             bool belowImportThreshold = ratio < importThreshold 
-                                        && CType != ColonyType.Agricultural
+                                        && (CType != ColonyType.Agricultural || Food.NetMaxPotential < 0)
                                         && Food.NetFlatBonus < Consumption;
 
             // This will allow a buffer for import / export, so they dont constantly switch between them
             if      (ShortOnFood() || belowImportThreshold)   FS = GoodState.IMPORT; 
-            else if (Food.NetMaxPotential < 0 && ratio > 0.9) FS = GoodState.STORE;  // We are negative on food production but have a lot of food
+            else if (Food.NetMaxPotential < 0)                FS = GoodState.STORE;  // Negative food production: keep the buffer, never export it away
             else if (ratio > exportThreshold)                 FS = GoodState.EXPORT; // Until we get back to the Threshold, then export
             else                                              FS = GoodState.STORE;  // We are between our thresholds
         }

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Trade.cs
@@ -121,7 +121,8 @@ namespace Ship_Game
             if (ManualFoodExportSlots > 0 && Owner == Universe.Player)
                 return ManualFoodExportSlots;
 
-            int min = Storage.FoodRatio > 0.75f ? 2 : 1;
+            // a planet LOSING food guarantees no export slot - the last freighter no longer leaves no matter what
+            int min = Food.NetIncome < 0 ? 0 : Storage.FoodRatio > 0.75f ? 2 : 1;
             int maxSlots = CType is ColonyType.Agricultural or ColonyType.Colony or ColonyType.TradeHub? 14 : 7;
             int storageSlots = (int)(Storage.Food / Owner.AverageFreighterCargoCap);
             int outputSlots  = (int)(Food.NetIncome * AverageFoodExportTurns / Owner.AverageFreighterCargoCap);


### PR DESCRIPTION
Fixes #314.

Three-stage fix for the export-while-starving window:
- DetermineFoodState: negative max food production now always resolves
  to STORE (previously only above 0.9 storage ratio, so a declining
  planet in the [export threshold, 0.9] window kept exporting while
  melting toward famine).
- GetFoodExportSlots: the guaranteed minimum export slot drops to 0
  when net food income is negative.
- The Agricultural exemption from the import threshold no longer
  applies when the planet cannot feed itself even at max farming
  (crushed fertility): the ruined farm finally accepts relief.

Diagnosis credit: colony-logic review pass on the fork.

Test status: compiled and logic-reviewed against the issue's repro; play-testing on our fork is partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
