### PR TITLE
Terraformer picks a terraformable tile deterministically

### DIFF
--- a/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
+++ b/Ship_Game/Universe/SolarBodies/Planet/Planet_EvaluateBuildings.cs
@@ -744,7 +744,13 @@ namespace Ship_Game
                     potentialTiles.Add(tile);
             }
 
-            return Random.Item(potentialTiles.Count > 0 ? potentialTiles : tileList.ToArrayList());
+            // A terraformable tile first: biospheres already skip those once terraformers are
+            // unlocked, so this is the terraformer's own ground. The LAST of the others when there
+            // is none, which is the far end from where a biosphere starts looking. Deterministic
+            // either way, so reloading a save gives back the same build order.
+            Array<PlanetGridSquare> eligible = potentialTiles.Count > 0 ? potentialTiles : tileList.ToArrayList();
+            PlanetGridSquare terraformable = eligible.Find(t => t.Terraformable);
+            return terraformable ?? eligible[eligible.Count - 1];
 
             bool NoVolcanosAround(PlanetGridSquare tile)
             {


### PR DESCRIPTION
`PickTileForTerraformer` returns `Random.Item` over the tiles that pass the volcano filter, so the terraformer lands anywhere on the grid.

Two consequences:

* Since #337, biospheres skip terraformable tiles once terraformers are unlocked, precisely to keep those tiles for the terraformer. The random pick gives that up on the other side: the terraformer often settles on a plain tile and leaves the terraformable one for the next biosphere to cover over.
* Reloading the same save puts the terraformer on a different tile every time, which makes any report about colony layout impossible to reproduce.

The pick becomes: the first terraformable tile in grid order, and when there is none, the last eligible tile, which is the far end from where a biosphere starts looking. The volcano filter and both call sites are unchanged.

Tested on a save where a terraformer kept moving around on a crowded colony.

Companion to #405, which applies the same rule to a biosphere placed by hand. The two are independent, neither depends on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XiWUe8Cn9QRu181S8oheXy
