### PR TITLE
Serializer: skip enum values from deleted types instead of crashing on load

### DIFF
--- a/Ship_Game/Data/Binary/BinarySerializerReader.cs
+++ b/Ship_Game/Data/Binary/BinarySerializerReader.cs
@@ -399,6 +399,18 @@ public class BinarySerializerReader
                 cs.Deserialize(this, instance);
             }
         }
+        // an enum type that no longer exists: its values are still in the stream and each one
+        // is a single VLi32, so they can be read past without knowing the type. Every other
+        // deleted category still needs a skipping serializer (see the FIXMEs above).
+        else if (ser == null && type.Category is SerializerCategory.Enums)
+        {
+            if (Verbose) Log.Warning($"Skipping {count} values of deleted enum {type}");
+            for (int i = 0; i < count; ++i)
+            {
+                BR.ReadVLi32();
+                ObjectsList[baseId + i] = null;
+            }
+        }
         // fundamental types such as int, Vector2, String, Byte[], Point. @see TypeSerializerMap.cs
         // also RawArrays like Ship[]
         else


### PR DESCRIPTION
Loading a save that carries an enum type the running build does not know crashes with a NullReferenceException in `BinarySerializerReader.ReadObjects`.

The header pass already handles the case: `GetTypeFrom` returns null, `AddDeletedTypeInfo` records the type with `Ser = null` and logs "Read DELETED". The object pass then calls `ser.Deserialize(this)` on that null serializer.

Enum values are a single VLi32 each, so they can be read past without knowing the type. This adds that branch, guarded on `ser == null` and the Enums category, so nothing else changes.

The other deleted categories still throw. Skipping those needs the `CollectionSkippingSerializer` the FIXMEs at lines 219 and 398 describe, which is a larger change. Happy to submit it separately if there is interest.

Tested in a live build: the game starts and existing saves load normally. The crash path itself needs a build without the enum reading a save with it, which is the situation this fixes rather than one I can reproduce in a single build.
