### PR TITLE
Close the colonist import/export overlap window

### DIFF
--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Resources.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Resources.cs
@@ -85,7 +85,10 @@ namespace Ship_Game
             return GoodState.STORE;
         }
 
-        bool ShouldImportColonists(float popRatio) => popRatio < 0.8f || BiosphereInTheWorks && PopPerBiosphere(Owner) > 100 && popRatio < 0.99f;
+        // the biosphere-anticipation import rule is bounded at the EXPORT threshold (0.9):
+        // in the old ]0.9, 0.99[ window import and export were both defensible and every
+        // biosphere queued flipped the traffic direction - the population ping-pong (issue 293)
+        bool ShouldImportColonists(float popRatio) => popRatio < 0.8f || BiosphereInTheWorks && PopPerBiosphere(Owner) > 100 && popRatio < 0.9f;
 
         public bool ShortOnFood()
         {


### PR DESCRIPTION
Fixes #293.

ShouldImportColonists allowed biosphere-anticipation imports up to a
0.99 population ratio while the export rule starts at 0.9: in the
]0.9, 0.99[ window on a large planet, the trade direction depended
solely on BiosphereInTheWorks, so every biosphere queued flipped the
traffic and freighters already in flight kept coming - simultaneous
import and export, the reported ping-pong. Bounding the anticipation
rule at the export threshold keeps its real purpose (fill capacity
under construction while below export levels) and removes the window.
Best paired with the issue-321 fix, which stops the biosphere
build/scrap oscillation that kept flipping the flag.

Diagnosis credit: colony-logic review pass on the fork.

Test status: running on our fork since this morning's build; compiled and logic-reviewed, full play-test still in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
