### PR TITLE
Clarify money units: all flows are per turn

### DIFF
--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -4096,17 +4096,17 @@ namespace Ship_Game
         Override = 4226,
         /// <summary>Override this budget and set your own.</summary>
         OverrideThisBudgetAndSet = 4227,
-        /// <summary>Civilian Buildings Expenditure/Budget in BY/C. If you see over-budget, you</summary>
+        /// <summary>Civilian Buildings Expenditure/Budget in bc/turn. If you see over-budget, you</summary>
         CivilianBuildingsExpenditurebudgetInByc = 4228,
-        /// <summary>Ground Defense Buildings Expenditure/Budget in BY/C. If you see over-budget,</summary>
+        /// <summary>Ground Defense Buildings Expenditure/Budget in bc/turn. If you see over-budget,</summary>
         GroundDefenseBuildingsExpenditurebudgetIn = 4229,
-        /// <summary>Orbitals Expenditure/Budget in BY/C</summary>
+        /// <summary>Orbitals Expenditure/Budget in bc/turn</summary>
         OrbitalsExpenditurebudgetInByc = 4230,
-        /// <summary>Civilian Buildings Expenditure in BY/C</summary>
+        /// <summary>Civilian Buildings Expenditure in bc/turn</summary>
         CivilianBuildingsExpenditureInByc = 4231,
-        /// <summary>Ground Defense Buildings Expenditure in BY/C</summary>
+        /// <summary>Ground Defense Buildings Expenditure in bc/turn</summary>
         GroundDefenseBuildingsExpenditureIn = 4232,
-        /// <summary>Orbitals Expenditure in BY/C</summary>
+        /// <summary>Orbitals Expenditure in bc/turn</summary>
         OrbitalsExpenditureInByc = 4233,
         /// <summary>Total:</summary>
         Total3 = 4234,

--- a/Ship_Game/Data/GameText.cs
+++ b/Ship_Game/Data/GameText.cs
@@ -4096,17 +4096,17 @@ namespace Ship_Game
         Override = 4226,
         /// <summary>Override this budget and set your own.</summary>
         OverrideThisBudgetAndSet = 4227,
-        /// <summary>Civilian Buildings Expenditure/Budget in bc/turn. If you see over-budget, you</summary>
+        /// <summary>Civilian Buildings Expenditure/Budget in bc/t. If you see over-budget, you</summary>
         CivilianBuildingsExpenditurebudgetInByc = 4228,
-        /// <summary>Ground Defense Buildings Expenditure/Budget in bc/turn. If you see over-budget,</summary>
+        /// <summary>Ground Defense Buildings Expenditure/Budget in bc/t. If you see over-budget,</summary>
         GroundDefenseBuildingsExpenditurebudgetIn = 4229,
-        /// <summary>Orbitals Expenditure/Budget in bc/turn</summary>
+        /// <summary>Orbitals Expenditure/Budget in bc/t</summary>
         OrbitalsExpenditurebudgetInByc = 4230,
-        /// <summary>Civilian Buildings Expenditure in bc/turn</summary>
+        /// <summary>Civilian Buildings Expenditure in bc/t</summary>
         CivilianBuildingsExpenditureInByc = 4231,
-        /// <summary>Ground Defense Buildings Expenditure in bc/turn</summary>
+        /// <summary>Ground Defense Buildings Expenditure in bc/t</summary>
         GroundDefenseBuildingsExpenditureIn = 4232,
-        /// <summary>Orbitals Expenditure in bc/turn</summary>
+        /// <summary>Orbitals Expenditure in bc/t</summary>
         OrbitalsExpenditureInByc = 4233,
         /// <summary>Total:</summary>
         Total3 = 4234,

--- a/Ship_Game/DeepSpaceBuildingWindow.cs
+++ b/Ship_Game/DeepSpaceBuildingWindow.cs
@@ -92,7 +92,7 @@ namespace Ship_Game
                 batch.DrawString(Fonts.Arial8Bold, Template.GetRole(), X+iconSize+2, Y+18, Color.Orange);
 
                 float prodX = Right - 120;
-                batch.DrawString(Fonts.Arial8Bold, Template.GetMaintenanceCost(Universe.Player).String(2)+" BC/Y", prodX, Y+4, Color.Salmon); // Maintenance Cost
+                batch.DrawString(Fonts.Arial8Bold, Template.GetMaintenanceCost(Universe.Player).String(2)+" bc/turn", prodX, Y+4, Color.Salmon); // Maintenance Cost
                 batch.Draw(iconProd, new Vector2(prodX+50, Y+4), iconProd.SizeF); // Production Icon
                 batch.DrawString(Fonts.Arial12Bold, Template.GetCost(Universe.Player).String(1), prodX+50+iconProd.Width+2, Y+4); // Build Production Cost
             }

--- a/Ship_Game/DeepSpaceBuildingWindow.cs
+++ b/Ship_Game/DeepSpaceBuildingWindow.cs
@@ -92,7 +92,7 @@ namespace Ship_Game
                 batch.DrawString(Fonts.Arial8Bold, Template.GetRole(), X+iconSize+2, Y+18, Color.Orange);
 
                 float prodX = Right - 120;
-                batch.DrawString(Fonts.Arial8Bold, Template.GetMaintenanceCost(Universe.Player).String(2)+" bc/turn", prodX, Y+4, Color.Salmon); // Maintenance Cost
+                batch.DrawString(Fonts.Arial8Bold, Template.GetMaintenanceCost(Universe.Player).String(2)+" bc/t", prodX, Y+4, Color.Salmon); // Maintenance Cost
                 batch.Draw(iconProd, new Vector2(prodX+50, Y+4), iconProd.SizeF); // Production Icon
                 batch.DrawString(Fonts.Arial12Bold, Template.GetCost(Universe.Player).String(1), prodX+50+iconProd.Width+2, Y+4); // Build Production Cost
             }

--- a/Ship_Game/GameScreens/ColonyBlueprints/BlueprintsBuildableListItem.cs
+++ b/Ship_Game/GameScreens/ColonyBlueprints/BlueprintsBuildableListItem.cs
@@ -60,7 +60,7 @@ namespace Ship_Game
             batch.Draw(ProdIcon, new Vector2(x, y), iconSize); // Production Icon
             batch.DrawString(font, prod.String(), x + iconSize.X + 2, y); // Build Production Cost
 
-            string maintString = (-maintenance).String(2) + " BC/Y";
+            string maintString = (-maintenance).String(2) + " bc/turn";
             float maintX = x + iconSize.X + 50;
 
             if (cost > 0)

--- a/Ship_Game/GameScreens/ColonyBlueprints/BlueprintsBuildableListItem.cs
+++ b/Ship_Game/GameScreens/ColonyBlueprints/BlueprintsBuildableListItem.cs
@@ -60,7 +60,7 @@ namespace Ship_Game
             batch.Draw(ProdIcon, new Vector2(x, y), iconSize); // Production Icon
             batch.DrawString(font, prod.String(), x + iconSize.X + 2, y); // Build Production Cost
 
-            string maintString = (-maintenance).String(2) + " bc/turn";
+            string maintString = (-maintenance).String(2) + " bc/t";
             float maintX = x + iconSize.X + 50;
 
             if (cost > 0)

--- a/Ship_Game/GameScreens/ColonyScreen/BuildableListItem.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/BuildableListItem.cs
@@ -110,7 +110,7 @@ namespace Ship_Game
             batch.Draw(ProdIcon, new Vector2(x, y), iconSize); // Production Icon
             batch.DrawString(font, prod.String(), x + iconSize.X + 2, y); // Build Production Cost
 
-            string maintString = (-maintenance).String(2) + " BC/Y";
+            string maintString = (-maintenance).String(2) + " bc/turn";
             float maintX       = x + iconSize.X + 50;
 
             if (cost > 0)

--- a/Ship_Game/GameScreens/ColonyScreen/BuildableListItem.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/BuildableListItem.cs
@@ -110,7 +110,7 @@ namespace Ship_Game
             batch.Draw(ProdIcon, new Vector2(x, y), iconSize); // Production Icon
             batch.DrawString(font, prod.String(), x + iconSize.X + 2, y); // Build Production Cost
 
-            string maintString = (-maintenance).String(2) + " bc/turn";
+            string maintString = (-maintenance).String(2) + " bc/t";
             float maintX       = x + iconSize.X + 50;
 
             if (cost > 0)

--- a/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
@@ -686,15 +686,15 @@ namespace Ship_Game
             Font font = LowRes ? Font8 : Font14;
 
             batch.DrawString(font, $"{gIncome}: ", cursor, Color.LightGray);
-            batch.DrawString(font, $"{grossIncome.String(2)} BC/Y", new Vector2(cursor.X + 150, cursor.Y), Color.LightGreen);
+            batch.DrawString(font, $"{grossIncome.String(2)} bc/turn", new Vector2(cursor.X + 150, cursor.Y), Color.LightGreen);
             cursor.Y += font.LineSpacing +  1;
 
             batch.DrawString(font, $"{gUpkeep}: ", cursor, Color.LightGray);
-            batch.DrawString(font, $"{grossUpkeep.String(2)} BC/Y", new Vector2(cursor.X + 150, cursor.Y), Color.Pink);
+            batch.DrawString(font, $"{grossUpkeep.String(2)} bc/turn", new Vector2(cursor.X + 150, cursor.Y), Color.Pink);
             cursor.Y += font.LineSpacing + 1;
 
             batch.DrawString(font, $"{(netIncome > 0 ? nIncome : nLosses)}: ", cursor, Color.LightGray);
-            batch.DrawString(font, $"{netIncome.String(2)} BC/Y", new Vector2(cursor.X + 150, cursor.Y), netIncome > 0.0 ? Color.Green : Color.Red);
+            batch.DrawString(font, $"{netIncome.String(2)} bc/turn", new Vector2(cursor.X + 150, cursor.Y), netIncome > 0.0 ? Color.Green : Color.Red);
             cursor.Y += font.LineSpacing*2 + 1;
         }
 

--- a/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/ColonyScreen_Draw.cs
@@ -686,15 +686,15 @@ namespace Ship_Game
             Font font = LowRes ? Font8 : Font14;
 
             batch.DrawString(font, $"{gIncome}: ", cursor, Color.LightGray);
-            batch.DrawString(font, $"{grossIncome.String(2)} bc/turn", new Vector2(cursor.X + 150, cursor.Y), Color.LightGreen);
+            batch.DrawString(font, $"{grossIncome.String(2)} bc/t", new Vector2(cursor.X + 150, cursor.Y), Color.LightGreen);
             cursor.Y += font.LineSpacing +  1;
 
             batch.DrawString(font, $"{gUpkeep}: ", cursor, Color.LightGray);
-            batch.DrawString(font, $"{grossUpkeep.String(2)} bc/turn", new Vector2(cursor.X + 150, cursor.Y), Color.Pink);
+            batch.DrawString(font, $"{grossUpkeep.String(2)} bc/t", new Vector2(cursor.X + 150, cursor.Y), Color.Pink);
             cursor.Y += font.LineSpacing + 1;
 
             batch.DrawString(font, $"{(netIncome > 0 ? nIncome : nLosses)}: ", cursor, Color.LightGray);
-            batch.DrawString(font, $"{netIncome.String(2)} bc/turn", new Vector2(cursor.X + 150, cursor.Y), netIncome > 0.0 ? Color.Green : Color.Red);
+            batch.DrawString(font, $"{netIncome.String(2)} bc/t", new Vector2(cursor.X + 150, cursor.Y), netIncome > 0.0 ? Color.Green : Color.Red);
             cursor.Y += font.LineSpacing*2 + 1;
         }
 

--- a/Ship_Game/GameScreens/ColonyScreen/GovernorDetailsComponent.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/GovernorDetailsComponent.cs
@@ -858,6 +858,7 @@ namespace Ship_Game
                 BudgetSum.Text      = $"{Localizer.Token(GameText.Total3)} {spent.String(1)}" +
                                       $" {Localizer.Token(GameText.Of)} {budget.TotalAlloc.String(1)} bc/turn";
                 BudgetPercent.Text  = $" ({percentSpent.String(1)}%)";
+                BudgetPercent.Pos   = new Vector2(BudgetSum.Pos.X + FontBig.TextWidth(BudgetSum.Text) + 4, BudgetSum.Pos.Y); // follow the total text (bc/turn is wider than the old label)
                 BudgetPercent.Color = GetColor();
             }
             else

--- a/Ship_Game/GameScreens/ColonyScreen/GovernorDetailsComponent.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/GovernorDetailsComponent.cs
@@ -856,16 +856,16 @@ namespace Ship_Game
             {
                 float percentSpent  = spent / budget.TotalAlloc.LowerBound(0.01f) * 100;
                 BudgetSum.Text      = $"{Localizer.Token(GameText.Total3)} {spent.String(1)}" +
-                                      $" {Localizer.Token(GameText.Of)} {budget.TotalAlloc.String(1)} BC/Y";
+                                      $" {Localizer.Token(GameText.Of)} {budget.TotalAlloc.String(1)} bc/turn";
                 BudgetPercent.Text  = $" ({percentSpent.String(1)}%)";
                 BudgetPercent.Color = GetColor();
             }
             else
             {
-                NoGovernorCivExpense.Text = $"{Planet.CivilianBuildingsMaintenance.String(2)} BC/Y";
-                NoGovernorGrdExpense.Text = $"{Planet.GroundDefMaintenance.String(2)} BC/Y";
-                NoGovernorSpcExpense.Text = $"{Planet.SpaceDefMaintenance.String(2)} BC/Y";
-                BudgetSum.Text            = $"{Localizer.Token(GameText.Total3)} {spent.String(2)} BC/Y";
+                NoGovernorCivExpense.Text = $"{Planet.CivilianBuildingsMaintenance.String(2)} bc/turn";
+                NoGovernorGrdExpense.Text = $"{Planet.GroundDefMaintenance.String(2)} bc/turn";
+                NoGovernorSpcExpense.Text = $"{Planet.SpaceDefMaintenance.String(2)} bc/turn";
+                BudgetSum.Text            = $"{Localizer.Token(GameText.Total3)} {spent.String(2)} bc/turn";
                 BudgetPercent.Text        = "";
             }
 

--- a/Ship_Game/GameScreens/ColonyScreen/GovernorDetailsComponent.cs
+++ b/Ship_Game/GameScreens/ColonyScreen/GovernorDetailsComponent.cs
@@ -856,17 +856,17 @@ namespace Ship_Game
             {
                 float percentSpent  = spent / budget.TotalAlloc.LowerBound(0.01f) * 100;
                 BudgetSum.Text      = $"{Localizer.Token(GameText.Total3)} {spent.String(1)}" +
-                                      $" {Localizer.Token(GameText.Of)} {budget.TotalAlloc.String(1)} bc/turn";
+                                      $" {Localizer.Token(GameText.Of)} {budget.TotalAlloc.String(1)} bc/t";
                 BudgetPercent.Text  = $" ({percentSpent.String(1)}%)";
-                BudgetPercent.Pos   = new Vector2(BudgetSum.Pos.X + FontBig.TextWidth(BudgetSum.Text) + 4, BudgetSum.Pos.Y); // follow the total text (bc/turn is wider than the old label)
+                BudgetPercent.Pos   = new Vector2(BudgetSum.Pos.X + FontBig.TextWidth(BudgetSum.Text) + 4, BudgetSum.Pos.Y); // follow the total text (the unit label's width varies)
                 BudgetPercent.Color = GetColor();
             }
             else
             {
-                NoGovernorCivExpense.Text = $"{Planet.CivilianBuildingsMaintenance.String(2)} bc/turn";
-                NoGovernorGrdExpense.Text = $"{Planet.GroundDefMaintenance.String(2)} bc/turn";
-                NoGovernorSpcExpense.Text = $"{Planet.SpaceDefMaintenance.String(2)} bc/turn";
-                BudgetSum.Text            = $"{Localizer.Token(GameText.Total3)} {spent.String(2)} bc/turn";
+                NoGovernorCivExpense.Text = $"{Planet.CivilianBuildingsMaintenance.String(2)} bc/t";
+                NoGovernorGrdExpense.Text = $"{Planet.GroundDefMaintenance.String(2)} bc/t";
+                NoGovernorSpcExpense.Text = $"{Planet.SpaceDefMaintenance.String(2)} bc/t";
+                BudgetSum.Text            = $"{Localizer.Token(GameText.Total3)} {spent.String(2)} bc/t";
                 BudgetPercent.Text        = "";
             }
 

--- a/Ship_Game/GameScreens/Espionage/EmpiresButton.cs
+++ b/Ship_Game/GameScreens/Espionage/EmpiresButton.cs
@@ -274,7 +274,7 @@ namespace Ship_Game.GameScreens
         void UpdateCostPerTurn()
         {
             float espionageCost = Player.GetEspionageCost();
-            CostPerTurn.Text = $"{(espionageCost > 0 ? -espionageCost : espionageCost).String(1)} bc/y";
+            CostPerTurn.Text = $"{(espionageCost > 0 ? -espionageCost : espionageCost).String(1)} bc/turn";
             CostPerTurn.Color = espionageCost > 0 ? Color.Pink : Color.LightGreen;
         }
 

--- a/Ship_Game/GameScreens/Espionage/EmpiresButton.cs
+++ b/Ship_Game/GameScreens/Espionage/EmpiresButton.cs
@@ -274,7 +274,7 @@ namespace Ship_Game.GameScreens
         void UpdateCostPerTurn()
         {
             float espionageCost = Player.GetEspionageCost();
-            CostPerTurn.Text = $"{(espionageCost > 0 ? -espionageCost : espionageCost).String(1)} bc/turn";
+            CostPerTurn.Text = $"{(espionageCost > 0 ? -espionageCost : espionageCost).String(1)} bc/t";
             CostPerTurn.Color = espionageCost > 0 ? Color.Pink : Color.LightGreen;
         }
 

--- a/Ship_Game/GameScreens/Universe/BudgetScreen.cs
+++ b/Ship_Game/GameScreens/Universe/BudgetScreen.cs
@@ -105,8 +105,8 @@ namespace Ship_Game.GameScreens
                                     text:GameText.NetGain, Fonts.Arial20Bold);
             EmpireNetIncome.DropShadow  = true;
             string unitNote = "(all money values are per turn)";
-            Label(new Vector2(Window.Menu.Right - Fonts.Arial12.TextWidth(unitNote) - 22, Window.Menu.Y + 24),
-                  unitNote, Fonts.Arial12, Color.Gray); // added last so it draws over the panels
+            Label(new Vector2(Window.Menu.CenterTextX(unitNote, Fonts.Arial12), Window.Menu.Y + 38),
+                  unitNote, Fonts.Arial12, Color.Gray); // centered under the title, added last so it draws over the panels
             EmpireNetIncome.DynamicText = DynamicText(
                 ()   => Player.NetIncome-Player.MoneySpendOnProductionNow,
                 (f) => $"{( f >= 0f ? Localizer.Token(GameText.NetGain) : Localizer.Token(GameText.NetLoss) )} : {f.MoneyString()}");

--- a/Ship_Game/GameScreens/Universe/BudgetScreen.cs
+++ b/Ship_Game/GameScreens/Universe/BudgetScreen.cs
@@ -79,6 +79,8 @@ namespace Ship_Game.GameScreens
             //Screen Title
             string title   = Localizer.Token(GameText.EconomicOverview);
             Label(Window.Menu.CenterTextX(title), Window.Menu.Y + 20, title);
+            string unitNote = "(all money values are per turn)";
+            Label(new Vector2(Window.Menu.CenterTextX(unitNote, Fonts.Arial12), Window.Menu.Y + 42), unitNote, Fonts.Arial12, Color.Gray);
 
             // background panels for TaxRate, incomes, cost, trade: 6138
             SummaryPanel tax = Add(new SummaryPanel("", taxRect, new Color(17, 21, 28)));

--- a/Ship_Game/GameScreens/Universe/BudgetScreen.cs
+++ b/Ship_Game/GameScreens/Universe/BudgetScreen.cs
@@ -79,9 +79,6 @@ namespace Ship_Game.GameScreens
             //Screen Title
             string title   = Localizer.Token(GameText.EconomicOverview);
             Label(Window.Menu.CenterTextX(title), Window.Menu.Y + 20, title);
-            string unitNote = "(all money values are per turn)";
-            Label(new Vector2(Window.Menu.CenterTextX(unitNote, Fonts.Arial12), Window.Menu.Y + 42), unitNote, Fonts.Arial12, Color.Gray);
-
             // background panels for TaxRate, incomes, cost, trade: 6138
             SummaryPanel tax = Add(new SummaryPanel("", taxRect, new Color(17, 21, 28)));
             var taxTitle = Player.AutoTaxes ? GameText.AutoTaxes : GameText.TaxRate;
@@ -107,6 +104,9 @@ namespace Ship_Game.GameScreens
             EmpireNetIncome = Label(Window.Menu.Right - 200,Window.Menu.Bottom - 47,
                                     text:GameText.NetGain, Fonts.Arial20Bold);
             EmpireNetIncome.DropShadow  = true;
+            string unitNote = "(all money values are per turn)";
+            Label(new Vector2(Window.Menu.Right - Fonts.Arial12.TextWidth(unitNote) - 22, Window.Menu.Y + 24),
+                  unitNote, Fonts.Arial12, Color.Gray); // added last so it draws over the panels
             EmpireNetIncome.DynamicText = DynamicText(
                 ()   => Player.NetIncome-Player.MoneySpendOnProductionNow,
                 (f) => $"{( f >= 0f ? Localizer.Token(GameText.NetGain) : Localizer.Token(GameText.NetLoss) )} : {f.MoneyString()}");

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -8492,7 +8492,7 @@ TreasuryGoal:
  PTB: "Meta do Tesouro"
 TreasuryGoalIsTheTarget:
  Id: 1918
- ENG: "Treasury Goal is the target treasury amount for the empire. The various governors use this value to set their budgets. Warning: This is a percentage of a 20 year projection. This can cause massive empire overspending. "
+ ENG: "Treasury Goal is the target treasury amount for the empire. The various governors use this value to set their budgets. Warning: This is a percentage of a 20 year (200 turns) projection. This can cause massive empire overspending. "
  RUS: "Цель казначейства - целевая сумма казны империи. Различные губернаторы используют это значение для определения своих бюджетов. Предупреждение: это процент от 20-летнего прогноза. Это может привести к огромным перерасходам империи."
  UKR: "Мета скарбниці - це цільова сума скарбниці для імперії. Різні губернатори використовують це значення для формування своїх бюджетів. Попередження: Це відсоток від 20-річного прогнозу. Це може призвести до значних перевитрат імперії."
  PTB: "A Meta do Tesouro é o valor-alvo do tesouro para o império. Os vários governadores usam esse valor para definir seus orçamentos. Aviso: isso é uma porcentagem de uma projeção de 20 anos. Isso pode causar gastos imperiais massivos. "
@@ -13764,9 +13764,9 @@ OverrideThisBudgetAndSet:
  PTB: "Substitua este orçamento e defina o seu próprio."
 CivilianBuildingsExpenditurebudgetInByc:
  Id: 4228
- ENG: "Civilian Buildings Expenditure/Budget in bc/y. If you see over-budget, you might have buildings you have manually built and the Governor cannot scrap them."
+ ENG: "Civilian Buildings Expenditure/Budget in bc/turn. If you see over-budget, you might have buildings you have manually built and the Governor cannot scrap them."
  RUS: "Расходы/бюджет на гражданские здания в МГ/K (Миллиард Кредитов/Год). Если вы наблюдаете превышение бюджета, возможно, есть здания, которые вы построили вручную, и губернатор не может их снести."
- UKR: "Витрати/бюджет на цивільні будівлі в bc/y. Якщо ви бачите перевиконання бюджету, можливо, у вас є будівлі, які ви побудували вручну, і губернатор не може їх здати на металобрухт."
+ UKR: "Витрати/бюджет на цивільні будівлі в bc/turn. Якщо ви бачите перевиконання бюджету, можливо, у вас є будівлі, які ви побудували вручну, і губернатор не може їх здати на металобрухт."
  PTB: "Gasto/Orçamento de Construções Civis em bc/ano. Se aparecer acima do orçamento, talvez haja construções feitas manualmente que o Governador não pode sucatear."
 GroundDefenseBuildingsExpenditurebudgetIn:
  Id: 4229

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -13770,34 +13770,34 @@ CivilianBuildingsExpenditurebudgetInByc:
  PTB: "Gasto/Orçamento de Construções Civis em bc/ano. Se aparecer acima do orçamento, talvez haja construções feitas manualmente que o Governador não pode sucatear."
 GroundDefenseBuildingsExpenditurebudgetIn:
  Id: 4229
- ENG: "Ground Defense Buildings Expenditure/Budget in BY/C. If you see over-budget, you might have buildings you have manually built and the Governor cannot scrap them."
+ ENG: "Ground Defense Buildings Expenditure/Budget in bc/turn. If you see over-budget, you might have buildings you have manually built and the Governor cannot scrap them."
  RUS: "Расходы/бюджет на здания наземной обороны в МК/Г (Миллиард Кредитов/Год). Если вы видите превышение бюджета, возможно, есть здания, которые вы построили вручную, и губернатор не может их снести."
- UKR: "Витрати/бюджет на наземні оборонні споруди в BY/C. Якщо ви бачите перевиконання бюджету, можливо, у вас є будівлі, які ви побудували вручну, і губернатор не може їх здати на металобрухт."
- PTB: "Gasto/Orçamento de Construções de Defesa Terrestre em BY/C. Se aparecer acima do orçamento, talvez haja construções feitas manualmente que o Governador não pode sucatear."
+ UKR: "Витрати/бюджет на наземні оборонні споруди в bc/turn. Якщо ви бачите перевиконання бюджету, можливо, у вас є будівлі, які ви побудували вручну, і губернатор не може їх здати на металобрухт."
+ PTB: "Gasto/Orçamento de Construções de Defesa Terrestre em bc/turn. Se aparecer acima do orçamento, talvez haja construções feitas manualmente que o Governador não pode sucatear."
 OrbitalsExpenditurebudgetInByc:
  Id: 4230
- ENG: "Orbitals Expenditure/Budget in BY/C"
+ ENG: "Orbitals Expenditure/Budget in bc/turn"
  RUS: "Расходы/бюджет на орбитальные конструкции в МК/Г"
- UKR: "Витрати/бюджет орбіти в BY/C"
- PTB: "Gasto/Orçamento de Orbitais em BY/C"
+ UKR: "Витрати/бюджет орбіти в bc/turn"
+ PTB: "Gasto/Orçamento de Orbitais em bc/turn"
 CivilianBuildingsExpenditureInByc:
  Id: 4231
- ENG: "Civilian Buildings Expenditure in BY/C"
+ ENG: "Civilian Buildings Expenditure in bc/turn"
  RUS: "Расходы на гражданские здания в МК/Г"
  UKR: "Видатки на цивільні будівлі в білоруських рублях"
- PTB: "Gasto de Construções Civis em BY/C"
+ PTB: "Gasto de Construções Civis em bc/turn"
 GroundDefenseBuildingsExpenditureIn:
  Id: 4232
- ENG: "Ground Defense Buildings Expenditure in BY/C"
+ ENG: "Ground Defense Buildings Expenditure in bc/turn"
  RUS: "Расходы на здания наземной обороны в МК/Г"
  UKR: "Витрати на наземні оборонні споруди в британських доларах"
- PTB: "Gasto de Construções de Defesa Terrestre em BY/C"
+ PTB: "Gasto de Construções de Defesa Terrestre em bc/turn"
 OrbitalsExpenditureInByc:
  Id: 4233
- ENG: "Orbitals Expenditure in BY/C"
+ ENG: "Orbitals Expenditure in bc/turn"
  RUS: "Расходы на орбитали в МК/Г"
- UKR: "Витрати на орбіти в BY/C"
- PTB: "Gasto de Orbitais em BY/C"
+ UKR: "Витрати на орбіти в bc/turn"
+ PTB: "Gasto de Orbitais em bc/turn"
 Total3:
  Id: 4234
  ENG: "Total:"

--- a/game/Content/GameText.yaml
+++ b/game/Content/GameText.yaml
@@ -13764,40 +13764,40 @@ OverrideThisBudgetAndSet:
  PTB: "Substitua este orçamento e defina o seu próprio."
 CivilianBuildingsExpenditurebudgetInByc:
  Id: 4228
- ENG: "Civilian Buildings Expenditure/Budget in bc/turn. If you see over-budget, you might have buildings you have manually built and the Governor cannot scrap them."
+ ENG: "Civilian Buildings Expenditure/Budget in bc/t. If you see over-budget, you might have buildings you have manually built and the Governor cannot scrap them."
  RUS: "Расходы/бюджет на гражданские здания в МГ/K (Миллиард Кредитов/Год). Если вы наблюдаете превышение бюджета, возможно, есть здания, которые вы построили вручную, и губернатор не может их снести."
- UKR: "Витрати/бюджет на цивільні будівлі в bc/turn. Якщо ви бачите перевиконання бюджету, можливо, у вас є будівлі, які ви побудували вручну, і губернатор не може їх здати на металобрухт."
+ UKR: "Витрати/бюджет на цивільні будівлі в bc/t. Якщо ви бачите перевиконання бюджету, можливо, у вас є будівлі, які ви побудували вручну, і губернатор не може їх здати на металобрухт."
  PTB: "Gasto/Orçamento de Construções Civis em bc/ano. Se aparecer acima do orçamento, talvez haja construções feitas manualmente que o Governador não pode sucatear."
 GroundDefenseBuildingsExpenditurebudgetIn:
  Id: 4229
- ENG: "Ground Defense Buildings Expenditure/Budget in bc/turn. If you see over-budget, you might have buildings you have manually built and the Governor cannot scrap them."
+ ENG: "Ground Defense Buildings Expenditure/Budget in bc/t. If you see over-budget, you might have buildings you have manually built and the Governor cannot scrap them."
  RUS: "Расходы/бюджет на здания наземной обороны в МК/Г (Миллиард Кредитов/Год). Если вы видите превышение бюджета, возможно, есть здания, которые вы построили вручную, и губернатор не может их снести."
- UKR: "Витрати/бюджет на наземні оборонні споруди в bc/turn. Якщо ви бачите перевиконання бюджету, можливо, у вас є будівлі, які ви побудували вручну, і губернатор не може їх здати на металобрухт."
- PTB: "Gasto/Orçamento de Construções de Defesa Terrestre em bc/turn. Se aparecer acima do orçamento, talvez haja construções feitas manualmente que o Governador não pode sucatear."
+ UKR: "Витрати/бюджет на наземні оборонні споруди в bc/t. Якщо ви бачите перевиконання бюджету, можливо, у вас є будівлі, які ви побудували вручну, і губернатор не може їх здати на металобрухт."
+ PTB: "Gasto/Orçamento de Construções de Defesa Terrestre em bc/t. Se aparecer acima do orçamento, talvez haja construções feitas manualmente que o Governador não pode sucatear."
 OrbitalsExpenditurebudgetInByc:
  Id: 4230
- ENG: "Orbitals Expenditure/Budget in bc/turn"
+ ENG: "Orbitals Expenditure/Budget in bc/t"
  RUS: "Расходы/бюджет на орбитальные конструкции в МК/Г"
- UKR: "Витрати/бюджет орбіти в bc/turn"
- PTB: "Gasto/Orçamento de Orbitais em bc/turn"
+ UKR: "Витрати/бюджет орбіти в bc/t"
+ PTB: "Gasto/Orçamento de Orbitais em bc/t"
 CivilianBuildingsExpenditureInByc:
  Id: 4231
- ENG: "Civilian Buildings Expenditure in bc/turn"
+ ENG: "Civilian Buildings Expenditure in bc/t"
  RUS: "Расходы на гражданские здания в МК/Г"
  UKR: "Видатки на цивільні будівлі в білоруських рублях"
- PTB: "Gasto de Construções Civis em bc/turn"
+ PTB: "Gasto de Construções Civis em bc/t"
 GroundDefenseBuildingsExpenditureIn:
  Id: 4232
- ENG: "Ground Defense Buildings Expenditure in bc/turn"
+ ENG: "Ground Defense Buildings Expenditure in bc/t"
  RUS: "Расходы на здания наземной обороны в МК/Г"
  UKR: "Витрати на наземні оборонні споруди в британських доларах"
- PTB: "Gasto de Construções de Defesa Terrestre em bc/turn"
+ PTB: "Gasto de Construções de Defesa Terrestre em bc/t"
 OrbitalsExpenditureInByc:
  Id: 4233
- ENG: "Orbitals Expenditure in bc/turn"
+ ENG: "Orbitals Expenditure in bc/t"
  RUS: "Расходы на орбитали в МК/Г"
- UKR: "Витрати на орбіти в bc/turn"
- PTB: "Gasto de Orbitais em bc/turn"
+ UKR: "Витрати на орбіти в bc/t"
+ PTB: "Gasto de Orbitais em bc/t"
 Total3:
  Id: 4234
  ENG: "Total:"


### PR DESCRIPTION
- Espionage screen: cost label bc/y -> bc/turn (backing field is CostPerTurn)
- Governor civilian budget tooltip: bc/y -> bc/turn (ENG + UKR)
- Economic Overview: subtitle noting all money values are per turn
- Treasury Goal tooltip: clarify 20 year projection = 200 turns

Money is charged every turn while some labels implied per star-year
(10 turns). Maintainer feedback.

Test status: labels only; verified in-game on our fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
