### PR TITLE
Stations need 10% hangar area for the Dedicated Carrier design note

### DIFF
--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignIssues.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignIssues.cs
@@ -508,9 +508,12 @@ namespace Ship_Game.GameScreens.ShipDesign
         }
 
         public void CheckDedicatedCarrier(bool hasFighterHangars, RoleName role, 
-                                          int maxWeaponRange, float sensorRange, bool shortRange)
+                                          int maxWeaponRange, float sensorRange, bool shortRange,
+                                          float hangarAreaPercent = 1f)
         {
-            if (role != RoleName.carrier  && !Stationary || !hasFighterHangars)
+            // stationary designs were flagged 'Dedicated Carrier' from a single hangar bay;
+            // hold them to the same 10% hangar-area threshold ships need for the carrier role
+            if (role != RoleName.carrier && !(Stationary && hangarAreaPercent > 0.1f) || !hasFighterHangars)
                 return;
 
             bool minCarrier  = false;

--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignIssuesPanel.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignIssuesPanel.cs
@@ -111,7 +111,8 @@ namespace Ship_Game.GameScreens.ShipDesign
                 Issues.CheckSecondaryCarrier(ds.TotalHangarArea > 0, Screen.Role, (int)S.WeaponsMaxRange);
                 Issues.CheckConstructorCost(S.IsConstructor, S.GetCost(S.Universe.Player));
                 Issues.CheckDedicatedCarrier(ds.TotalHangarArea > 0, Screen.Role, (int)S.WeaponsMaxRange, S.SensorRange,
-                    S.ShipData.DefaultCombatState is CombatState.ShortRange or CombatState.AttackRuns);
+                    S.ShipData.DefaultCombatState is CombatState.ShortRange or CombatState.AttackRuns,
+                    hangarAreaPercent: ds.TotalHangarArea / (float)S.SurfaceArea);
 
                 Issues.CheckTargetExclusions(ds.NumWeaponSlots > 0, ds.CanTargetFighters, ds.CanTargetCorvettes,
                     ds.CanTargetCapitals, Screen.HangarDesignation);


### PR DESCRIPTION
Fixes #317.

CheckDedicatedCarrier fired for ANY stationary design with any fighter
hangar (a 24-slot bay on a 356-slot station, or a single 12-slot
hangar). Stationary designs are now held to the same 10% hangar-area
threshold that ships need to classify as carriers. Informative-level
issue, display only.

Test status: verified at our fork's bench (in-game), logic reviewed against the issue's repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
