### PR TITLE
Shipyard: WIP names stop stacking their version suffix

### DIFF
--- a/Ship_Game/GameScreens/ShipDesign/ShipDesignWIP.cs
+++ b/Ship_Game/GameScreens/ShipDesign/ShipDesignWIP.cs
@@ -37,8 +37,11 @@ namespace Ship_Game.GameScreens.ShipDesign
 
         static string GetWipFileNameToSave(string wipFileName)
         {
-            string defaultShipName = $"{wipFileName}_v1_WIP";
+            // Built from the prefix, not from the name as given: when saving a WIP a second time
+            // the caller passes a name that already carries a suffix, and appending to that
+            // produced "Design_ship3_v1_WIP_v1_WIP", with another one stacked on every save.
             string shipPrefix      = GetWipShipNameAndNum(wipFileName);
+            string defaultShipName = $"{shipPrefix}_v1_WIP";
             FileInfo[] wipFiles    = GetWipFiles().Filter(f => f.NameNoExt().StartsWith(shipPrefix));
 
             if (wipFiles.Length == 0) // first wip


### PR DESCRIPTION
Saving a work-in-progress design a second time produces names like `Design_ship3_v1_WIP_v1_WIP`, and every save after that appends another `_v1_WIP`. The names grow through a session until they no longer fit the list they are shown in.

`GetWipFileNameToSave` builds its default name by appending the suffix to the name it was handed — but when saving an existing WIP, the caller passes a name that already carries one. Building from the prefix instead (`GetWipShipNameAndNum`, which the very next line already computes) appends exactly once whatever it is given, and an already-stacked name is repaired on its next save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)