### PR TITLE
Refit: prioritized ports should narrow the choice, not replace the selector

### DIFF
--- a/Ship_Game/Empire_RallyPlanets.cs
+++ b/Ship_Game/Empire_RallyPlanets.cs
@@ -218,10 +218,11 @@ public sealed partial class Empire
         planet = null;
         int travelMultiplier = travelBack ? 2 : 1;
 
-        if (isPlayer && PlayerPrioritizedPorts.Length > 0)
-            return FindPlanetToBuildShipAt(ports, newShip, out planet);
+        // Prioritized ports restrict the candidates, but they must not change the selector:
+        // an existing ship has to fly there (and back), so travel time stays part of the choice.
+        IReadOnlyList<Planet> actualPorts = isPlayer && PlayerPrioritizedPorts.Length > 0 ? PlayerPrioritizedPorts : ports;
 
-        if (ports.Count == 0 || !GetBestPorts(ports, out Planet[] bestPorts, 1))
+        if (actualPorts.Count == 0 || !GetBestPorts(actualPorts, out Planet[] bestPorts, 1))
             return false;
 
         planet = bestPorts.FindMin(p => p.TurnsUntilQueueComplete(cost, 1f, newShip)


### PR DESCRIPTION
`FindPlanetToRefitAt` handed the entire choice to `FindPlanetToBuildShipAt` when the player has prioritized ports:

```csharp
if (isPlayer && PlayerPrioritizedPorts.Length > 0)
    return FindPlanetToBuildShipAt(ports, newShip, out planet);
```

That selector ranks candidates by queue time alone, which is right for a hull that does not exist yet. A refit is different: an existing ship has to fly to the port, and back if `travelBack` — which is why the method's own selector, two lines below, already includes `GetAstrogateTimeTo`. Taking the other branch dropped that term, so a ship could be sent across the map to a marginally emptier yard.

Prioritized ports now restrict the candidate list without replacing the selector:

```csharp
IReadOnlyList<Planet> actualPorts = isPlayer && PlayerPrioritizedPorts.Length > 0 ? PlayerPrioritizedPorts : ports;
```

The player's preference is still honoured — it just narrows the field instead of changing how the field is ranked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
