### PR TITLE
Moles cannot infiltrate unexplored planets

### DIFF
--- a/Ship_Game/StoryAndEvents/Agents/Mole.cs
+++ b/Ship_Game/StoryAndEvents/Agents/Mole.cs
@@ -16,11 +16,13 @@ namespace Ship_Game
             if (target.IsDefeated) 
                 return null;
 
-            var potentials = target.GetPlanets().Filter(p => p.IsExploredBy(owner) 
+            // Ludoal fork: no fallback onto the full planet list - a mole cannot infiltrate a
+            // planet its owner never explored (nor stack onto an already infiltrated one). The
+            // operation reports its stock "no colony for infiltration" failure text instead.
+            var potentials = target.GetPlanets().Filter(p => p.IsExploredBy(owner)
                                                              && !owner.data.MoleList.Any(m => m.PlanetId == p.Id));
-
             if (potentials.Length == 0)
-                potentials = target.GetPlanets().ToArray();
+                return null;
 
             targetPlanet = target.Random.Item(potentials);
             Mole mole = new()
@@ -38,9 +40,12 @@ namespace Ship_Game
         public static Mole PlantStickyMoleAtHomeworld(Empire owner, Empire target, out Planet targetPlanet)
         {
             targetPlanet = null;
-            var planets = target.GetPlanets().Filter(p => p.IsHomeworld || p.HasCapital);
+            // Ludoal fork: only planets the owner explored qualify. The level perk retries on
+            // the espionage tick, so the sticky mole simply lands once the homeworld is found.
+            var planets = target.GetPlanets().Filter(p => (p.IsHomeworld || p.HasCapital) && p.IsExploredBy(owner));
 
-            targetPlanet = planets.Length == 0 ? target.GetPlanets().FindMax(p => p.PopulationBillion)
+            targetPlanet = planets.Length == 0 ? target.GetPlanets().Filter(p => p.IsExploredBy(owner))
+                                                                    .FindMax(p => p.PopulationBillion)
                                                 : target.Random.Item(planets);
 
             if (targetPlanet == null)


### PR DESCRIPTION
`PlantMole` already filters candidate planets for `IsExploredBy(owner)`, but when no planet qualifies it falls back onto the target's **full** planet list - so a mole can land on a planet its owner has never seen, and can even stack onto an already infiltrated planet, since the fallback drops that filter too.

This removes the fallback: with no qualifying planet the operation returns null and reports its existing "no colony for infiltration" failure text - the same path already taken when the target is defeated, so the caller needs no change.

The sticky homeworld mole gets the same explored requirement. Its level perk retries on the espionage tick (`CanPlantStickyMole && StickyMole == null`), so it simply lands as soon as the homeworld is discovered - nothing is lost, only deferred.

Applies to every empire, AI included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
