### PR TITLE
Governor builds biospheres again on ex-volcano worlds

### DIFF
--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
@@ -851,9 +851,12 @@ namespace Ship_Game
                 PlanetGridSquare preferred = null;
                 if (Owner.IsBuildingUnlocked(Building.TerraformerId))
                 {
-                    preferred = TilesList.Find(t => !t.Habitable && !t.Terraformable && !t.BuildingOnTile);
-                    if (preferred == null)
-                        preferred = TilesList.Find(t => !t.Habitable && !t.Terraformable);
+                    // upstream issue 312: the old fallback accepted tiles carrying a building or a
+                    // queued item; Enqueue rejected them every pass while perfectly valid terraformable
+                    // tiles stayed excluded, so the governor never built the biosphere (manual placement
+                    // worked, it validates the actual tile). A null preferred falls through to random
+                    // tile assignment, which accepts terraformables.
+                    preferred = TilesList.Find(t => !t.Habitable && !t.Terraformable && !t.BuildingOnTile && t.NoQueuedBuildings);
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #312.

`GetPreferredTile`'s fallback `Find` accepted tiles carrying a building or a queued item; `Enqueue` then rejected that exact tile on every governor pass, while perfectly valid terraformable tiles (e.g. flagged back after an eruption, Volcano.cs restores the flag) stayed excluded from preference. Net effect: the governor stalled forever on those worlds, and manual placement worked because it validates the actual tile — the reporter's exact experience.

The preferred tile is now enqueue-valid or null; null falls through to the existing random tile assignment, which accepts terraformables.

Test status: compiled and logic-reviewed against the issue's repro (save Jerez I, Star Date 1159.8); play-testing on our fork pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)