### PR TITLE
Save list: show the player's real flag for custom and renamed races

### DIFF
--- a/Ship_Game/GameScreens/LoadSaveItems/GenericLoadSaveScreen.cs
+++ b/Ship_Game/GameScreens/LoadSaveItems/GenericLoadSaveScreen.cs
@@ -355,6 +355,13 @@ namespace Ship_Game
                 string extraInfo = header.RealDate;
                 string tooltip = file.Name;
 
+                // headers that carry the player's flag draw it directly; older headers read
+                // -1 and fall back to the race-name lookup below, which shows the default
+                // flag for custom and renamed races
+                if (header.FlagIndex >= 0)
+                    return new(file, header, header.SaveName, info, extraInfo, tooltip,
+                               ResourceManager.Flag(header.FlagIndex), header.EmpireColor);
+
                 IEmpireData empire = ResourceManager.AllRaces.FirstOrDefault(e => e.Name == header.PlayerName)
                                   ?? ResourceManager.AllRaces[0];
                 return new(file, header, header.SaveName, info, extraInfo, tooltip,

--- a/Ship_Game/SavedGame.cs
+++ b/Ship_Game/SavedGame.cs
@@ -5,6 +5,7 @@ using Ship_Game.Data.Serialization;
 using Ship_Game.Universe;
 using SDUtils;
 using Ship_Game.Data.Binary;
+using Color = Microsoft.Xna.Framework.Color;
 
 namespace Ship_Game
 {
@@ -18,6 +19,11 @@ namespace Ship_Game
         [StarData] public string RealDate;
         [StarData] public string ModName = "";
         [StarData] public DateTime Time;
+        // the player's flag, so the save list can show it without a race-name lookup
+        // (a renamed or custom race matches nothing and fell back to the default icon).
+        // -1 = header written before the field existed; the reader falls back to the lookup.
+        [StarData] public int FlagIndex = -1;
+        [StarData] public Color EmpireColor;
     }
 
     public sealed class SavedGame
@@ -84,6 +90,8 @@ namespace Ship_Game
                 RealDate   = now.ToString("M/d/yyyy") + " " + now.ToString("t", CultureInfo.CreateSpecificCulture("en-US").DateTimeFormat),
                 ModName    = GlobalStats.ModName,
                 Time       = now,
+                FlagIndex  = state.Player.data.Traits.FlagIndex,
+                EmpireColor = state.Player.EmpireColor,
             };
 
             // an annoying edge case, someone has created a folder with the same name


### PR DESCRIPTION
**The bug:** in the load/save screen, every save made with a custom or renamed race shows the default flag instead of the player's own. `FileData.FromSaveHeader` finds the icon by looking the header's `PlayerName` up in `ResourceManager.AllRaces`; a name that isn't one of the stock races matches nothing and silently falls back to `AllRaces[0]`.

**The fix:** the save header now stores the player's `FlagIndex` and empire color at save time, and the list draws them directly — no lookup involved.

**Backward compatibility:** the new field defaults to `-1`, and headers from older saves deserialize to that default (the binary serializer constructs through the real parameterless constructor, so field initializers run). Those saves keep the existing name-lookup path and list exactly as they do today — verified against a mixed folder of pre- and post-change saves.

Shipped and play-tested in the Ludoal fork (47-c hotfix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
