### PR TITLE
Blueprints: a technology unlock refreshed only half the pair

### DIFF
--- a/Ship_Game/Empire.cs
+++ b/Ship_Game/Empire.cs
@@ -1005,6 +1005,10 @@ namespace Ship_Game
             for (int i = 0; i < OwnedPlanets.Count; i++)
             {
                 Planet p = OwnedPlanets[i];
+                // the whole pair: a technology changes what a colony can reach, and the figure
+                // beside it shares that denominator, so recomputing one alone leaves the two
+                // disagreeing until something else refreshes them.
+                p.Blueprints?.UpdateCompletion();
                 p.Blueprints?.UpdatePercentAchievable();
             }
         }


### PR DESCRIPTION
`Empire.UpdateBlueprintsAchievablePercentage` recomputes only one of the two figures a blueprint carries:

```csharp
p.Blueprints?.UpdatePercentAchievable();
```

`PercentCompleted` and `PercentAchievable` share a denominator — the plan's entry count — and a technology unlock changes what a colony can reach. Recomputing the achievable share alone leaves the pair disagreeing until something else happens to refresh them, and the colony screen shows a plan further along, or further behind, than it is.

Both are now recomputed together, using the two methods `ColonyBlueprints` already exposes:

```csharp
p.Blueprints?.UpdateCompletion();
p.Blueprints?.UpdatePercentAchievable();
```

Note on naming: the method now updates both figures while still being called `UpdateBlueprintsAchievablePercentage`. Left as is to keep the diff to the fix — happy to rename it in this PR if you would rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
