### PR TITLE
Governor keeps unprofitable biospheres the colony budget pays for

### DIFF
--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
@@ -821,9 +821,14 @@ namespace Ship_Game
                 if (NumFreeBiospheres > 0)
                 {
                     // We do not need more than 1 free biospheres if not profitable.
-                    // We need only 1 free biosphere if we have anything to built at all
-                    shouldScrapBioSpheres = NumFreeBiospheres > 1 
-                        || numBuildingsWeCanBuild == 0 && (!HasBlueprints || Blueprints.IsAchievableCompleted);
+                    // We need only 1 free biosphere if we have anything to built at all.
+                    // But a colony budget that covers the upkeep of the free biospheres is an
+                    // explicit 'I am paying, keep them' - the scrap decision never consulted
+                    // the budget, so governors razed player-funded biospheres at budget 99 (issue 313)
+                    bool budgetCoversUpkeep = budget >= NumFreeBiospheres * bio.ActualMaintenance(this);
+                    shouldScrapBioSpheres = !budgetCoversUpkeep
+                        && (NumFreeBiospheres > 1 
+                            || numBuildingsWeCanBuild == 0 && (!HasBlueprints || Blueprints.IsAchievableCompleted));
                     return false;
                 }
                 else if (numBuildingsWeCanBuild == 0 || HabiableBuiltCoverage.Less(1))


### PR DESCRIPTION
Fixes #313.

The scrap decision for free biospheres never consulted the colony
budget: TryBuildBiospheres gates CONSTRUCTION on budget, but the
demolition branch keyed on profitability alone, so governors razed
player-built biospheres even at budget 99. If the budget covers the
upkeep of the existing free biospheres, that is an explicit 'I am
paying, keep them' - no scrapping. Tight-budget governors keep their
current cleanup behavior.

Diagnosis credit: colony-logic review pass on the fork.

Test status: running on our fork since this morning's build; compiled and logic-reviewed, full play-test still in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
