### PR TITLE
Biospheres placed by hand follow the governor's tile rule

### DIFF
--- a/Ship_Game/Building.cs
+++ b/Ship_Game/Building.cs
@@ -416,8 +416,25 @@ namespace Ship_Game
                 return where.CanEnqueueBuildingHere(b);
 
             PlanetGridSquare[] freeSpots = planet.TilesList.Filter(pgs => pgs.CanEnqueueBuildingHere(b));
+
+            // A Biosphere leaves the terraformable tiles to the Terraformer, and takes the first
+            // free tile in list order instead of a random one, so the same colony is laid out the
+            // same way twice. Only when there is something else to take: a world made of nothing
+            // but terraformable tiles still gets its Biosphere.
+            if (b.IsBiospheres && planet.Owner?.IsBuildingUnlocked(TerraformerId) == true)
+            {
+                foreach (PlanetGridSquare t in freeSpots)
+                {
+                    if (!t.Terraformable)
+                    {
+                        where = t;
+                        return true;
+                    }
+                }
+            }
+
             if (freeSpots.Length > 0)
-                where = planet.Random.Item(freeSpots);
+                where = b.IsBiospheres ? freeSpots[0] : planet.Random.Item(freeSpots);
             return where != null;
         }
 


### PR DESCRIPTION
Double-clicking a biosphere in the Colony screen drops it on a random free tile: `AssignBuildingToTile` picks with `Random.Item`, and nothing on that path knows about terraformable ground.

The governor already knows. `GetPreferredTile` in `Planet_EvaluateBuildings` takes the first tile that is neither habitable nor terraformable once terraformers are unlocked, and only falls back to a terraformable one when the colony has nothing else free. The manual path never got that rule, so the same colony behaves in two different ways depending on who places the building, and a hand placed biosphere can take the tile the terraformer was waiting for.

`AssignBuildingToTile` now applies the governor's rule to biospheres: leave the terraformable tiles alone while there is something else free, and take the first free tile in list order instead of a random one, so the same colony is laid out the same way twice. A world made of nothing but terraformable tiles still gets its biosphere, and the rule only applies once the terraformer is unlocked, since before that there is nothing to spare the tiles for. Every other building keeps the random pick.

Companion to #404, which fixes the terraformer's own tile pick. The two are independent, neither depends on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XiWUe8Cn9QRu181S8oheXy
