### PR TITLE
Diplomacy: subtitle scrim spans the screen width instead of a hardcoded 1920

### DIFF
--- a/Ship_Game/GameScreens/DiplomacyScreen/DiplomacyScreen.cs
+++ b/Ship_Game/GameScreens/DiplomacyScreen/DiplomacyScreen.cs
@@ -577,7 +577,7 @@ namespace Ship_Game.GameScreens.DiplomacyScreen
             }
 
             batch.DrawDropShadowText1(Them.data.Traits.Name, EmpireNamePos, Fonts.Pirulen20, Them.EmpireColor);
-            batch.FillRectangle(new Rectangle(0, R.Y, 1920, R.Height), new Color(0, 0, 0, 150));
+            batch.FillRectangle(new Rectangle(0, R.Y, ScreenWidth, R.Height), new Color(0, 0, 0, 150));
             batch.Draw(ResourceManager.Texture("GameScreens/Bridge"), BridgeRect, Color.White);
         }
 


### PR DESCRIPTION
The dialogue scrim in `DiplomacyScreen.Draw` is drawn with a literal width of 1920:

```cs
batch.FillRectangle(new Rectangle(0, R.Y, 1920, R.Height), new Color(0, 0, 0, 150));
```

That band is what keeps the subtitle text readable over the portrait artwork, so it needs to span at least as far as the portrait does. The portrait is centred and capped at 1280px wide (`portraitWidth = bridgeWidth * 1280f/1920f`, with `bridgeWidth = Math.Min(1920, ScreenWidth)`), so its right edge sits at `ScreenWidth/2 + 640`.

The scrim therefore stops covering the portrait as soon as `ScreenWidth > 2560`:

| Width | Portrait spans | Scrim covers | Result |
|---|---|---|---|
| 1920 | 320 - 1600 | 0 - 1920 | fine |
| 2560 | 640 - 1920 | 0 - 1920 | exact, by coincidence |
| 3440 | 1080 - 2360 | 0 - 1920 | last 440px of the subtitle band unscrimmed |
| 3840 | 1280 - 2560 | 0 - 1920 | last 640px unscrimmed |

Using `ScreenWidth` makes the band follow the screen at every resolution. Below 2560 nothing changes at all, which is why this has gone unnoticed.

Test status: verified in game by the fork maintainer on a window wider than 2560 (the fix removes the bright strip); at 2560 and below there is no visible difference, as the table above predicts.
