### PR TITLE
Research screen: anchor the Search button to the frame bottom

### DIFF
--- a/Ship_Game/GameScreens/Universe/ResearchScreenNew.cs
+++ b/Ship_Game/GameScreens/Universe/ResearchScreenNew.cs
@@ -97,7 +97,7 @@ namespace Ship_Game
             // Create queue once all techs are populated
             var queue = new Rectangle(main.X + main.Width - 355, main.Y + 40, 330, main.Height - 100);
             Queue = Add(new ResearchQueueUIComponent(this, queue));
-            Vector2 searchPos = new(main.X + main.Width - 360, main.Height - 55);
+            Vector2 searchPos = new(main.X + main.Width - 360, main.Bottom - 55);
             Search = Add(new UIButton(ButtonStyle.BigDip, searchPos, "Search"));
             Search.OnClick = OnSearchButtonClicked;
 


### PR DESCRIPTION
`searchPos` uses `main.Height` as a Y coordinate — harmless today because the frame starts at zero, but it is `main.Bottom` that was meant, and any future offset of the research frame silently misplaces the button (we hit it on our fork).

Test status: no visible change upstream by construction; verified in-game on our fork with an offset frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)