### PR TITLE
Jupiter 1.60 fixes batch 28: community fixes + Sentry version gate

### DIFF
--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignInfoPanel.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignInfoPanel.cs
@@ -97,7 +97,9 @@ namespace Ship_Game.GameScreens.ShipDesign
             Val(() => S.ShieldMax, GT.ShieldPower, GT.TT_ShieldPower, Tint.Pos, protect, vis: Ds.HasRegularShields);
             Val(() => S.ShieldMax, GT.ShieldPower, GT.TT_ShieldPower, Tint.Pos, Color.Gold, vis: Ds.HasAmplifiedMains);
             ValNZ(() => (int)S.Stats.ShieldAmplifyPerShield, GT.ShieldAmplify, GT.TT_ShieldAmplify, Tint.Pos, protect);
-            ValNZ(() => S.BonusEMPProtection, GT.EmpProtection, GT.TT_EmpProtection, Tint.Pos, protect);
+            // the tooltip promises the TOTAL protection of the design, and the load-list
+            // overlay already shows EmpTolerance - show the same effective value here
+            Val(() => S.EmpTolerance, GT.EmpProtection, GT.TT_EmpProtection, Tint.Pos, protect);
             ValNZ(() => S.ECMValue, GT.Ecm3, GT.TT_Ecm3, Tint.Pos, protect);
             Line();
 

--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignInfoPanel.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignInfoPanel.cs
@@ -97,8 +97,6 @@ namespace Ship_Game.GameScreens.ShipDesign
             Val(() => S.ShieldMax, GT.ShieldPower, GT.TT_ShieldPower, Tint.Pos, protect, vis: Ds.HasRegularShields);
             Val(() => S.ShieldMax, GT.ShieldPower, GT.TT_ShieldPower, Tint.Pos, Color.Gold, vis: Ds.HasAmplifiedMains);
             ValNZ(() => (int)S.Stats.ShieldAmplifyPerShield, GT.ShieldAmplify, GT.TT_ShieldAmplify, Tint.Pos, protect);
-            // the tooltip promises the TOTAL protection of the design, and the load-list
-            // overlay already shows EmpTolerance - show the same effective value here
             Val(() => S.EmpTolerance, GT.EmpProtection, GT.TT_EmpProtection, Tint.Pos, protect);
             ValNZ(() => S.ECMValue, GT.Ecm3, GT.TT_Ecm3, Tint.Pos, protect);
             Line();

--- a/Ship_Game/Ships/Components/LoyaltyChanges.cs
+++ b/Ship_Game/Ships/Components/LoyaltyChanges.cs
@@ -67,9 +67,8 @@ namespace Ship_Game.Ships.Components
         static bool DoLoyaltyChange(Ship ship, Type type, Empire changeTo)
         {
             // Spawned ships should not clear orders since some of them are given immediate orders
-            // Like pirates and meteors.
-            // Clear BEFORE the transfer handlers run: they may issue orders for the new owner
-            // (pirate boarding orders the ship to flee to a pirate base) which must survive.
+            // like pirates and meteors. Must run BEFORE the transfer handlers: orders they
+            // issue for the new owner (e.g. pirate flee-home) must survive.
             if (type != Type.Spawn)
                 ship.AI.ClearOrdersAndWayPoints();
 

--- a/Ship_Game/Ships/Components/LoyaltyChanges.cs
+++ b/Ship_Game/Ships/Components/LoyaltyChanges.cs
@@ -66,6 +66,13 @@ namespace Ship_Game.Ships.Components
 
         static bool DoLoyaltyChange(Ship ship, Type type, Empire changeTo)
         {
+            // Spawned ships should not clear orders since some of them are given immediate orders
+            // Like pirates and meteors.
+            // Clear BEFORE the transfer handlers run: they may issue orders for the new owner
+            // (pirate boarding orders the ship to flee to a pirate base) which must survive.
+            if (type != Type.Spawn)
+                ship.AI.ClearOrdersAndWayPoints();
+
             switch (type)
             {
                 default:
@@ -76,11 +83,6 @@ namespace Ship_Game.Ships.Components
                 case Type.Absorbed:       LoyaltyChangeDueToFederation(ship, changeTo, false); break;
                 case Type.AbsorbedNotify: LoyaltyChangeDueToFederation(ship, changeTo, true);  break;
             }
-
-            // Spawned ships should not clear orders since some of them are given immediate orders
-            // Like pirates and meteors
-            if (type != Type.Spawn)
-                ship.AI.ClearOrdersAndWayPoints();
 
             return true;
         }

--- a/Ship_Game/TechEntry.cs
+++ b/Ship_Game/TechEntry.cs
@@ -959,7 +959,7 @@ namespace Ship_Game
                 case "Reactive Armor":
                 case "Armor Explosion Reduction": data.ExplosiveRadiusReduction += unlockedBonus.Bonus; break;
                 case "Slipstreams":
-                case "Subspace Tunneling": // flavor name used by the Slip Streams secret tech - it had no case, so its +30% did nothing (issue 328); the tech text promises an IN-BORDERS bonus, not a global one
+                case "Subspace Tunneling": // Slip Streams secret tech flavor name; its text promises an in-borders bonus
                 case "In Borders FTL Bonus": data.Traits.InBordersSpeedBonus += unlockedBonus.Bonus; break;
                 case "StarDrive Enhancement":
                 case "FTL Speed Bonus": data.FTLModifier += unlockedBonus.Bonus * data.FTLModifier; break;

--- a/Ship_Game/TechEntry.cs
+++ b/Ship_Game/TechEntry.cs
@@ -959,9 +959,9 @@ namespace Ship_Game
                 case "Reactive Armor":
                 case "Armor Explosion Reduction": data.ExplosiveRadiusReduction += unlockedBonus.Bonus; break;
                 case "Slipstreams":
+                case "Subspace Tunneling": // flavor name used by the Slip Streams secret tech - it had no case, so its +30% did nothing (issue 328); the tech text promises an IN-BORDERS bonus, not a global one
                 case "In Borders FTL Bonus": data.Traits.InBordersSpeedBonus += unlockedBonus.Bonus; break;
                 case "StarDrive Enhancement":
-                case "Subspace Tunneling": // the Slip Streams secret tech uses this flavor name - it had no case, so its +30% did nothing (issue 328)
                 case "FTL Speed Bonus": data.FTLModifier += unlockedBonus.Bonus * data.FTLModifier; break;
                 case "FTL Efficiency":
                 case "FTL Efficiency Bonus": data.FTLPowerDrainModifier -= unlockedBonus.Bonus * data.FTLPowerDrainModifier; break;

--- a/Ship_Game/TechEntry.cs
+++ b/Ship_Game/TechEntry.cs
@@ -961,6 +961,7 @@ namespace Ship_Game
                 case "Slipstreams":
                 case "In Borders FTL Bonus": data.Traits.InBordersSpeedBonus += unlockedBonus.Bonus; break;
                 case "StarDrive Enhancement":
+                case "Subspace Tunneling": // the Slip Streams secret tech uses this flavor name - it had no case, so its +30% did nothing (issue 328)
                 case "FTL Speed Bonus": data.FTLModifier += unlockedBonus.Bonus * data.FTLModifier; break;
                 case "FTL Efficiency":
                 case "FTL Efficiency Bonus": data.FTLPowerDrainModifier -= unlockedBonus.Bonus * data.FTLPowerDrainModifier; break;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
@@ -457,7 +457,9 @@ public partial class Planet
             TerraformingHere = HasBuilding(bb => bb.IsTerraformer || bb.IsEventTerraformer);
         
         // FB - no terraformers present, terraform effort halted
-        if (b.IsTerraformer && !TerraformingHere)
+        // (event terraformers too - a depleted World Tree left the points frozen and
+        // the planet stuck displaying 'Terraforming in Progress', issue 294)
+        if ((b.IsTerraformer || b.IsEventTerraformer) && !TerraformingHere)
             TerraformPoints = 0;
 
         if (b.IsCapital) HasCapital = false;

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_ConstructionQueue.cs
@@ -457,8 +457,6 @@ public partial class Planet
             TerraformingHere = HasBuilding(bb => bb.IsTerraformer || bb.IsEventTerraformer);
         
         // FB - no terraformers present, terraform effort halted
-        // (event terraformers too - a depleted World Tree left the points frozen and
-        // the planet stuck displaying 'Terraforming in Progress', issue 294)
         if ((b.IsTerraformer || b.IsEventTerraformer) && !TerraformingHere)
             TerraformPoints = 0;
 

--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_Generate.cs
@@ -269,7 +269,20 @@ namespace Ship_Game
         void ApplyTerraforming(RandomBase random) // Added by Fat Bastard
         {
             if (!Terraformable)
+            {
+                // no doable job is left at the current terraform level, e.g. an event
+                // terraformer died mid-job above the empire's own tech level: clear the
+                // in-progress status and scrap the now-useless terraformers.
+                // A live event terraformer is exempt - RemoveTerraformers never scraps
+                // those, so scrapping+notifying would repeat every turn
+                if (TerraformPoints > 0 || TerraformingHere)
+                {
+                    TerraformPoints = 0;
+                    if (TerraformingHere && !ContainsEventTerraformers)
+                        RemoveTerraformers();
+                }
                 return;
+            }
 
             if (TerraformToAdd <= 0 || Owner == null)
             {

--- a/Ship_Game/Universe/SolarBodies/SBProduction.cs
+++ b/Ship_Game/Universe/SolarBodies/SBProduction.cs
@@ -498,9 +498,8 @@ namespace Ship_Game.Universe.SolarBodies
                     }
                     else if (P.Universe.P.PrioitizeProjectors && item.QType == QueueItemType.RoadNode)
                     {
-                        // prioritize projector bridges for the player — but BELOW the projectors
-                        // already leading the queue, so a road completes segment by segment
-                        // instead of three half-roads racing each other (upstream issue 300)
+                        // prioritize projector bridges for the player, below the projectors
+                        // already leading the queue so a road completes segment by segment
                         int insertAt = 0;
                         while (insertAt < Count - 1 && ConstructionQueue[insertAt].QType == QueueItemType.RoadNode)
                             ++insertAt;

--- a/Ship_Game/Universe/SolarBodies/SBProduction.cs
+++ b/Ship_Game/Universe/SolarBodies/SBProduction.cs
@@ -492,11 +492,19 @@ namespace Ship_Game.Universe.SolarBodies
                     if (P.Owner.AutoBuildTerraformers && P.Owner.data.Traits.TerraformingLevel > 0 && !item.IsPlayerAdded)
                         DePrioritizeTerraformer();
 
-                    if (item.Rush && item.QType == QueueItemType.OrbitalUrgent
-                        || P.Universe.P.PrioitizeProjectors && item.QType == QueueItemType.RoadNode)
+                    if (item.Rush && item.QType == QueueItemType.OrbitalUrgent)
                     {
-                        // prioritize projector bridges for the player (or any projector if flag is set).
                         MoveTo(0, Count - 1);
+                    }
+                    else if (P.Universe.P.PrioitizeProjectors && item.QType == QueueItemType.RoadNode)
+                    {
+                        // prioritize projector bridges for the player — but BELOW the projectors
+                        // already leading the queue, so a road completes segment by segment
+                        // instead of three half-roads racing each other (upstream issue 300)
+                        int insertAt = 0;
+                        while (insertAt < Count - 1 && ConstructionQueue[insertAt].QType == QueueItemType.RoadNode)
+                            ++insertAt;
+                        MoveTo(insertAt, Count - 1);
                     }
                 }
 

--- a/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
+++ b/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
@@ -94,7 +94,11 @@ namespace Ship_Game.Universe
 
             // if ALT key is down, always Orbit the planet
             if (Input.IsAltKeyDown)
+            {
                 ship.OrderToOrbit(planet, clearOrders, GetStanceType());
+                if (clearOrders)
+                    CancelAbandonedColonizationGoal(ship);
+            }
             else if (ship.ShipData.IsColonyShip)
                 PlanetRightClickColonyShip(ship, planet, clearOrders); // This ship can colonize planets
             else if (ship.Carrier.AnyAssaultOpsAvailable)
@@ -114,7 +118,26 @@ namespace Ship_Game.Universe
             else
             {
                 ship.OrderToOrbit(planet, clearOrders);
+                if (clearOrders)
+                    CancelAbandonedColonizationGoal(ship);
             }
+        }
+
+        // Issue 324: a direct player order that pulls a colony ship off a manual colonization
+        // is the player changing their mind - retire the empire goal too, so the automation
+        // stops feeding replacement colony ships to that planet. Triggered only by explicit
+        // player input (never by load or transient AI states - the lesson of the first fix),
+        // and the ship itself is not touched: it is already following the new order.
+        void CancelAbandonedColonizationGoal(Ship ship)
+        {
+            if (!ship.ShipData.IsColonyShip)
+                return;
+
+            var goal = Universe.Player.AI.FindGoal(g => g is MarkForColonization m
+                                                     && m.IsManualColonizationOrder
+                                                     && m.FinishedShip == ship);
+            if (goal != null)
+                Universe.Player.AI.RemoveGoal(goal);
         }
 
         void PlanetRightClickTroopShip(Ship ship, Planet planet, bool clearOrders, AI.MoveOrder order)
@@ -300,6 +323,8 @@ namespace Ship_Game.Universe
 
             Vector2 corrected = HelperFunctions.GetCorrectedMovePosWithAudio([ship], enemyShips, pos);
             ship.AI.OrderMoveTo(corrected, direction, GetMoveOrderType());
+            if (!Input.QueueAction) // a queued waypoint is not a change of mind
+                CancelAbandonedColonizationGoal(ship);
         }
     }
 }

--- a/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
+++ b/Ship_Game/Universe/UniverseScreen/ShipMoveCommands.cs
@@ -123,11 +123,6 @@ namespace Ship_Game.Universe
             }
         }
 
-        // Issue 324: a direct player order that pulls a colony ship off a manual colonization
-        // is the player changing their mind - retire the empire goal too, so the automation
-        // stops feeding replacement colony ships to that planet. Triggered only by explicit
-        // player input (never by load or transient AI states - the lesson of the first fix),
-        // and the ship itself is not touched: it is already following the new order.
         void CancelAbandonedColonizationGoal(Ship ship)
         {
             if (!ship.ShipData.IsColonyShip)

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Camera.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Camera.cs
@@ -155,6 +155,9 @@ namespace Ship_Game
 
             SnapViewTo(new(s.Position.X, s.Position.Y + 400, 2500), 5f, 2f);
             LookingAtPlanet = false;
+            // snappingToShip follows ShipToView - without this the camera snapped to
+            // whatever ship was viewed LAST (station-built notifications zoomed wrong)
+            ShipToView = s;
             snappingToShip = true;
             ViewingShip = true;
         }

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.Camera.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.Camera.cs
@@ -155,8 +155,6 @@ namespace Ship_Game
 
             SnapViewTo(new(s.Position.X, s.Position.Y + 400, 2500), 5f, 2f);
             LookingAtPlanet = false;
-            // snappingToShip follows ShipToView - without this the camera snapped to
-            // whatever ship was viewed LAST (station-built notifications zoomed wrong)
             ShipToView = s;
             snappingToShip = true;
             ViewingShip = true;

--- a/Ship_Game/Universe/UniverseScreen/UniverseScreen.UpdateGame.cs
+++ b/Ship_Game/Universe/UniverseScreen/UniverseScreen.UpdateGame.cs
@@ -121,6 +121,10 @@ namespace Ship_Game
                 ++SimTurnId;
 
                 UState.Objects.Update(FixedSimTime.Zero/*paused*/);
+
+                // keep build-goal icons visible/selectable and tracking the camera while
+                // paused; must stay on this thread - GoalsList is owned by the sim thread
+                UpdateClickableItems();
             }
             else
             {

--- a/Ship_Game/Utils/Log.cs
+++ b/Ship_Game/Utils/Log.cs
@@ -90,6 +90,18 @@ namespace Ship_Game
         public static string LogFilePath { get; private set; }
         public static string OldLogFilePath { get; private set; }
 
+        // official releases version as exactly Major.Minor.Patch, e.g. "1.60.00046 jupiter-1.60"
+        public static bool IsOfficialVersionFormat(string version)
+        {
+            string[] parts = version.Split(' ')[0].Split('.');
+            if (parts.Length != 3)
+                return false;
+            for (int i = 0; i < parts.Length; ++i)
+                if (!uint.TryParse(parts[i], out _))
+                    return false;
+            return true;
+        }
+
         public static void Initialize(bool enableSentry, bool showHeader)
         {
             if (LogThread != null)
@@ -161,6 +173,14 @@ namespace Ship_Game
                 init += $" ==== UTC: {DateTime.UtcNow,-39} ====\r\n";
                 init +=  " ======================================================\r\n";
                 LogWriteAsync(init, ConsoleColor.Green);
+            }
+
+            if (enableSentry && !IsOfficialVersionFormat(GlobalStats.Version))
+            {
+                // forked builds tag extra version parts (e.g. "1.60.00046.123") and
+                // must not report into the official Sentry project
+                enableSentry = false;
+                LogWriteAsync($"Sentry disabled: unofficial version format '{GlobalStats.Version}'", ConsoleColor.Yellow);
             }
 
             if (enableSentry)

--- a/Ship_Game/Utils/Log.cs
+++ b/Ship_Game/Utils/Log.cs
@@ -195,7 +195,8 @@ namespace Ship_Game
                         o.Environment = environment;
                         var versionParts = GlobalStats.Version.Split(' '); // "1.30.13000 release/mars-1.41/f83ab4a"
                         o.Release = versionParts[0]; // 1.30.13000
-                        o.Distribution = versionParts[1].Replace('/', '-'); // release/mars-1.41/f83ab4a -> release-mars-1.41-f83ab4a
+                        if (versionParts.Length > 1)
+                            o.Distribution = versionParts[1].Replace('/', '-'); // release/mars-1.41/f83ab4a -> release-mars-1.41-f83ab4a
                         o.IsGlobalModeEnabled = true;
                         o.CacheDirectoryPath = Dir.StarDriveAppData;
 

--- a/UnitTests/Data/VersionFormatTests.cs
+++ b/UnitTests/Data/VersionFormatTests.cs
@@ -1,0 +1,29 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ship_Game;
+
+namespace UnitTests.Data;
+
+// Only official builds (exactly Major.Minor.Patch) may report to Sentry;
+// forked builds tag extra version parts and must be filtered out.
+[TestClass]
+public class VersionFormatTests
+{
+    [TestMethod]
+    public void OfficialReleaseFormatsAreAccepted()
+    {
+        Assert.IsTrue(Log.IsOfficialVersionFormat("1.60.00046 release/jupiter-1.60/f83ab4a"));
+        Assert.IsTrue(Log.IsOfficialVersionFormat("1.60.00046"));
+        Assert.IsTrue(Log.IsOfficialVersionFormat("1.51.15120 release/mars-1.51/abc1234"));
+    }
+
+    [TestMethod]
+    public void ForkedAndMalformedFormatsAreRejected()
+    {
+        Assert.IsFalse(Log.IsOfficialVersionFormat("1.60.00046.123 fork/jupiter-1.60/abc1234"));
+        Assert.IsFalse(Log.IsOfficialVersionFormat("1.60.00046.1"));
+        Assert.IsFalse(Log.IsOfficialVersionFormat("1.60"));
+        Assert.IsFalse(Log.IsOfficialVersionFormat("1.60.dev"));
+        Assert.IsFalse(Log.IsOfficialVersionFormat("1.60.-46"));
+        Assert.IsFalse(Log.IsOfficialVersionFormat(""));
+    }
+}

--- a/UnitTests/SDUnitTests.csproj
+++ b/UnitTests/SDUnitTests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Data\TestAudioConfig.cs" />
     <Compile Include="Data\AdviceFallbackTests.cs" />
     <Compile Include="Data\LocalizationMergeTests.cs" />
+    <Compile Include="Data\VersionFormatTests.cs" />
     <Compile Include="Data\TestMeshImportExport.cs" />
     <Compile Include="Data\MeshExporterStaticPathTests.cs" />
     <Compile Include="Data\MeshImporterTests.cs" />


### PR DESCRIPTION
Batch of 9 small fixes: 7 community fixes by @Ludoal (individually verified against source, merged, comments trimmed) and 2 of our own.

## Community fixes (by Ludoal)
- **#355** SnapViewShip assigns ShipToView, so clicking a ship notification zooms to the referenced ship instead of the last-followed one.
- **#354** A direct, non-queued player move/orbit order to a manual colonization's colony ship retires the goal, so the automation stops re-ordering ships to the target (fixes #324).
- **#353** Shipyard design panel shows effective EmpTolerance (hull + modules) — the value combat tests and the load-list overlay already shows (fixes #323).
- **#352** Captured-ship order clearing runs before the transfer handlers, so the pirate flee-to-base order survives capture (fixes #316).
- **#366** "Subspace Tunneling" (Slip Streams secret tech) bonus now applies, routed to the in-borders FTL group its description promises (fixes #328).
- **#372** Event-terraformer removal zeroes TerraformPoints like regular terraformers, clearing the stuck "Terraforming in Progress" status (fixes #294).
- **#379** Prioritized road nodes queue after the road nodes already leading the queue, so long roads complete segment by segment (fixes #300).

## Our fixes
- **Paused DSB visibility** (diagnosis by Ludoal in #356, reworked): clickable build goals refresh from the paused branch of ProcessSimulationTurns on the sim thread — new deep-space build orders show and select while paused, without the UI-thread GoalsList race the original PR would have reintroduced (fixes #285).
- **Sentry version gate**: forked builds (4-part versions like 1.60.00046.123) no longer report into the official Sentry project; official 3-part versions are unaffected. Covered by new VersionFormatTests.

## Follow-up candidates noted by review (pre-existing patterns, not regressions)
- Marshal the FindGoal+RemoveGoal pair in CancelAbandonedColonizationGoal (and the MarkForColonization ctor) onto the sim thread as one action.
- AddToQueueAndPrioritize should locate the enqueued item via IndexOf instead of assuming Count-1 (DePrioritizeTerraformer can shift it for auto-added items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
