### PR TITLE
DSB menu allows platforms in orbit of planets close to the sun

### DIFF
--- a/Ship_Game/DeepSpaceBuildingWindow.cs
+++ b/Ship_Game/DeepSpaceBuildingWindow.cs
@@ -185,6 +185,8 @@ namespace Ship_Game
                 return false;
 
             if (targetSystem != null && (Screen.CursorWorldPosition2D.InRadius(targetSystem.Position, MinimumBuildDistanceFromSun) 
+                                         && targetPlanet == null // a planet's orbit is a valid site even close to the sun -
+                                                                 // the planet UI allows it, this menu refused it (issue 284)
                                          || !targetSystem.InSafeDistanceFromRadiation(Screen.CursorWorldPosition2D)))
             {
                 return false;


### PR DESCRIPTION
Fixes #284.

The deep space build menu rejected any spot within 20k of the star, so
planets orbiting inside that radius could never receive platforms from
this menu while the planet UI path allowed them. The sun-distance guard
now yields when the cursor is snapped to a planet; the radiation-safety
guard is unchanged.

Test status: running on our fork since this morning's build; compiled and logic-reviewed, full play-test still in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
