### PR TITLE
Blueprints: the terraformer half-completion gate never closed

### DIFF
--- a/Ship_Game/Universe/SolarBodies/ColonyBlueprints.cs
+++ b/Ship_Game/Universe/SolarBodies/ColonyBlueprints.cs
@@ -27,7 +27,9 @@ namespace Ship_Game.Universe.SolarBodies
         bool Completed => PercentCompleted == 100;
 
         public bool IsAchievableCompleted => PercentAchievable == 0 || PercentAchievable == PercentCompleted;
-        bool IsHalfAchievableCompleted => PercentAchievable == 0 || PercentAchievable >= PercentCompleted/2;
+        // a standing building counts as reachable too, so achievable is never below completed:
+        // the gate asks whether half of what this colony can reach is already up.
+        bool IsHalfAchievableCompleted => PercentAchievable == 0 || PercentCompleted >= PercentAchievable/2;
 
         public bool IsRequired(Building b) => PlannedBuildings.Contains(b.Name);
         public bool IsNotRequired(Building b) => !IsRequired(b);


### PR DESCRIPTION
`ColonyBlueprints.IsHalfAchievableCompleted` compared the reachable share of a plan against half of the *completed* share:

```csharp
PercentAchievable >= PercentCompleted/2
```

A standing building counts as reachable too, so `PercentAchievable` is never below `PercentCompleted`. The test therefore read true in every case, and on any plan claiming at least half the tile area — the branch of `OkToBuildTerraformers` that uses this gate — the gate never closed. Terraformers could go up on a colony that had barely started its list.

It now asks what the name says: half of what this colony can reach is already up.

```csharp
PercentCompleted >= PercentAchievable/2
```

One line, plus a comment recording why achievable cannot sit below completed.

Reported independently by a player who noticed terraformers appearing early on freshly colonised worlds while their plans were still running, without knowing the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
