### PR TITLE
Double refit keeps the ship's fleet affiliation

### DIFF
--- a/Ship_Game/Commands/Goals/RefitShip.cs
+++ b/Ship_Game/Commands/Goals/RefitShip.cs
@@ -45,7 +45,14 @@ namespace Ship_Game.Commands.Goals  // Created by Fat Bastard
                 VanityName = oldShip.VanityName;
 
             if (OldShip.AI.State == AIState.Refit)
+            {
+                // A ship already refitting was detached from its fleet by the FIRST refit goal
+                // (the fleet link lives in that goal, not on the ship anymore). Inherit the
+                // affiliation before removing the old goal, or a double refit loses the fleet.
+                if (Fleet == null && Owner.AI.FindGoal(g => g.Type == GoalType.Refit && g.OldShip == OldShip) is FleetGoal prior)
+                    Fleet = prior.Fleet;
                 RemoveOldRefitGoal();
+            }
         }
 
         GoalStep FindShipAndPlanetToRefit()


### PR DESCRIPTION
Fixes #295.

The first refit detaches the ship from its fleet (the link then lives
only in the refit goal's Fleet + the fleet node). A second refit order
read oldShip.Fleet - already null - then removed the old goal, so the
affiliation died with it and the rebuilt ship never rejoined its fleet.
The new goal now inherits the Fleet from the goal it replaces.

Test status: verified at our fork's bench (in-game), logic reviewed against the issue's repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
