### PR TITLE
Demands cannot be dodged without consequence

### DIFF
--- a/Ship_Game/AI/EmpireAI/Offer.cs
+++ b/Ship_Game/AI/EmpireAI/Offer.cs
@@ -9,6 +9,11 @@ namespace Ship_Game
         public Array<string> TechnologiesOffered = new();
         public Array<string> ArtifactsOffered = new();
         public Ref<bool> ValueToModify;
+        // upstream issue 307: marks a true ultimatum (currently only DemandTech).
+        // ValueToModify alone is NOT a demand marker - peace/trade/alliance dialogs
+        // use it too, with per-dialog semantics (the peace Ref fires SetImperialistWar
+        // on any write), so the dodge-a-demand penalty must key on this flag.
+        public bool IsDemand;
         public bool PeaceTreaty;
         public bool Alliance;
         public string AcceptDL;

--- a/Ship_Game/GameScreens/DiplomacyScreen/DiplomacyScreen.cs
+++ b/Ship_Game/GameScreens/DiplomacyScreen/DiplomacyScreen.cs
@@ -702,13 +702,27 @@ namespace Ship_Game.GameScreens.DiplomacyScreen
             OnOfferChanged();
         }
 
+        bool DemandAnswered; // upstream issue 307
+
+        // upstream issue 307: only the Reject button carried the refusal penalty — walking
+        // out, discussing or negotiating away an ultimatum had no consequence, though
+        // CanEscapeFromScreen=false shows the player was meant to answer. An explicit
+        // Accept/Reject afterwards still overwrites the flag.
+        void MarkUnansweredDemandRejected()
+        {
+            if (!DemandAnswered && TheirOffer?.ValueToModify != null)
+                TheirOffer.ValueToModify.Value = true;
+        }
+
         void OnNegotiateClicked(GenericButton b)
         {
+            MarkUnansweredDemandRejected();
             BeginNegotiations();
         }
 
         void OnAcceptClicked(GenericButton b)
         {
+            DemandAnswered = true; // upstream issue 307
             if (TheirOffer.ValueToModify != null) TheirOffer.ValueToModify.Value = false;
             if (OurOffer.ValueToModify != null)   OurOffer.ValueToModify.Value = true;
 
@@ -718,6 +732,7 @@ namespace Ship_Game.GameScreens.DiplomacyScreen
 
         void OnRejectClicked(GenericButton b)
         {
+            DemandAnswered = true; // upstream issue 307
             if (TheirOffer.ValueToModify != null) TheirOffer.ValueToModify.Value = true;
             if (OurOffer.ValueToModify != null)   OurOffer.ValueToModify.Value = false;
             
@@ -740,6 +755,7 @@ namespace Ship_Game.GameScreens.DiplomacyScreen
 
         void OnDiscussButtonClicked(GenericButton b)
         {
+            MarkUnansweredDemandRejected();
             Array<DialogOption> options = new();
             foreach (StatementSet set in ResourceManager.GetDiplomacyDialog("SharedDiplomacy").StatementSets)
             {
@@ -762,6 +778,7 @@ namespace Ship_Game.GameScreens.DiplomacyScreen
 
         void OnExitClicked(GenericButton b)
         {
+            MarkUnansweredDemandRejected();
             Audio.GameAudio.SwitchBackToGenericMusic();
             ExitScreen();
         }

--- a/Ship_Game/GameScreens/DiplomacyScreen/DiplomacyScreen.cs
+++ b/Ship_Game/GameScreens/DiplomacyScreen/DiplomacyScreen.cs
@@ -706,11 +706,16 @@ namespace Ship_Game.GameScreens.DiplomacyScreen
 
         // upstream issue 307: only the Reject button carried the refusal penalty — walking
         // out, discussing or negotiating away an ultimatum had no consequence, though
-        // CanEscapeFromScreen=false shows the player was meant to answer. An explicit
-        // Accept/Reject afterwards still overwrites the flag.
+        // CanEscapeFromScreen=false shows the player was meant to answer. Scoped to
+        // Offer.IsDemand per review: ValueToModify is a generic per-dialog side-effect
+        // carrier (peace fires SetImperialistWar on ANY write; friendly dialogs would
+        // pre-flag HaveRejected_* on Negotiate), so only true ultimatums may mark here.
+        // Known residual: Negotiate marks up front (BeginNegotiations discards the Ref,
+        // so it is the only window) — a negotiation that ends up conceding the demand
+        // cannot unmark. Rare and accepted.
         void MarkUnansweredDemandRejected()
         {
-            if (!DemandAnswered && TheirOffer?.ValueToModify != null)
+            if (!DemandAnswered && TheirOffer?.IsDemand == true && TheirOffer.ValueToModify != null)
                 TheirOffer.ValueToModify.Value = true;
         }
 

--- a/Ship_Game/Gameplay/Relationship.cs
+++ b/Ship_Game/Gameplay/Relationship.cs
@@ -1128,6 +1128,7 @@ namespace Ship_Game.Gameplay
             {
                 AcceptDL      = "Xeno Demand Tech Accepted",
                 RejectDL      = "Xeno Demand Tech Rejected",
+                IsDemand      = true, // upstream issue 307: a true ultimatum - dodging it counts as refusal
                 ValueToModify = new Ref<bool>(() => HaveRejectedDemandTech,
                                                x => HaveRejectedDemandTech = x)
             };


### PR DESCRIPTION
Fixes #307.

Only the Reject button set HaveRejectedDemandTech; Exit, Discuss and
Negotiate walked away from an ultimatum with zero diplomatic effect —
even though CanEscapeFromScreen=false shows the player was meant to
answer. Any exit without an explicit answer now counts as a refusal;
an explicit Accept or Reject afterwards still overwrites the flag.

Test status: compiled and logic-reviewed against the issue's repro (diagnostic with exact code paths in the linked report); play-testing on our fork pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
