### PR TITLE
Shipyard: match the click threshold to the game's own held-button default

### DIFF
--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignScreenInput.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignScreenInput.cs
@@ -19,7 +19,10 @@ namespace Ship_Game
         Vector2 ClassifCursor;
         UICheckBox CarrierOnlyCheckBox;
         bool DisplayedBulkReplacementHint;
-        const float ClickThresholdSeconds = 0.1f;
+        // 0.15 matches InputState.LeftMouseHeld's own default. Picking a fitted module up runs
+        // only inside the "released and held for less than this" branch, so at 0.10 an ordinary,
+        // slightly deliberate click was already too long to count and did nothing at all.
+        const float ClickThresholdSeconds = 0.15f;
 
         void UpdateCarrierShip()
         {


### PR DESCRIPTION
Clicking a fitted module to pick it back up frequently did nothing at all. Picking a module up happens only inside the branch guarded by `input.LeftMouseReleased && input.LeftMouseHoldDuration < ClickThresholdSeconds`, and that threshold is 0.10s — shorter than a normal, slightly deliberate click. Past it no branch handles the press, so the module is simply never loaded onto the cursor.

`InputState.LeftMouseHeld` defaults to 0.15s for what counts as a held button, and `ShipYardArcMove` calls it with no argument, so this screen was also disagreeing with the rest of the input layer about where a click ends. Aligning on 0.15 fixes both: an ordinary click is a click again, and the two thresholds no longer leave a window that is neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)