### PR TITLE
Governor no-scrap setting protects player buildings from Replace

### DIFF
--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
@@ -339,7 +339,10 @@ namespace Ship_Game
             if (BuildingsHereCanBeBuiltAnywhere || BuildingsCanBuild.Count == 0)
                 return;
 
-            // Replace works even if the governor is not scrapping buildings, unless they are player built
+            // a replace is a scrap with a gift behind it: the no-scrap setting covers it too (upstream issue 303)
+            if (GovernorShouldNotScrapBuilding)
+                return;
+
             float worstBuildingScore = ChooseWorstBuilding(overBudget, scrapZeroMaintenance: true, true, out Building worstBuilding);
             if (worstBuilding == null)
                 return;
@@ -483,6 +486,7 @@ namespace Ship_Game
             if (b.IsBiospheres
                 || b.IsMilitary
                 || !b.Scrappable
+                || b.IsPlayerAdded && OwnerIsPlayer // player-built is never the governor's to scrap — the guard below sat after the no-blueprint early return and was unreachable (upstream issue 303)
                 || b.IsSpacePort && Owner.GetPlanets().Count == 1 // Dont scrap our last spaceport
                 || b.BuildOnlyOnce
                 || b.PlusTerraformPoints > 0) // using this instead of IsTerraformer since some event building might also terraform without the terraformer building ID


### PR DESCRIPTION
Fixes #303.

Two stacked holes made the setting a no-op exactly where the reporter hit it:
- `ReplaceBuilding` never consulted the per-design `DontScrapBuildings` setting (`TryScrapBuilding` and the over-budget path do). A replace is a scrap with a gift behind it, so the setting now covers it.
- The *unless they are player built* guard in `SuitableForScrap` sat after the no-blueprint early return — without blueprints every building exited as scrappable one line earlier, so the player guard was dead code. It moves to the head of the method, unconditional.

Test status: compiled and logic-reviewed against the issue's repro; play-testing on our fork pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)