### PR TITLE
Box select survives troop transports in the rectangle

### DIFF
--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.HandleInput.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.HandleInput.cs
@@ -840,7 +840,8 @@ namespace Ship_Game
 
             // TODO: These are not documented to the players
             bool addToSelection = input.IsShiftKeyDown;
-            bool selectAll      = input.IsCtrlKeyDown || !hasCombatShips;
+            bool ctrlSelect     = input.IsCtrlKeyDown;
+            bool selectAll      = ctrlSelect || !hasCombatShips;
             bool nonPlayer      = input.IsAltKeyDown || !potentialShips.Any(s => s.Loyalty.isPlayer);
             bool onlyPlayer     = !nonPlayer && potentialShips.Any(s => s.Loyalty.isPlayer);
 
@@ -859,11 +860,14 @@ namespace Ship_Game
                 ships.RemoveAll(NonCombatShip);
             }
 
-            if (onlyPlayer && !hasCombatShips)
+            if (onlyPlayer && !ctrlSelect && !hasCombatShips)
             {
                 // if we selected a bunch of civilian ships, but some of them are troop transports
-                // then discard all ships that aren't troop transports
-                bool hasTroopTransports = potentialShips.Any(s => s.IsSingleTroopShip);
+                // then discard all ships that aren't troop transports.
+                // upstream issue 298: count only the player's own selected ships — an ENEMY
+                // transport in the box used to poison this and strip the whole selection.
+                // And Ctrl means 'everything of mine': the preference filter yields to it.
+                bool hasTroopTransports = ships.Any(s => s.IsSingleTroopShip);
                 if (hasTroopTransports)
                     ships.RemoveAll(s => !s.IsSingleTroopShip);
             }


### PR DESCRIPTION
Fixes #298.

The prefer-troop-transports filter counted transports among ALL ships
in the box — an ENEMY transport stripped the player's own selection to
nothing. It now counts only the player's selected ships. Ctrl-select
means 'everything of mine', so the preference filter yields to it;
plain box select over your civilians keeps preferring your transports.

Test status: compiled and logic-reviewed against the issue's repro; play-testing on our fork pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
