### PR TITLE
Crash sites wait for the conquest to resolve

### DIFF
--- a/Ship_Game/Universe/SolarBodies/PlanetGridSquare.cs
+++ b/Ship_Game/Universe/SolarBodies/PlanetGridSquare.cs
@@ -324,7 +324,10 @@ namespace Ship_Game
             {
                 if (IsCrashSiteActive)
                 {
-                    if (!planet.SpaceCombatNearPlanet)
+                    // upstream issue 343: no recovery infrastructure on a planet someone else
+                    // still owns — an invader waits for the conquest to resolve. Safe to defer:
+                    // this check re-fires as long as a troop holds the tile.
+                    if (!planet.SpaceCombatNearPlanet && (planet.Owner == null || planet.Owner == empire))
                         CrashSite.ActivateSite(planet.Universe, planet, empire, this);
                 }
                 else


### PR DESCRIPTION
Fixes #343.

Landing troops on a crash-site tile of a planet someone else still
owns triggered the recovery mid-invasion (credits or even a spawned
ship for the invader). There is no recovery infrastructure on a world
you do not own yet: activation now waits until the planet is neutral
or yours. Deferring is safe — the trigger re-fires while a troop
holds the tile, so the site activates right after the conquest.

Test status: compiled and logic-reviewed against the issue's repro; play-testing on our fork pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
