### PR TITLE
Projector roads have no more gaps between circles

### DIFF
--- a/Ship_Game/Gameplay/SpaceRoad.cs
+++ b/Ship_Game/Gameplay/SpaceRoad.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using SDGraphics;
@@ -132,7 +133,11 @@ namespace Ship_Game.Gameplay
         {
             float projectorRadius = owner.GetProjectorRadius() * ProjectorDensity;
             float distance = origin.Position.Distance(destination.Position);
-            return (int)(distance / projectorRadius);
+            if (distance <= projectorRadius)
+                return 0; // the hop is short enough for the systems own influence
+            // upstream issue 301: flooring left up to a whole projector-length of the road
+            // uncovered, drawing roads with open gaps between the circles. Round up.
+            return (int)Math.Ceiling(distance / projectorRadius);
         }
 
         // This ensures a road will be the same object, regardless of the order of sys1 and sys2

--- a/UnitTests/AITests/Empire/SpaceRoadsTests.cs
+++ b/UnitTests/AITests/Empire/SpaceRoadsTests.cs
@@ -33,7 +33,7 @@ namespace UnitTests.AITests.Empire
 
         void CreateSystemsAndRoad() // 5 projectors
         {
-            CreateSystemsAndPlanets(800000);
+            CreateSystemsAndPlanets(660000); // exactly 5 projectors under the round-up contract (issue 301)
             int numProjectors = SpaceRoad.GetNeededNumProjectors(System1, System2, Player);
             string name = SpaceRoad.GetSpaceRoadName(System1, System2);
             Road = new(System1, System2, Player, numProjectors, name, 
@@ -67,7 +67,7 @@ namespace UnitTests.AITests.Empire
         {
             CreateSystemsAndPlanets(300000);
             int numProjectors = SpaceRoad.GetNeededNumProjectors(System1, System2, Player);
-            AssertEqual(2, numProjectors);
+            AssertEqual(3, numProjectors); // ceil since issue 300 fix: 300000 / (80000*1.7) = 2.21 rounds up
         }
 
         [TestMethod]
@@ -75,7 +75,7 @@ namespace UnitTests.AITests.Empire
         {
             CreateSystemsAndPlanets(1000000);
             int numProjectors = SpaceRoad.GetNeededNumProjectors(System1, System2, Player);
-            AssertEqual(7, numProjectors);
+            AssertEqual(8, numProjectors); // ceil since issue 300 fix: 1000000 / 136000 = 7.35 rounds up
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes #301.

The needed projector count was floored, leaving up to a whole
projector-length of the road uncovered — visible as openings between
the influence circles. Rounded up now; hops short enough for the
systems' own influence still get no projector. The reporter's second
point (end nodes placed closer to the planets than the systems' own
influence requires) is a separate refinement, noted for later.

Test status: compiled and logic-reviewed against the issue's repro; play-testing on our fork pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
