### PR TITLE
Terraforming status clears when an event terraformer dies

### DIFF
--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
@@ -457,7 +457,9 @@ public partial class Planet
             TerraformingHere = HasBuilding(bb => bb.IsTerraformer || bb.IsEventTerraformer);
         
         // FB - no terraformers present, terraform effort halted
-        if (b.IsTerraformer && !TerraformingHere)
+        // (event terraformers too - a depleted World Tree left the points frozen and
+        // the planet stuck displaying 'Terraforming in Progress', issue 294)
+        if ((b.IsTerraformer || b.IsEventTerraformer) && !TerraformingHere)
             TerraformPoints = 0;
 
         if (b.IsCapital) HasCapital = false;


### PR DESCRIPTION
Fixes #294.

UpdatePlanetStatsFromRemovedBuilding zeroed TerraformPoints only for
regular terraformers (b.IsTerraformer); a depleted World Tree is an
event terraformer, so its removal left the points frozen and the planet
displayed 'Terraforming in Progress' forever (ApplyTerraforming's
early-outs never got to clean it once the planet had nothing normally
terraformable left). Same one-line rule as the TerraformingHere line
just above it.

Test status: running on our fork since this morning's build; compiled and logic-reviewed, full play-test still in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
