### PR TITLE
Espionage intel: count THEIR moles at us, not ours at them

### DIFF
--- a/Ship_Game/Empire_Espionage.cs
+++ b/Ship_Game/Empire_Espionage.cs
@@ -132,7 +132,9 @@ namespace Ship_Game
 
         public int GetNumOfTheirMoles(Empire them)
         {
-            return NewEspionageEnabled ? GetEspionage(them).NumPlantedMoles 
+            // upstream issue 311: this read OUR moles planted at THEM (constant 1, the auto
+            // sticky mole), while the intel panel and the legacy branch mean THEIR moles at US
+            return NewEspionageEnabled ? them.GetEspionage(this).NumPlantedMoles 
                                        : them.data.MoleList.Count(m =>  Universe.GetPlanet(m.PlanetId).Owner == this);
         }
 


### PR DESCRIPTION
Fixes #311.

The new-espionage branch of GetNumOfTheirMoles returned the moles WE
planted at the target empire — a constant 1 (the auto sticky mole) —
while the intel panel and the legacy branch mean the moles THEY have
planted at us. One inverted keyword; catching a spy now moves the
displayed count.

Test status: compiled and logic-reviewed against the issue's repro (diagnostic with exact code paths in the linked report); play-testing on our fork pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
