### PR TITLE
Biosphere profitability judged at a nominal tax rate

### DIFF
--- a/Ship_Game/Universe/SolarBodies/ColonyResource.cs
+++ b/Ship_Game/Universe/SolarBodies/ColonyResource.cs
@@ -299,7 +299,12 @@ namespace Ship_Game.Universe.SolarBodies
             if (b.IsBiospheres)
                 newPopulation += Planet.PopPerBiosphere(Planet.Owner)*0.001f;
 
-            float grossIncome = newPopulation * IncomePerColonist * TaxRate;
+            // Judge infrastructure at a fixed NOMINAL tax rate: keying on the live empire
+            // tax rate made governors build biospheres at high tax and raze them at low
+            // tax - a structural build/scrap oscillation driven by fiscal policy, since
+            // the scrap side (BioSphereProfitable) uses this very value (issue 321)
+            const float NominalTaxRate = 0.25f;
+            float grossIncome = newPopulation * IncomePerColonist * NominalTaxRate;
             return grossIncome - b.ActualMaintenance(Planet);
         }
 


### PR DESCRIPTION
Fixes #321.

NetRevenueGain multiplied by the live empire tax rate, and the governor
uses it on BOTH sides: build when profitable, scrap when not (via the
issue-313 path). High tax -> build, low tax -> raze: a structural
build/scrap oscillation driven by fiscal policy (worse with automatic
tax balancing, and it hurts the AI too). Infrastructure decisions now
use a fixed nominal 25% rate, decoupled from the tax slider.

Diagnosis credit: colony-logic review pass on the fork.

Test status: running on our fork since this morning's build; compiled and logic-reviewed, full play-test still in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
