### PR TITLE
Open borders costs the same trust whichever side offers it

### DIFF
--- a/Ship_Game/AI/EmpireAI/EmpireAI.DiplomacyOffers.cs
+++ b/Ship_Game/AI/EmpireAI/EmpireAI.DiplomacyOffers.cs
@@ -321,8 +321,10 @@ namespace Ship_Game.AI
             {
                 totalTrustRequiredFromUs += dt.Trade;
             }
-            if (ourOffer.OpenBorders)
+            if (ourOffer.OpenBorders || theirOffer.OpenBorders)
             {
+                // upstream issue 306: the treaty is signed bilateral either way — accepting
+                // 'their' open borders opens OUR borders too, so it costs the same trust
                 totalTrustRequiredFromUs += (dt.NAPact + 7.5f);
             }
             if (ourOffer.NAPact)
@@ -366,6 +368,7 @@ namespace Ship_Game.AI
             }
 
             if (ourOffer.OpenBorders)   valueToThem += 5f;
+            if (theirOffer.OpenBorders) valueToThem += 5f; // issue 306: they receive the access either way
             if (theirOffer.OpenBorders) valueToUs   += them.isPlayer ? 2f : 5f;
             if (ourOffer.NAPact)        valueToThem += 10f;
             if (theirOffer.NAPact)      valueToUs   += 10f;


### PR DESCRIPTION
Fixes #306.

The treaty is signed bilateral on acceptance (SignTreatyWith), but the
evaluator only charged trust when the AI itself offered open borders —
accepting the player's one-sided 'gift' opens the AI's borders too and
was treated as free. Same trust cost either way now, and the value
credit applies either way.

Test status: compiled and logic-reviewed against the issue's repro (diagnostic with exact code paths in the linked report); play-testing on our fork pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
