### PR TITLE
Prioritized projectors queue below earlier projectors

### DIFF
--- a/Ship_Game/Universe/SolarBodies/SBProduction.cs
+++ b/Ship_Game/Universe/SolarBodies/SBProduction.cs
@@ -492,11 +492,19 @@ namespace Ship_Game.Universe.SolarBodies
                     if (P.Owner.AutoBuildTerraformers && P.Owner.data.Traits.TerraformingLevel > 0 && !item.IsPlayerAdded)
                         DePrioritizeTerraformer();
 
-                    if (item.Rush && item.QType == QueueItemType.OrbitalUrgent
-                        || P.Universe.P.PrioitizeProjectors && item.QType == QueueItemType.RoadNode)
+                    if (item.Rush && item.QType == QueueItemType.OrbitalUrgent)
                     {
-                        // prioritize projector bridges for the player (or any projector if flag is set).
                         MoveTo(0, Count - 1);
+                    }
+                    else if (P.Universe.P.PrioitizeProjectors && item.QType == QueueItemType.RoadNode)
+                    {
+                        // prioritize projector bridges for the player — but BELOW the projectors
+                        // already leading the queue, so a road completes segment by segment
+                        // instead of three half-roads racing each other (upstream issue 300)
+                        int insertAt = 0;
+                        while (insertAt < Count - 1 && ConstructionQueue[insertAt].QType == QueueItemType.RoadNode)
+                            ++insertAt;
+                        MoveTo(insertAt, Count - 1);
                     }
                 }
 


### PR DESCRIPTION
Fixes #300.

Each new road node was moved to the absolute top of the queue, above
the projectors already prioritized — so a long road built as several
half-roads racing each other. New nodes now slot in after the road
nodes already leading the queue; rushed urgent orbitals keep the
absolute front.

Test status: compiled and logic-reviewed against the issue's repro; play-testing on our fork pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
