### PR TITLE
Carrier settings no longer reset when a save is loaded

### DIFF
--- a/Ship_Game/Ships/CarrierBays.cs
+++ b/Ship_Game/Ships/CarrierBays.cs
@@ -110,6 +110,28 @@ namespace Ship_Game.Ships
             return None;
         }
 
+        // Ludoal fork, issue #338: loading a save calls InitializeStatus, which rebuilds
+        // Carrier from the module list — that has to happen, because the hangar arrays and the
+        // readonly Has* flags are derived from the modules and are not serialized. But the
+        // rebuild also discarded everything the save file had just restored, so the player's
+        // own choices came back at their defaults: "recall fighters before FTL" and "send
+        // troops to ship" both default to true, which is exactly what the reporter saw.
+        // The state below is carried over from the deserialized instance onto the fresh one.
+        public void CarryOverSavedState(CarrierBays saved)
+        {
+            // None is a shared static instance: writing to it would leak one ship's settings
+            // onto every other carrier-less ship in the game.
+            if (saved == null || saved == None || this == None)
+                return;
+
+            RecallFightersBeforeFTL = saved.RecallFightersBeforeFTL;
+            SendTroopsToShip        = saved.SendTroopsToShip;
+            AllowBoardShip          = saved.AllowBoardShip;
+            FightersLaunched        = saved.FightersLaunched;
+            TroopsLaunched          = saved.TroopsLaunched;
+            OrdnanceInSpace         = saved.OrdnanceInSpace;
+        }
+
         public void Dispose()
         {
             if (Owner == null)

--- a/Ship_Game/Ships/Ship_Initialize.cs
+++ b/Ship_Game/Ships/Ship_Initialize.cs
@@ -472,7 +472,13 @@ namespace Ship_Game.Ships
 
         void InitializeStatus(bool fromSave)
         {
+            // Ludoal fork, issue #338: keep what the save file restored. The rebuild itself is
+            // necessary (hangar arrays and the readonly Has* flags come from the modules, not
+            // from the save), but it used to throw away the player's per-ship carrier settings
+            // along with it, putting them back at their defaults on every load.
+            CarrierBays savedCarrier = fromSave ? Carrier : null;
             Carrier = CarrierBays.Create(this, ModuleSlotList);
+            Carrier.CarryOverSavedState(savedCarrier);
             Supply = new(this);
             ShipEngines = new();
             TroopUpdateTimer = Universe?.P.TurnTimer ?? 0; // null for Templates


### PR DESCRIPTION
Fixes #338.

Both settings the reporter named are serialized correctly. The problem is that loading throws them away again.

`Ship.OnDeserialized` calls `InitializeStatus(fromSave: true)`, whose first line is:

```csharp
Carrier = CarrierBays.Create(this, ModuleSlotList);
```

That rebuild is necessary — the hangar arrays and the `readonly Has*` flags are derived from the module list and are not serialized — but it runs unconditionally, so it also discards everything the save file had just restored onto that component. `RecallFightersBeforeFTL` and `SendTroopsToShip` both default to `true`, which is why the reporter's disabled settings came back *enabled* rather than coming back wrong.

It also explains his hunch that other settings might be affected: every `[StarData]` field on `CarrierBays` is lost the same way, not just those two.

**The fix** carries the deserialized instance's state over onto the fresh one: `RecallFightersBeforeFTL`, `SendTroopsToShip`, `AllowBoardShip`, `FightersLaunched`, `TroopsLaunched` and `OrdnanceInSpace`.

Nothing is ever written onto the shared `None` instance — that would leak one ship's settings onto every carrier-less ship in the game.

**Verified in game:** disabled both settings on a ship with hangars, saved, quit, reloaded — both stayed disabled. Ships with no hangars or transporters (the `None` case) showed no change in behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
